### PR TITLE
[BUGFIX] Always exclude extensions when requested

### DIFF
--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -118,7 +118,7 @@ class InstallCommandController extends CommandController
      *
      * @param array $frameworkExtensions TYPO3 system extensions that should be marked as active. Extension keys separated by comma.
      * @param bool $activateDefault If true, <code>typo3/cms</code> extensions that are marked as TYPO3 factory default, will be activated, even if not in the list of configured active framework extensions.
-     * @param array $excludedExtensions Extensions in typo3conf/ext/ directory, which should stay inactive
+     * @param array $excludedExtensions Extensions which should stay inactive. This does not affect provided framework extensions or framework extensions that are required or part as minimal usable system.
      */
     public function generatePackageStatesCommand(array $frameworkExtensions = [], $activateDefault = false, array $excludedExtensions = [])
     {

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -879,7 +879,7 @@ Options
 ``--activate-default``
   If true, ``typo3/cms`` extensions that are marked as TYPO3 factory default, will be activated, even if not in the list of configured active framework extensions.
 ``--excluded-extensions``
-  Extensions in typo3conf/ext/ directory, which should stay inactive
+  Extensions which should stay inactive. This does not affect provided framework extensions or framework extensions that are required or part as minimal usable system.
 
 
 

--- a/Tests/Unit/Install/PackageStatesGeneratorTest.php
+++ b/Tests/Unit/Install/PackageStatesGeneratorTest.php
@@ -1,0 +1,389 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Unit\Install;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Install\PackageStatesGenerator;
+use Helhum\Typo3Console\Package\UncachedPackageManager;
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Core\Package\PackageInterface;
+
+class PackageStatesGeneratorTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function localExtensionsAreMarkedActive()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(false);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(false);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3conf/ext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->activatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate();
+    }
+
+    /**
+     * @test
+     */
+    public function localExtensionsAreNotMarkedActiveWhenExcluded()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(false);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(false);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3conf/ext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->deactivatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate([], false, ['foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function frameworkExtensionsAreNotMarkedAsActiveByDefault()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(false);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(false);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3/sysext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->deactivatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate();
+    }
+
+    /**
+     * @test
+     */
+    public function defaultFrameworkExtensionsAreNotMarkedAsActiveByDefault()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(false);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(false);
+        $packageProphecy->isPartOfFactoryDefault()->willReturn(true);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3/sysext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->deactivatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate();
+    }
+
+    /**
+     * @test
+     */
+    public function defaultFrameworkExtensionsAreMarkedAsActiveWhenSwitchProvided()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(false);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(false);
+        $packageProphecy->isPartOfFactoryDefault()->willReturn(true);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3/sysext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->activatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate([], true);
+    }
+
+    /**
+     * @test
+     */
+    public function defaultFrameworkExtensionsAreNotMarkedAsActiveWhenSwitchProvidedButExcluded()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(false);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(false);
+        $packageProphecy->isPartOfFactoryDefault()->willReturn(true);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3/sysext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->deactivatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate([], true, ['foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function frameworkExtensionsAreMarkedAsActiveWhenProvided()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(false);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(false);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3/sysext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->activatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate(['foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function frameworkExtensionsAreMarkedAsActiveWhenProvidedEvenWhenExcluded()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(false);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(false);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3/sysext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->activatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate(['foo'], false, ['foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function frameworkExtensionsAreMarkedAsActiveWhenProtected()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(true);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(false);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3/sysext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->activatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate(['foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function frameworkExtensionsAreMarkedAsActiveWhenProtectedEvenWhenExcluded()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(true);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(false);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3/sysext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->activatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate(['foo'], false, ['foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function frameworkExtensionsAreMarkedAsActiveWhenPartOfMinimalUsableSystem()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(false);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(true);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3/sysext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->activatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate(['foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function frameworkExtensionsAreMarkedAsActiveWhenPartOfMinimalUsableSystemEvenWhenExcluded()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(false);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(true);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3/sysext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->activatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate(['foo'], false, ['foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function localExtensionsAreNotMarkedAsActiveWhenPartOfMinimalUsableSystemWhenExcluded()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(false);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(true);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3conf/ext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->deactivatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate(['foo'], false, ['foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function localExtensionsAreNotMarkedAsActiveWhenProtectedWhenExcluded()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(true);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(false);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3conf/ext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->deactivatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator->generate(['foo'], false, ['foo']);
+    }
+}


### PR DESCRIPTION
For generating PackageStates.php we now mark
local extensions as inactive when they are excluded,
even if they have been marked as protected by the
extension owner.

We now also allow framework extensions to be excluded,
but only if they are neither protected, nor provided
in the list of active framework extensions.

This makes it possible to exclude some framework extensions,
when using the --activate-default switch.

Fixes #541