### PR TITLE
Refactor extension compatiblity check

### DIFF
--- a/Classes/Command/UpgradeCommandController.php
+++ b/Classes/Command/UpgradeCommandController.php
@@ -17,9 +17,7 @@ use Helhum\Typo3Console\Install\Upgrade\UpgradeHandling;
 use Helhum\Typo3Console\Install\Upgrade\UpgradeWizardListRenderer;
 use Helhum\Typo3Console\Install\Upgrade\UpgradeWizardResultRenderer;
 use Helhum\Typo3Console\Mvc\Controller\CommandController;
-use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Package\Exception\UnknownPackageException;
-use TYPO3\CMS\Install\Controller\Action\Ajax\ExtensionCompatibilityTester;
 
 class UpgradeCommandController extends CommandController
 {
@@ -163,21 +161,12 @@ class UpgradeCommandController extends CommandController
      * This command in meant to be executed as sub process as it is is subject to cause fatal errors
      * when extensions have broken (incompatible) code
      *
-     * @param bool $force Needs to be set on first execution
+     * @param string $extensionKey Extension key for extension to check
+     * @param bool $configOnly
      * @internal
      */
-    public function checkBrokenExtensionsCommand($force = false)
+    public function checkExtensionCompatibilityCommand($extensionKey, $configOnly = false)
     {
-        // Yeah, right. This class accesses super globals directly
-        $_GET['install']['extensionCompatibilityTester']['forceCheck'] = $force;
-        $result = $this->objectManager->get(ExtensionCompatibilityTester::class)->handle();
-        if ($result instanceof JsonResponse) {
-            $result = $result->getBody();
-        }
-        $result = \json_decode($result, true);
-        if (is_array($result) && !empty($result['success'])) {
-            $result = 'OK';
-        }
-        $this->output($result);
+        $this->output(\json_encode($this->upgradeHandling->isCompatible($extensionKey, $configOnly)));
     }
 }

--- a/Classes/Extension/ExtensionCompatibilityCheck.php
+++ b/Classes/Extension/ExtensionCompatibilityCheck.php
@@ -1,0 +1,171 @@
+<?php
+namespace Helhum\Typo3Console\Extension;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
+use TYPO3\CMS\Core\Package\PackageManager;
+
+class ExtensionCompatibilityCheck
+{
+    /**
+     * @var PackageManager
+     */
+    private $packageManager;
+
+    /**
+     * @var CommandDispatcher
+     */
+    private $commandDispatcher;
+
+    public function __construct(PackageManager $packageManager, CommandDispatcher $commandDispatcher)
+    {
+        $this->packageManager = $packageManager;
+        $this->commandDispatcher = $commandDispatcher;
+    }
+
+    /**
+     * This method is meant to be called form a sub process
+     * specifically from upgrade:checkextensioncompatiblity command
+     *
+     * @param string $extensionKey
+     * @param bool $configOnly
+     * @return bool
+     */
+    public function isCompatible($extensionKey, $configOnly = false)
+    {
+        try {
+            if ($configOnly) {
+                return $this->canLoadExtLocalconfFile($extensionKey);
+            }
+            return $this->canLoadExtTablesFile($extensionKey);
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function findIncompatible()
+    {
+        $failedPackages = [];
+        $activePackages = $this->packageManager->getActivePackages();
+        foreach ($activePackages as $package) {
+            if (strpos($package->getPackagePath(), '/typo3conf/ext/') === false) {
+                // There is not need to check core extensions
+                continue;
+            }
+            $isCompatible = @\json_decode($this->commandDispatcher->executeCommand('upgrade:checkextensioncompatibility', ['--extension-key' => $package->getPackageKey(), '--config-only' => true]));
+            if (!$isCompatible) {
+                $this->packageManager->deactivatePackage($package->getPackageKey());
+                $failedPackages[] = $package->getPackageKey();
+                continue;
+            }
+            $isCompatible = @\json_decode($this->commandDispatcher->executeCommand('upgrade:checkextensioncompatibility', ['--extension-key' => $package->getPackageKey()]));
+            if (!$isCompatible) {
+                $this->packageManager->deactivatePackage($package->getPackageKey());
+                $failedPackages[] = $package->getPackageKey();
+            }
+        }
+        return $failedPackages;
+    }
+
+    /**
+     * Load all ext_localconf files in order until given extension key
+     *
+     * @param string $extensionKey
+     * @return bool
+     */
+    private function canLoadExtLocalconfFile($extensionKey)
+    {
+        $activePackages = $this->packageManager->getActivePackages();
+        foreach ($activePackages as $package) {
+            $this->loadExtLocalconfForExtension($package->getPackageKey());
+            if ($package->getPackageKey() === $extensionKey) {
+                break;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Load all ext_table files in order until given extension key
+     *
+     * @param string $extensionKey
+     * @return bool
+     */
+    private function canLoadExtTablesFile($extensionKey)
+    {
+        $activePackages = $this->packageManager->getActivePackages();
+        foreach ($activePackages as $package) {
+            // Load all ext_localconf files first
+            $this->loadExtLocalconfForExtension($package->getPackageKey());
+        }
+        foreach ($activePackages as $package) {
+            $this->loadExtTablesForExtension($package->getPackageKey());
+            if ($package->getPackageKey() === $extensionKey) {
+                break;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Loads ext_localconf.php for a single extension. Method is a modified copy of
+     * the original bootstrap method.
+     *
+     * @param string $extensionKey
+     */
+    private function loadExtLocalconfForExtension($extensionKey)
+    {
+        $extensionInfo = $GLOBALS['TYPO3_LOADED_EXT'][$extensionKey];
+        // This is the main array meant to be manipulated in the ext_localconf.php files
+        // In general it is recommended to not rely on it to be globally defined in that
+        // scope but to use $GLOBALS['TYPO3_CONF_VARS'] instead.
+        // Nevertheless we define it here as global for backwards compatibility.
+        global $TYPO3_CONF_VARS;
+        $_EXTKEY = $extensionKey;
+        if (isset($extensionInfo['ext_localconf.php']) && $extensionInfo['ext_localconf.php']) {
+            // $_EXTKEY and $_EXTCONF are available in ext_localconf.php
+            // and are explicitly set in cached file as well
+            $_EXTCONF = $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY];
+            require $extensionInfo['ext_localconf.php'];
+        }
+    }
+
+    /**
+     * Loads ext_tables.php for a single extension. Method is a modified copy of
+     * the original bootstrap method.
+     *
+     * @param string $extensionKey
+     */
+    private function loadExtTablesForExtension($extensionKey)
+    {
+        $extensionInfo = $GLOBALS['TYPO3_LOADED_EXT'][$extensionKey];
+        // In general it is recommended to not rely on it to be globally defined in that
+        // scope, but we can not prohibit this without breaking backwards compatibility
+        global $T3_SERVICES, $T3_VAR, $TYPO3_CONF_VARS;
+        global $TBE_MODULES, $TBE_MODULES_EXT, $TCA;
+        global $PAGES_TYPES, $TBE_STYLES;
+        global $_EXTKEY;
+        // Load each ext_tables.php file of loaded extensions
+        $_EXTKEY = $extensionKey;
+        if (isset($extensionInfo['ext_tables.php']) && $extensionInfo['ext_tables.php']) {
+            // $_EXTKEY and $_EXTCONF are available in ext_tables.php
+            // and are explicitly set in cached file as well
+            $_EXTCONF = $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY];
+            require $extensionInfo['ext_tables.php'];
+        }
+    }
+}

--- a/Classes/Install/Upgrade/UpgradeHandling.php
+++ b/Classes/Install/Upgrade/UpgradeHandling.php
@@ -14,6 +14,7 @@ namespace Helhum\Typo3Console\Install\Upgrade;
  */
 
 use Helhum\Typo3Console\Core\ConsoleBootstrap;
+use Helhum\Typo3Console\Extension\ExtensionCompatibilityCheck;
 use Helhum\Typo3Console\Extension\ExtensionConstraintCheck;
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
 use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
@@ -70,6 +71,11 @@ class UpgradeHandling
     private $extensionConstraintCheck;
 
     /**
+     * @var ExtensionCompatibilityCheck
+     */
+    private $extensionCompatibilityCheck;
+
+    /**
      * Flag for same process
      *
      * @var bool
@@ -95,7 +101,9 @@ class UpgradeHandling
      * @param SilentConfigurationUpgrade|null $silentConfigurationUpgrade
      * @param CommandDispatcher|null $commandDispatcher
      * @param ConfigurationService|null $configurationService
+     * @param PackageManager|null $packageManager
      * @param ExtensionConstraintCheck|null $extensionConstraintCheck
+     * @param ExtensionCompatibilityCheck|null $extensionCompatibilityCheck
      */
     public function __construct(
         UpgradeWizardFactory $factory = null,
@@ -105,7 +113,8 @@ class UpgradeHandling
         CommandDispatcher $commandDispatcher = null,
         ConfigurationService $configurationService = null,
         PackageManager $packageManager = null,
-        ExtensionConstraintCheck $extensionConstraintCheck = null
+        ExtensionConstraintCheck $extensionConstraintCheck = null,
+        ExtensionCompatibilityCheck $extensionCompatibilityCheck = null
     ) {
         $this->factory = new UpgradeWizardFactory();
         $this->executor = $executor ?: new UpgradeWizardExecutor($this->factory);
@@ -115,6 +124,7 @@ class UpgradeHandling
         $this->configurationService = $configurationService ?: new ConfigurationService();
         $this->packageManager = $packageManager ?: GeneralUtility::makeInstance(PackageManager::class);
         $this->extensionConstraintCheck = $extensionConstraintCheck ?: new ExtensionConstraintCheck();
+        $this->extensionCompatibilityCheck = $extensionCompatibilityCheck ?: new ExtensionCompatibilityCheck($this->packageManager, $this->commandDispatcher);
     }
 
     /**
@@ -251,6 +261,24 @@ class UpgradeHandling
     }
 
     /**
+     * @param string $extensionKey
+     * @param bool $configOnly
+     * @return bool
+     */
+    public function isCompatible($extensionKey, $configOnly = false)
+    {
+        return $this->extensionCompatibilityCheck->isCompatible($extensionKey, $configOnly);
+    }
+
+    /**
+     * @return array Array of extension keys of not compatible extensions
+     */
+    public function findIncompatible()
+    {
+        return $this->extensionCompatibilityCheck->findIncompatible();
+    }
+
+    /**
      * Execute the command in a sub process,
      * but execute some automated migration steps beforehand
      *
@@ -287,7 +315,6 @@ class UpgradeHandling
             $this->configurationService->setLocal('EXTCONF/helhum-typo3-console/initialUpgradeDone', TYPO3_branch, 'string');
             $this->commandDispatcher->executeCommand('install:fixfolderstructure');
             $messages = $this->ensureExtensionCompatibility();
-            $messages = array_merge($messages, $this->checkForBrokenExtensions());
             $this->silentConfigurationUpgrade->executeSilentConfigurationUpgradesIfNeeded();
             // @deprecated if condition can be removed, when TYPO3 7.6 support is removed
             if (class_exists(DatabaseCharsetUpdate::class)) {
@@ -311,54 +338,10 @@ class UpgradeHandling
             $messages[] = sprintf('<error>%s</error>', $constraintMessage);
             $messages[] = sprintf('<info>Deactivated extension "%s".</info>', $extensionKey);
         }
-        return $messages;
-    }
-
-    /**
-     * @return string[]
-     */
-    private function checkForBrokenExtensions()
-    {
-        $errors = [];
-        $result = '';
-        $force = true;
-        $retryCount = 0;
-        do {
-            try {
-                $result = $this->commandDispatcher->executeCommand('upgrade:checkbrokenextensions', ['--force' => $force]);
-            } catch (FailedSubProcessCommandException $e) {
-                $force = false;
-                $retryCount++;
-                $this->collectErrors($errors);
-                // Happens only when more than 20 broken extensions were found.
-                if ($retryCount > 20) {
-                    throw new \RuntimeException('Loop detected when trying to find broken extensions.', 1494164326);
-                }
-            }
-        } while ($result !== 'OK');
-        $messages = [];
-        if ($failedExtensionKeys = @file_get_contents(PATH_site . 'typo3temp/assets/ExtensionCompatibilityTester.txt')) {
-            foreach (explode(', ', $failedExtensionKeys) as $extensionKey) {
-                $this->packageManager->deactivatePackage($extensionKey);
-                $messages[] = sprintf('<error>Extension "%s" seems to be not compatible or broken</error>', $extensionKey);
-                $messages[] = sprintf('<info>Deactivated extension "%s".</info>', $extensionKey);
-            }
+        foreach ($this->extensionCompatibilityCheck->findIncompatible() as $extensionKey) {
+            $messages[] = sprintf('<error>Extension "%s" seems to be not compatible or broken</error>', $extensionKey);
+            $messages[] = sprintf('<info>Deactivated extension "%s".</info>', $extensionKey);
         }
-        $messages = array_merge($messages, $errors);
-        // Make sure to clean up
-        @unlink(PATH_site . 'typo3temp/assets/ExtensionCompatibilityTester.txt');
-        @unlink(PATH_site . 'typo3temp/assets/ExtensionCompatibilityTesterErrors.json');
         return $messages;
-    }
-
-    /**
-     * @param array $errors
-     */
-    private function collectErrors(array &$errors)
-    {
-        // @TODO this somehow does not seem to work, as error_get_last() does not return anything. Not sure why currently
-        if (is_array($newErrors = json_decode(@file_get_contents(PATH_site . 'typo3temp/assets/ExtensionCompatibilityTesterErrors.json'), true))) {
-            $errors = array_merge($errors, array_filter($newErrors));
-        }
     }
 }


### PR DESCRIPTION
Don't rely on the core class, which vanished
in TYPO3 master anyway and never had a very
convenient API and introduce a class with
predictable API and behavior.

This also solves the issue of potentially having
an endless loop.