### PR TITLE
[FEATURE] Register Symfony commands from composer packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
     },
     "replace": {
         "typo3_console": "self.version",
-        "typo3-ter/typo3-console": "self.version"
+        "typo3-ter/typo3-console": "self.version",
+        "typo3/cms-cli": "*"
     },
     "config": {
         "vendor-dir": ".Build/vendor",


### PR DESCRIPTION
We now also scan composer packages for Symfony
command configurations, in both our config files
as well as in TYPO3's config files.