### PR TITLE
Allow the same pattern for command controller namespaces as the core

### DIFF
--- a/Classes/Mvc/Cli/Command.php
+++ b/Classes/Mvc/Cli/Command.php
@@ -76,15 +76,22 @@ class Command
             unset($classNameParts[1]);
             $classNameParts = array_values($classNameParts);
         }
-        if (count($classNameParts) !== 4 || strpos($classNameParts[3], 'CommandController') === false) {
+        $numberOfClassNameParts = count($classNameParts);
+        if ($numberOfClassNameParts < 3) {
             throw new \InvalidArgumentException(
-                'Invalid controller class name "' . $controllerClassName . '". Class name must have exactly 4 parts and must end with "CommandController" (e.g. Vendor\ExtensionName\Command\MySimpleCommandController).',
+                'Controller class names must at least consist of three parts: vendor, extension name and path.',
+                1438782187
+            );
+        }
+        if (strpos($classNameParts[$numberOfClassNameParts - 1], 'CommandController') === false) {
+            throw new \InvalidArgumentException(
+                'Invalid controller class name "' . $controllerClassName . '". Class name must end with "CommandController" (e.g. Vendor\ExtensionName\Command\MySimpleCommandController).',
                 1305100019
             );
         }
         $this->extensionName = $classNameParts[1];
         $extensionKey = \TYPO3\CMS\Core\Utility\GeneralUtility::camelCaseToLowerCaseUnderscored($this->extensionName);
-        $this->commandIdentifier = strtolower($extensionKey . ':' . substr($classNameParts[3], 0, -17) . ':' . $controllerCommandName);
+        $this->commandIdentifier = strtolower($extensionKey . ':' . substr($classNameParts[$numberOfClassNameParts - 1], 0, -17) . ':' . $controllerCommandName);
     }
 
     /**


### PR DESCRIPTION
Command controllers can be located in any folder per TYPO3 core rules, but TYPO3-Console throws an exception if the given command is located in a sub-folder.

See previous discussion in #303 and especially https://github.com/TYPO3-Console/TYPO3-Console/issues/303#issuecomment-327009095

The changes applied in this PR are copied from the core to accomplish the exact same behaviour.

Fixes #557 