### PR TITLE
[BUGFIX] Allow to update DB schema without ext_tables.php

### DIFF
--- a/Classes/Core/Booting/RunLevel.php
+++ b/Classes/Core/Booting/RunLevel.php
@@ -163,10 +163,10 @@ class RunLevel
     {
         $sequence = $this->buildBasicRuntimeSequence(self::LEVEL_FULL);
 
+        // @deprecated can be removed if TYPO3 8 support is removed
         $this->addStep($sequence, 'helhum.typo3console:database');
         // Fix core caches that were disabled beforehand
         $this->addStep($sequence, 'helhum.typo3console:enablecorecaches');
-        $this->addStep($sequence, 'helhum.typo3console:persistence');
         $this->addStep($sequence, 'helhum.typo3console:authentication');
 
         return $sequence;
@@ -214,11 +214,9 @@ class RunLevel
             case 'helhum.typo3console:enablecorecaches':
                 $sequence->addStep(new Step('helhum.typo3console:enablecorecaches', [\Helhum\Typo3Console\Core\Booting\Scripts::class, 'reEnableOriginalCoreCaches']), 'helhum.typo3console:database');
                 break;
+            // @deprecated can be removed if TYPO3 8 support is removed
             case 'helhum.typo3console:database':
                 $sequence->addStep(new Step('helhum.typo3console:database', [\Helhum\Typo3Console\Core\Booting\Scripts::class, 'initializeDatabaseConnection']), 'helhum.typo3console:errorhandling');
-                break;
-            case 'helhum.typo3console:persistence':
-                $sequence->addStep(new Step('helhum.typo3console:persistence', [\Helhum\Typo3Console\Core\Booting\Scripts::class, 'initializePersistence']), 'helhum.typo3console:extensionconfiguration');
                 break;
             case 'helhum.typo3console:authentication':
                 $sequence->addStep(new Step('helhum.typo3console:authentication', [\Helhum\Typo3Console\Core\Booting\Scripts::class, 'initializeAuthenticatedOperations']), 'helhum.typo3console:extensionconfiguration');

--- a/Classes/Core/Booting/Scripts.php
+++ b/Classes/Core/Booting/Scripts.php
@@ -152,20 +152,7 @@ class Scripts
     {
         ExtensionManagementUtility::loadExtLocalconf();
         $bootstrap->applyAdditionalConfigurationSettings();
-    }
-
-    /**
-     * @param ConsoleBootstrap $bootstrap
-     */
-    public static function initializePersistence(ConsoleBootstrap $bootstrap)
-    {
-        if (is_callable([$bootstrap, 'loadExtTables'])) {
-            $bootstrap->loadBaseTca();
-            $bootstrap->loadExtTables();
-        } else {
-            // @deprecated can be removed once TYPO3 7.6 support is removed
-            $bootstrap->loadExtensionTables();
-        }
+        $bootstrap->loadTcaOnly();
     }
 
     /**
@@ -173,6 +160,12 @@ class Scripts
      */
     public static function initializeAuthenticatedOperations(ConsoleBootstrap $bootstrap)
     {
+        if (is_callable([$bootstrap, 'loadExtTables'])) {
+            $bootstrap->loadExtTables();
+        } else {
+            // @deprecated can be removed once TYPO3 7.6 support is removed
+            $bootstrap->loadExtTablesOnly();
+        }
         $bootstrap->initializeBackendUser(CommandLineUserAuthentication::class);
         self::loadCommandLineBackendUser();
         // Global language object on CLI? rly? but seems to be needed by some scheduler tasks :(

--- a/Classes/Core/ConsoleBootstrap.php
+++ b/Classes/Core/ConsoleBootstrap.php
@@ -367,13 +367,32 @@ class ConsoleBootstrap extends Bootstrap
         $this->defineUserAgentConstant();
     }
 
+    /**
+     * @deprecated can be removed if TYPO3 7 support is removed (directly use $bootstrap->loadBaseTca())
+     */
+    public function loadTcaOnly()
+    {
+        Utility\ExtensionManagementUtility::loadBaseTca();
+    }
+
+    /**
+     * @deprecated can be removed if TYPO3 7 support is removed (directly use $bootstrap->loadExtTables())
+     */
+    public function loadExtTablesOnly()
+    {
+        Utility\ExtensionManagementUtility::loadExtTables();
+        $this->executeExtTablesAdditionalFile();
+        $this->runExtTablesPostProcessingHooks();
+    }
+
+    /**
+     * @deprecated can be removed if TYPO3 7 support is removed
+     */
     public function initializeDatabaseConnection()
     {
-        // @deprecated can be removed if TYPO3 7 support is removed
         if (is_callable([$this, 'defineDatabaseConstants'])) {
             $this->defineDatabaseConstants();
         }
-        // @deprecated can be removed if TYPO3 7 support is removed
         if (is_callable([$this, 'initializeTypo3DbGlobal'])) {
             $this->initializeTypo3DbGlobal();
         }

--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -153,6 +153,7 @@ class CliSetupRequestHandler
         }
         // Flush caches, as the extension list has changed
         $this->commandDispatcher->executeCommand('cache:flush', ['--files-only' => true]);
+        $this->commandDispatcher->executeCommand('database:updateschema');
         $this->commandDispatcher->executeCommand('extension:setupactive');
         $this->output->outputLine('<success>OK</success>');
     }

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -33,7 +33,6 @@ return [
         'typo3_console:cache:flush' => ['helhum.typo3console:database'],
         'typo3_console:database:updateschema' => [
             'helhum.typo3console:database',
-            'helhum.typo3console:persistence',
         ],
     ],
 ];

--- a/Tests/Functional/Command/AbstractCommandTest.php
+++ b/Tests/Functional/Command/AbstractCommandTest.php
@@ -184,7 +184,7 @@ abstract class AbstractCommandTest extends \PHPUnit_Framework_TestCase
         $process = $processBuilder->setTimeout(null)->getProcess();
         $process->run();
         if (!$process->isSuccessful()) {
-            $this->fail(sprintf('Composer command failed with message: "%s", output: "%s"', $process->getErrorOutput(), $process->getOutput()));
+            $this->fail(sprintf('Composer command "%s" failed with message: "%s", output: "%s"', $process->getCommandLine(), $process->getErrorOutput(), $process->getOutput()));
         }
         return $process->getOutput() . $process->getErrorOutput();
     }


### PR DESCRIPTION
We added this step to the bootstrap of
database:updateschmea command only because TYPO3 8 needs
TCA to add additional fields to the schema.

With this we however run into a chicken/egg issue, when an
extension tries to access DB (most likely a cache table)
in the process of reading ext_tables.php

Now we read TCA early on, when reading extension configuration,
which is exactly what happens in TYPO3 9 anyway,
so we can skip reading ext_tables.php for updating the DB schema.