### PR TITLE
[BUGFIX] Flush caches internally before upgrade

### DIFF
--- a/Classes/Install/Upgrade/UpgradeHandling.php
+++ b/Classes/Install/Upgrade/UpgradeHandling.php
@@ -293,6 +293,7 @@ class UpgradeHandling
             if (class_exists(DatabaseCharsetUpdate::class)) {
                 $this->commandDispatcher->executeCommand('upgrade:wizard', ['identifier' => DatabaseCharsetUpdate::class]);
             }
+            $this->commandDispatcher->executeCommand('cache:flush');
             $this->commandDispatcher->executeCommand('database:updateschema');
         }
         return $messages;

--- a/Classes/Package/UncachedPackageManager.php
+++ b/Classes/Package/UncachedPackageManager.php
@@ -18,9 +18,6 @@ use TYPO3\CMS\Core\Core\ClassLoadingInformation;
 use TYPO3\CMS\Core\Package\PackageInterface;
 use TYPO3\CMS\Core\Package\PackageManager;
 
-/**
- * Class UncachedPackageManager
- */
 class UncachedPackageManager extends PackageManager
 {
     /**
@@ -52,14 +49,10 @@ class UncachedPackageManager extends PackageManager
 
     protected function loadPackageStates()
     {
-        $this->packageStatesConfiguration = $this->packageStatesFileExists ? include($this->packageStatesPathAndFilename) : [];
-        if (!isset($this->packageStatesConfiguration['version']) || $this->packageStatesConfiguration['version'] < 4) {
-            $this->packageStatesConfiguration = [];
-        }
-        if ($this->packageStatesConfiguration === []) {
-            $this->scanAvailablePackages();
+        if ($this->packageStatesFileExists) {
+            parent::loadPackageStates();
         } else {
-            $this->registerPackagesFromConfiguration($this->packageStatesConfiguration['packages']);
+            $this->scanAvailablePackages();
         }
     }
 
@@ -82,7 +75,6 @@ class UncachedPackageManager extends PackageManager
     {
         if ($this->packageStatesFileExists) {
             parent::sortAndSavePackageStates();
-            $this->packageStatesFileExists = true;
         }
     }
 


### PR DESCRIPTION
When performing an upgrade directly after deploying
the new code base, there are cases where persistent
(DB) caches need to be flushed to ensure everything
works as expected.

Fixes: #532