### PR TITLE
[BUGFIX] Initialize database constants early

### DIFF
--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -131,8 +131,16 @@ class InstallCommandController extends CommandController
         $packageStatesGenerator = new PackageStatesGenerator($this->packageManager);
         $activatedExtensions = $packageStatesGenerator->generate($frameworkExtensions, $activateDefault, $excludedExtensions);
 
-        // Make sure file caches are empty after generating package states file
-        CommandDispatcher::createFromCommandRun()->executeCommand('cache:flush', ['--files-only' => true]);
+        try {
+            // Make sure file caches are empty after generating package states file
+            CommandDispatcher::createFromCommandRun()->executeCommand('cache:flush', ['--files-only' => true]);
+        } catch (FailedSubProcessCommandException $e) {
+            // Ignore errors here.
+            // They might be triggered from extensions accessing db or having other things
+            // broken in ext_tables or ext_localconf
+            // In such case we cannot do much about it other than ignoring it for
+            // generating packages states
+        }
 
         $this->outputLine(
             '<info>The following extensions have been added to the generated PackageStates.php file:</info> %s',

--- a/Classes/Core/ConsoleBootstrap.php
+++ b/Classes/Core/ConsoleBootstrap.php
@@ -369,6 +369,10 @@ class ConsoleBootstrap extends Bootstrap
         if (is_callable([$this, 'defineUserAgentConstant'])) {
             $this->defineUserAgentConstant();
         }
+        // @deprecated can be removed if TYPO3 7 support is removed
+        if (is_callable([$this, 'defineDatabaseConstants'])) {
+            $this->defineDatabaseConstants();
+        }
     }
 
     /**
@@ -392,13 +396,10 @@ class ConsoleBootstrap extends Bootstrap
     }
 
     /**
-     * @deprecated can be removed if TYPO3 7 support is removed
+     * @deprecated can be removed if TYPO3 8 support is removed
      */
     public function initializeDatabaseConnection()
     {
-        if (is_callable([$this, 'defineDatabaseConstants'])) {
-            $this->defineDatabaseConstants();
-        }
         if (is_callable([$this, 'initializeTypo3DbGlobal'])) {
             $this->initializeTypo3DbGlobal();
         }


### PR DESCRIPTION
It become in line with the TYPO3 7.6 bootstrap,
we initialize database constants directly after
pulling in configuration.

This fixes an edge case for not so clean extensions
that will manually initialize db connection in
ext_clocalconf.php and this relying on db constants
to be present.

Fixes #555
Fixes #540