### PR TITLE
[FEATURE] Add --skip-extension-setup to install:setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,6 @@ script:
   - typo3cms commandreference:render > /dev/null 2>&1 && test -z "$(git diff --shortstat 2> /dev/null | tail -n1)";
   - >
     echo "Running php lint…";
-    if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then rm -rf Classes/Composer/InstallerScript; fi;
     find . -name \*.php ! -path "./.Build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;;
     git checkout Classes/Composer/InstallerScript;
   - >

--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -54,6 +54,7 @@ class InstallCommandController extends CommandController
      * @param bool $nonInteractive If specified, optional arguments are not requested, but default values are assumed.
      * @param bool $force Force installation of TYPO3, even if <code>LocalConfiguration.php</code> file already exists.
      * @param bool $skipIntegrityCheck Skip the checking for clean state before executing setup. This allows a pre-defined <code>LocalConfiguration.php</code> to be present. Handle with care. It might lead to unexpected or broken installation results.
+     * @param bool $skipExtensionSetup Skip setting up extensions after TYPO3 is set up. Defaults to false in composer setups and to true in non composer setups.
      * @param string $databaseUserName User name for database server
      * @param string $databaseUserPassword User password for database server
      * @param string $databaseHostName Host name of database server
@@ -70,6 +71,7 @@ class InstallCommandController extends CommandController
         $nonInteractive = false,
         $force = false,
         $skipIntegrityCheck = false,
+        $skipExtensionSetup = false,
         $databaseUserName = '',
         $databaseUserPassword = '',
         $databaseHostName = '',
@@ -88,8 +90,8 @@ class InstallCommandController extends CommandController
         if (!$skipIntegrityCheck) {
             $this->ensureInstallationPossible($nonInteractive, $force);
         }
-
-        $this->cliSetupRequestHandler->setup(!$nonInteractive, $this->request->getArguments());
+        $skipExtensionSetup |= !Bootstrap::usesComposerClassLoading();
+        $this->cliSetupRequestHandler->setup(!$nonInteractive, $this->request->getArguments(), $skipExtensionSetup);
 
         $this->outputLine();
         $this->outputLine('<i>Successfully installed TYPO3 CMS!</i>');

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -906,6 +906,8 @@ Options
   Force installation of TYPO3, even if ``LocalConfiguration.php`` file already exists.
 ``--skip-integrity-check``
   Skip the checking for clean state before executing setup. This allows a pre-defined ``LocalConfiguration.php`` to be present. Handle with care. It might lead to unexpected or broken installation results.
+``--skip-extension-setup``
+  Skip setting up extensions after TYPO3 is set up. Defaults to false in composer setups and to true in non composer setups.
 ``--database-user-name``
   User name for database server
 ``--database-user-password``

--- a/Tests/Functional/Command/Install/InstallCommandControllerTest.php
+++ b/Tests/Functional/Command/Install/InstallCommandControllerTest.php
@@ -30,6 +30,34 @@ class InstallCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
+    public function setupCommandDoesNotSetupExtensionsIfRequested()
+    {
+        $this->executeMysqlQuery('DROP DATABASE IF EXISTS ' . getenv('TYPO3_INSTALL_DB_DBNAME'), false);
+        @unlink(getenv('TYPO3_PATH_ROOT') . '/typo3conf/PackageStates.php');
+        @unlink(getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php');
+        $output = $this->commandDispatcher->executeCommand(
+            'install:setup',
+            [
+                '--non-interactive' => true,
+                '--skip-extension-setup' => true,
+                '--database-user-name' => getenv('TYPO3_INSTALL_DB_USER'),
+                '--database-user-password' => getenv('TYPO3_INSTALL_DB_PASSWORD'),
+                '--database-host-name' => 'localhost',
+                '--database-port' => '3306',
+                '--database-name' => getenv('TYPO3_INSTALL_DB_DBNAME'),
+                '--admin-user-name' => 'admin',
+                '--admin-password' => 'password',
+                '--site-name' => 'Travis Install',
+                '--site-setup-type' => 'createsite',
+            ]
+        );
+        $this->assertContains('Successfully installed TYPO3 CMS!', $output);
+        $this->assertNotContains('Set up extensions', $output);
+    }
+
+    /**
+     * @test
+     */
     public function setupCommandWorksWithoutErrors()
     {
         $this->executeMysqlQuery('DROP DATABASE IF EXISTS ' . getenv('TYPO3_INSTALL_DB_DBNAME'), false);
@@ -51,6 +79,7 @@ class InstallCommandControllerTest extends AbstractCommandTest
             ]
         );
         $this->assertContains('Successfully installed TYPO3 CMS!', $output);
+        $this->assertContains('Set up extensions', $output);
     }
 
     /**


### PR DESCRIPTION
Allow to skip extension setup. This allows to make sure
installation succeeds.

While using this switch avoids issues with extensions,
it will leave the installation in a weird state,
with all third party extensions not active and
some core extensions that might not be needed in the
project being active.