### PR TITLE
[BUGFIX] If at all, the dummy extension must be in root-dir

### DIFF
--- a/Classes/Composer/InstallerScript/InstallDummyExtension.php
+++ b/Classes/Composer/InstallerScript/InstallDummyExtension.php
@@ -53,7 +53,7 @@ class InstallDummyExtension implements InstallerScript
         $typo3Config = Typo3Config::load($composer);
         $pluginConfig = PluginConfig::load($io, $composerConfig);
 
-        $webDir = $typo3Config->get('web-dir');
+        $webDir = $typo3Config->get('root-dir');
         $filesystem = new Filesystem();
         $extensionDir = "$webDir/typo3conf/ext/typo3_console";
 


### PR DESCRIPTION
Since the new composer installers can distinguish between
web-dir and root-dir, we must ensure the dummy extension
is always installed in the root-dir (PATH_site)