### PR TITLE
[BUGFIX] Init DB also on TYPO3 8

### DIFF
--- a/Classes/Service/CacheService.php
+++ b/Classes/Service/CacheService.php
@@ -187,14 +187,10 @@ class CacheService implements SingletonInterface
     }
 
     /**
-     * @deprecated can be removed when TYPO3 7.6 support is removed
+     * @deprecated can be removed when TYPO3 8 support is removed
      */
     private function ensureDatabaseIsInitialized()
     {
-        if (class_exists(ConnectionPool::class)) {
-            // With doctrine, we don't need to initialize $GLOBALS['TYPO3_DB']
-            return;
-        }
         if (!empty($GLOBALS['TYPO3_DB'])) {
             // Already initialized
             return;


### PR DESCRIPTION
Although TYPO3 8 comes with doctrine, there might be
some extensions which require $GLOBALS['TYPO3_DB'],
thus we need to initialize this global as well
for TYPO3 8