### PR TITLE
[BUGFIX] Cache flush command needs full bootstrap

### DIFF
--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -19,7 +19,6 @@ return [
         'typo3_console:install:defaultconfiguration' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:install:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
         'typo3_console:cache:flush' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
-        'typo3_console:cache:flushcomplete' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:configuration:show' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
         'typo3_console:configuration:showactive' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
         'typo3_console:configuration:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,


### PR DESCRIPTION
Accidentally we changed cache:flush to not initialize
database connection and not re-enable caches.

Make it a full bootstrap command again