### PR TITLE
Deprecate TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES

### DIFF
--- a/Classes/Composer/InstallerScript/GeneratePackageStates.php
+++ b/Classes/Composer/InstallerScript/GeneratePackageStates.php
@@ -15,12 +15,14 @@ namespace Helhum\Typo3Console\Composer\InstallerScript;
  */
 
 use Composer\Script\Event as ScriptEvent;
-use Composer\Util\Filesystem;
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
 use Helhum\Typo3ConsolePlugin\Config as PluginConfig;
 use TYPO3\CMS\Composer\Plugin\Config as Typo3Config;
 use TYPO3\CMS\Composer\Plugin\Core\InstallerScript;
 
+/**
+ * @deprecated will be removed with 5.0
+ */
 class GeneratePackageStates implements InstallerScript
 {
     /**
@@ -44,12 +46,9 @@ class GeneratePackageStates implements InstallerScript
             return false;
         }
 
-        if (!getenv('TYPO3_CONSOLE_TEST_SETUP') && $composer->getPackage()->getName() === 'helhum/typo3-console') {
-            return false;
-        }
+        $io->writeError('<warning>Using TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES env var has been deprecated.</warning>');
+        $io->writeError('<warning>Please abstain from using it and consider using "typo3-console/auto-setup" composer package instead.</warning>');
 
-        // Ensure we have at least the typo3conf folder present
-        (new Filesystem())->ensureDirectoryExists($typo3PluginConfig->get('root-dir') . '/typo3conf');
         return true;
     }
 

--- a/Classes/Composer/InstallerScripts.php
+++ b/Classes/Composer/InstallerScripts.php
@@ -51,8 +51,8 @@ class InstallerScripts implements InstallerScriptsRegistration
             $scriptDispatcher->addInstallerScript(new AutoloadConnector());
             $scriptDispatcher->addInstallerScript(new CopyTypo3Directory());
         }
-        $scriptDispatcher->addInstallerScript(new GeneratePackageStates(), 40);
-        $scriptDispatcher->addInstallerScript(new InstallDummyExtension(), 40);
+        $scriptDispatcher->addInstallerScript(new GeneratePackageStates(), 65);
+        $scriptDispatcher->addInstallerScript(new InstallDummyExtension(), 65);
     }
 
     /**

--- a/Classes/Composer/LegacyInstallerScripts.php
+++ b/Classes/Composer/LegacyInstallerScripts.php
@@ -94,13 +94,8 @@ class LegacyInstallerScripts
             return;
         }
 
-        if (!getenv('TYPO3_CONSOLE_TEST_SETUP') && $composer->getPackage()->getName() === 'helhum/typo3-console') {
-            return;
-        }
-
-        // Ensure we have at least the typo3conf folder present
-        (new Filesystem())->ensureDirectoryExists($typo3PluginConfig->get('web-dir') . '/typo3conf');
-        $io = $event->getIO();
+        $io->writeError('<warning>Using TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES env var has been deprecated.</warning>');
+        $io->writeError('<warning>Please abstain from using it and consider using "typo3-console/auto-setup" composer package instead.</warning>');
 
         $commandDispatcher = CommandDispatcher::createFromComposerRun($event);
         $commandOptions = [

--- a/Tests/Functional/Command/Install/InstallCommandControllerTest.php
+++ b/Tests/Functional/Command/Install/InstallCommandControllerTest.php
@@ -112,35 +112,4 @@ class InstallCommandControllerTest extends AbstractCommandTest
             $this->assertSame('active', $packageConfig['packages']['reports']['state']);
         }
     }
-
-    /**
-     * @test
-     */
-    public function packageStatesFileIsCreatedFromComposerRun()
-    {
-        $packageStatesFile = getenv('TYPO3_PATH_ROOT') . '/typo3conf/PackageStates.php';
-        copy($packageStatesFile, $packageStatesFile . '_');
-        @unlink($packageStatesFile);
-
-        $this->executeComposerCommand(
-            [
-                'dump-autoload',
-                '-vv',
-            ],
-            [
-                'TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES' => 'yes',
-                'TYPO3_CONSOLE_TEST_SETUP' => 'yes',
-                'TYPO3_ACTIVATE_DEFAULT_FRAMEWORK_EXTENSIONS' => 'yes',
-            ]
-        );
-
-        $this->assertTrue(file_exists($packageStatesFile));
-        $packageConfig = require $packageStatesFile;
-        copy($packageStatesFile . '_', $packageStatesFile);
-        if ($packageConfig['version'] === 5) {
-            $this->assertArrayHasKey('reports', $packageConfig['packages']);
-        } else {
-            $this->assertSame('active', $packageConfig['packages']['reports']['state']);
-        }
-    }
 }


### PR DESCRIPTION
This environment variable has been introduced as feature
switch to avoid breaking changes. Therefore this feature
never really took off and people kept using composer scripts for that.

To make some things automatable but still optional,
a new package typo3-console/auto-setup will be introduced,
which (once required) generates package states during composer
build time, but also can perform a complete TYPO3 setup
and some other useful commands during development.