### PR TITLE
[BUGFIX] Initialize CachHashCalculator during boot

### DIFF
--- a/Classes/Core/ConsoleBootstrap.php
+++ b/Classes/Core/ConsoleBootstrap.php
@@ -360,6 +360,9 @@ class ConsoleBootstrap extends Bootstrap
         if (!self::usesComposerClassLoading()) {
             $this->initializeRuntimeActivatedPackagesFromConfiguration();
         }
+        // Because links might be generated from CLI (e.g. by Solr indexer)
+        // We need to properly initialize the cache hash calculator here!
+        $this->setCacheHashOptions();
         $this->setDefaultTimezone();
         $this->defineUserAgentConstant();
     }


### PR DESCRIPTION
Solr generates links during indexing. For that the
CachHashCalculator might be used.

To avoid cHash to be wrongly calculated, we therefore need
to properly initialize the CachHashCalculator during boot