### PR TITLE
[FEATURE] Allow replacing commands from other packages

### DIFF
--- a/Classes/Mvc/Cli/CommandCollection.php
+++ b/Classes/Mvc/Cli/CommandCollection.php
@@ -15,7 +15,7 @@ namespace Helhum\Typo3Console\Mvc\Cli;
  */
 
 use Helhum\Typo3Console\Core\Booting\RunLevel;
-use Helhum\Typo3Console\Mvc\Cli\Symfony\Command\ExtbaseCommand;
+use Helhum\Typo3Console\Mvc\Cli\Symfony\Command\CommandControllerCommand;
 use Symfony\Component\Console\Command\Command as BaseCommand;
 use TYPO3\CMS\Core\Console\CommandNameAlreadyInUseException;
 use TYPO3\CMS\Core\Package\PackageManager;
@@ -111,9 +111,9 @@ class CommandCollection implements \IteratorAggregate
     private function populateFromCommandControllers($onlyNew = false): array
     {
         $registeredCommands = [];
-        foreach ($this->commandManager->getAvailableCommands($onlyNew) as $command) {
-            $commandName = $this->commandManager->getShortestIdentifierForCommand($command);
-            $fullCommandName = $command->getCommandIdentifier();
+        foreach ($this->commandManager->getAvailableCommands($onlyNew) as $commandDefinition) {
+            $commandName = $this->commandManager->getShortestIdentifierForCommand($commandDefinition);
+            $fullCommandName = $commandDefinition->getCommandIdentifier();
             if ($fullCommandName === 'typo3_console:help:help') {
                 continue;
             }
@@ -123,11 +123,7 @@ class CommandCollection implements \IteratorAggregate
             if (isset($this->commands[$commandName])) {
                 throw new CommandNameAlreadyInUseException('Command "' . $commandName . '" registered by "' . explode(':', $fullCommandName)[0] . '" is already in use', 1484486383);
             }
-            $extbaseCommand = GeneralUtility::makeInstance(ExtbaseCommand::class, $commandName);
-            $extbaseCommand->setExtbaseCommand($command);
-            if ($command->isInternal()) {
-                $extbaseCommand->setHidden(true);
-            }
+            $extbaseCommand = GeneralUtility::makeInstance(CommandControllerCommand::class, $commandName, $commandDefinition);
             $registeredCommands[$commandName] = $this->commands[$commandName] = $extbaseCommand;
         }
 

--- a/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
+++ b/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
@@ -32,23 +32,28 @@ use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Extbase\Mvc\Cli\Command as CommandDefinition;
 
 /**
- * Wrapper to turn an Extbase command from a command controller into a Symfony Command
+ * Wrapper to turn a command controller commands into a Symfony Command
  */
-class ExtbaseCommand extends Command
+class CommandControllerCommand extends Command
 {
     /**
-     * Extbase command
-     *
-     * @var \TYPO3\CMS\Extbase\Mvc\Cli\Command
+     * @var CommandDefinition
      */
-    private $command;
+    private $commandDefinition;
 
     /**
      * @var Application
      */
     private $application;
+
+    public function __construct($name, CommandDefinition $commandDefinition)
+    {
+        $this->commandDefinition = $commandDefinition;
+        parent::__construct($name);
+    }
 
     public function isEnabled()
     {
@@ -74,22 +79,13 @@ class ExtbaseCommand extends Command
     protected function configure()
     {
         $this->ignoreValidationErrors();
-    }
-
-    /**
-     * Sets the extbase command to be used for fetching the description etc.
-     *
-     * @param \TYPO3\CMS\Extbase\Mvc\Cli\Command $command
-     */
-    public function setExtbaseCommand(\TYPO3\CMS\Extbase\Mvc\Cli\Command $command)
-    {
-        $this->command = $command;
+        $this->setDescription($this->commandDefinition->getShortDescription());
+        $this->setHelp($this->commandDefinition->getDescription());
     }
 
     /**
      * Sets the application instance for this command.
-     * Also uses the setApplication call now, as $this->configure() is called
-     * too early
+     * It is used later for isEnabled()
      *
      * @param BaseApplication $application An Application instance
      */
@@ -100,8 +96,6 @@ class ExtbaseCommand extends Command
         }
         $this->application = $application;
         parent::setApplication($application);
-        $this->setDescription($this->command->getShortDescription());
-        $this->setHelp($this->command->getDescription());
     }
 
     /**
@@ -120,5 +114,10 @@ class ExtbaseCommand extends Command
         $argv[1] = $this->getName();
         $response = (new RequestHandler())->handle($argv, $input, $output);
         return $response->getExitCode();
+    }
+
+    public function isHidden()
+    {
+        return $this->commandDefinition->isInternal();
     }
 }

--- a/Classes/Mvc/Cli/Symfony/Command/HelpCommand.php
+++ b/Classes/Mvc/Cli/Symfony/Command/HelpCommand.php
@@ -71,7 +71,7 @@ class HelpCommand extends \Symfony\Component\Console\Command\HelpCommand
         if (null === $this->command) {
             $this->command = $this->getApplication()->find($input->getArgument('command_name'));
         }
-        if ($this->command instanceof ExtbaseCommand) {
+        if ($this->command instanceof CommandControllerCommand) {
             // An Extbase command was originally called, but is now required to show the help information
             if ($isRaw = $input->getOption('raw')) {
                 $output->setDecorated(false);

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -33,4 +33,13 @@ return [
         'typo3_console:install:defaultconfiguration' => ['helhum.typo3console:database'],
         'typo3_console:database:updateschema' => ['helhum.typo3console:database'],
     ],
+    'replace' => [
+        'extbase',
+        '_extbase_help',
+        '_core_command',
+        'backend:backend:lock',
+        'backend:backend:unlock',
+        'help:help',
+        'referenceindex:update',
+    ],
 ];


### PR DESCRIPTION
It is now possible to override/ replace/ remove
commands from other packages (or even the core
or TYPO3 Console themselves).

A package can define a "replace" section in the
configuration with an array of command identifiers.
Commands having these identifiers will be skipped
in any case, whether they really have a replacement
or not.