### PR TITLE
[FEATURE] Make cache:flush --files-only low level

### DIFF
--- a/Classes/Core/Booting/RunLevel.php
+++ b/Classes/Core/Booting/RunLevel.php
@@ -269,9 +269,6 @@ class RunLevel
         if ($availableRunlevel === self::LEVEL_COMPILE) {
             if (in_array($expectedRunLevel, [self::LEVEL_FULL, self::LEVEL_MINIMAL], true)) {
                 $isAvailable = false;
-            } elseif ($commandIdentifier === 'cache:flush') {
-                // @TODO: find a nicer way to hide this command when TYPO3 is not installed yet
-                $isAvailable = false;
             }
         }
 

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -19,6 +19,7 @@ return [
         'typo3_console:install:defaultconfiguration' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:install:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
         'typo3_console:cache:flush' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        'typo3_console:cache:flushcomplete' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:configuration:show' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
         'typo3_console:configuration:showactive' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
         'typo3_console:configuration:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
@@ -30,9 +31,6 @@ return [
     'bootingSteps' => [
         'typo3_console:install:databasedata' => ['helhum.typo3console:database'],
         'typo3_console:install:defaultconfiguration' => ['helhum.typo3console:database'],
-        'typo3_console:cache:flush' => ['helhum.typo3console:database'],
-        'typo3_console:database:updateschema' => [
-            'helhum.typo3console:database',
-        ],
+        'typo3_console:database:updateschema' => ['helhum.typo3console:database'],
     ],
 ];


### PR DESCRIPTION
It is now possible to call

typo3cms cache:flush --files-only when TYPO3 is not
set up. While this does not sound too exciting at first,
it enables usage of low level file cache flush
e.g. in composer scripts, which makes it much easier
to ensure not having some stale file caches lying around.

We now also give a nice error message in case
cache:flush is called without --files-only, but fails.

At the same time we fall back to flush files caches only
but still return an error code, to clearly communicate
that something went wrong. Otherwise one would not realize
that flushing DB caches failed for some other reason than
TYPO3 not being set up yet.