### PR TITLE
[FEATURE] Use new API of typo3/cms-composer-installers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,9 @@ script:
   - typo3cms commandreference:render > /dev/null 2>&1 && test -z "$(git diff --shortstat 2> /dev/null | tail -n1)";
   - >
     echo "Running php lint…";
+    if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then rm -rf Classes/Composer/InstallerScript; fi;
     find . -name \*.php ! -path "./.Build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;;
+    git checkout Classes/Composer/InstallerScript;
   - >
     echo "Running unit and functional tests…";
     .Build/bin/phpunit;

--- a/Classes/Composer/InstallerScript/InstallDummyExtension.php
+++ b/Classes/Composer/InstallerScript/InstallDummyExtension.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Composer\InstallerScript;
 
 /*
@@ -15,20 +16,20 @@ namespace Helhum\Typo3Console\Composer\InstallerScript;
 
 use Composer\Script\Event as ScriptEvent;
 use Helhum\Typo3ConsolePlugin\Config as PluginConfig;
-use Helhum\Typo3ConsolePlugin\InstallerScriptInterface;
 use TYPO3\CMS\Composer\Plugin\Config as Typo3Config;
+use TYPO3\CMS\Composer\Plugin\Core\InstallerScript;
 use TYPO3\CMS\Composer\Plugin\Util\Filesystem;
 
 /**
  * @deprecated will be removed with 5.0
  */
-class InstallDummyExtension implements InstallerScriptInterface
+class InstallDummyExtension implements InstallerScript
 {
     /**
      * @param ScriptEvent $event
      * @return bool
      */
-    public function shouldRun(ScriptEvent $event)
+    private function shouldRun(ScriptEvent $event): bool
     {
         return $event->getComposer()->getPackage()->getName() !== 'helhum/typo3-console';
     }
@@ -39,8 +40,12 @@ class InstallDummyExtension implements InstallerScriptInterface
      * @return bool
      * @internal
      */
-    public function run(ScriptEvent $event)
+    public function run(ScriptEvent $event): bool
     {
+        if (!$this->shouldRun($event)) {
+            return true;
+        }
+
         $io = $event->getIO();
         $composer = $event->getComposer();
 

--- a/Classes/Composer/InstallerScript/PopulateCommandConfiguration.php
+++ b/Classes/Composer/InstallerScript/PopulateCommandConfiguration.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Composer\InstallerScript;
 
 /*
@@ -14,25 +15,14 @@ namespace Helhum\Typo3Console\Composer\InstallerScript;
  */
 
 use Composer\Script\Event as ScriptEvent;
-use Helhum\Typo3ConsolePlugin\InstallerScriptInterface;
+use TYPO3\CMS\Composer\Plugin\Core\InstallerScript;
 
 /**
  * Reads console command configuration files from all composer packages in the current project
  * and writes a file with all command configurations accumulated
  */
-class PopulateCommandConfiguration implements InstallerScriptInterface
+class PopulateCommandConfiguration implements InstallerScript
 {
-    /**
-     * This method is called first. setupConsole is not called if this returns false
-     *
-     * @param ScriptEvent $event
-     * @return bool
-     */
-    public function shouldRun(ScriptEvent $event)
-    {
-        return true;
-    }
-
     /**
      * Called from Composer
      *
@@ -41,7 +31,7 @@ class PopulateCommandConfiguration implements InstallerScriptInterface
      * @return bool
      * @internal
      */
-    public function run(ScriptEvent $event)
+    public function run(ScriptEvent $event): bool
     {
         $composer = $event->getComposer();
         $composerConfig = $composer->getConfig();

--- a/Classes/Composer/LegacyInstallerScripts.php
+++ b/Classes/Composer/LegacyInstallerScripts.php
@@ -1,0 +1,159 @@
+<?php
+namespace Helhum\Typo3Console\Composer;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Composer\Script\Event as ScriptEvent;
+use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
+use Helhum\Typo3ConsolePlugin\Config as PluginConfig;
+use TYPO3\CMS\Composer\Plugin\Config as Typo3Config;
+use TYPO3\CMS\Composer\Plugin\Util\Filesystem;
+
+/**
+ * Legacy class for Composer and Extension Manager install scripts
+ * @deprecated Will be removed with 5.0
+ */
+class LegacyInstallerScripts
+{
+    /**
+     * Called from Composer Plugin
+     *
+     * @throws \RuntimeException
+     * @return void
+     * @internal
+     */
+    public static function setupConsole(ScriptEvent $event)
+    {
+        self::populateCommandConfiguration($event);
+        self::generatePackageStates($event);
+        self::installDummyExtension($event);
+    }
+
+    private static function populateCommandConfiguration(ScriptEvent $event)
+    {
+        $composer = $event->getComposer();
+        $composerConfig = $composer->getConfig();
+        $basePath = realpath(substr($composerConfig->get('vendor-dir'), 0, -strlen($composerConfig->get('vendor-dir', $composerConfig::RELATIVE_PATHS))));
+        $commandConfiguration = [];
+        foreach (self::extractPackageMapFromComposer($composer) as $item) {
+            /** @var \Composer\Package\PackageInterface $package */
+            list($package, $installPath) = $item;
+            $installPath = ($installPath ?: $basePath);
+            if (file_exists($commandConfigurationFile = $installPath . '/Configuration/Console/Commands.php')) {
+                $commandConfiguration[$package->getName()] = require $commandConfigurationFile;
+            }
+        }
+        file_put_contents(
+            __DIR__ . '/../../Configuration/Console/AllCommands.php',
+            '<?php' . chr(10)
+            . 'return '
+            . var_export($commandConfiguration, true)
+            . ';'
+        );
+    }
+
+    /**
+     * @param \Composer\Composer $composer
+     * @return array
+     */
+    private static function extractPackageMapFromComposer(\Composer\Composer $composer)
+    {
+        $mainPackage = $composer->getPackage();
+        $autoLoadGenerator = $composer->getAutoloadGenerator();
+        $localRepo = $composer->getRepositoryManager()->getLocalRepository();
+        return $autoLoadGenerator->buildPackageMap($composer->getInstallationManager(), $mainPackage, $localRepo->getCanonicalPackages());
+    }
+
+    private static function generatePackageStates(ScriptEvent $event)
+    {
+        if (!getenv('TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES')) {
+            return;
+        }
+        $io = $event->getIO();
+        $composer = $event->getComposer();
+        $pluginConfig = PluginConfig::load($io, $composer->getConfig());
+        $typo3PluginConfig = Typo3Config::load($composer);
+
+        if ($pluginConfig->get('skip-packagestates-write')) {
+            $io->writeError('<warning>It is highly recommended to let the PackageStates.php file be generated automatically</warning>');
+            $io->writeError('<warning>Disabling this functionality will be removed with TYPO3 Console 5.0</warning>');
+            return;
+        }
+
+        if ($typo3PluginConfig->get('prepare-web-dir') === false) {
+            return;
+        }
+
+        if (!getenv('TYPO3_CONSOLE_TEST_SETUP') && $composer->getPackage()->getName() === 'helhum/typo3-console') {
+            return;
+        }
+
+        // Ensure we have at least the typo3conf folder present
+        (new Filesystem())->ensureDirectoryExists($typo3PluginConfig->get('web-dir') . '/typo3conf');
+        $io = $event->getIO();
+
+        $commandDispatcher = CommandDispatcher::createFromComposerRun($event);
+        $commandOptions = [
+            'frameworkExtensions' => (string)getenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS'),
+        ];
+        if (getenv('TYPO3_ACTIVATE_DEFAULT_FRAMEWORK_EXTENSIONS')) {
+            $commandOptions['activateDefault'] = true;
+        }
+        if ($event->isDevMode() && getenv('TYPO3_EXCLUDED_EXTENSIONS')) {
+            $commandOptions['excludedExtensions'] = (string)getenv('TYPO3_EXCLUDED_EXTENSIONS');
+        }
+        $output = $commandDispatcher->executeCommand('install:generatepackagestates', $commandOptions);
+        $io->writeError($output, true, $io::VERBOSE);
+    }
+
+    private static function installDummyExtension(ScriptEvent $event)
+    {
+        if ($event->getComposer()->getPackage()->getName() === 'helhum/typo3-console') {
+            return;
+        }
+        $io = $event->getIO();
+        $composer = $event->getComposer();
+
+        $composerConfig = $composer->getConfig();
+        $typo3Config = Typo3Config::load($composer);
+        $pluginConfig = PluginConfig::load($io, $composerConfig);
+
+        $webDir = $typo3Config->get('web-dir');
+        $filesystem = new Filesystem();
+        $extensionDir = "$webDir/typo3conf/ext/typo3_console";
+
+        if ($pluginConfig->get('install-extension-dummy')) {
+            $io->writeError('<warning>Installation of TYPO3 extension has been deprecated</warning>');
+            $io->writeError('<warning>To get rid of this message, set "install-extension-dummy" option to false</warning>');
+            $io->writeError('<warning>Use the following command to set this option:</warning>');
+            $io->writeError('<warning>composer config extra.helhum/typo3-console.install-extension-dummy 0</warning>');
+
+            $extResourcesDir = __DIR__ . '/../../Resources/Private/ExtensionArtifacts';
+            $resources = [
+                'ext_icon.png',
+                'ext_emconf.php',
+            ];
+            foreach ($resources as $resource) {
+                $target = "$extensionDir/$resource";
+                $filesystem->ensureDirectoryExists(dirname($target));
+                $filesystem->copy("$extResourcesDir/$resource", $target);
+            }
+            $io->writeError('<info>TYPO3 Console: Installed TYPO3 extension into TYPO3 extension directory</info>');
+        } else {
+            if (file_exists($extensionDir) || is_dir($extensionDir)) {
+                $filesystem->removeDirectory($extensionDir);
+                $io->writeError('<info>TYPO3 Console: Removed TYPO3 extension from TYPO3 extension directory</info>');
+            }
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "license": "GPL-2.0+",
     "require": {
         "ext-Phar": "*",
-        "php": ">=5.5.0",
-        "helhum/typo3-console-plugin": "^1.7.2",
+        "php": ">=5.5.0 <7.2",
+        "helhum/typo3-console-plugin": "^1.7.5 || ^2.0",
 
         "typo3/cms-backend": "^7.6 || ^8.7",
         "typo3/cms-core": "^7.6 || ^8.7",


### PR DESCRIPTION
The installer now implements a lot of things we invented here,
so we can pull in the new API from there now.

