### PR TITLE
[BUGFIX] Define aliases for command controller commands

### DIFF
--- a/Classes/Command/CacheCommandController.php
+++ b/Classes/Command/CacheCommandController.php
@@ -122,7 +122,7 @@ class CacheCommandController extends CommandController
             $this->outputLine('Flushed all caches for group(s): "' . implode('","', $groups) . '".');
         } catch (NoSuchCacheGroupException $e) {
             $this->outputLine($e->getMessage());
-            $this->sendAndExit(1);
+            $this->quit(1);
         }
     }
 
@@ -147,7 +147,7 @@ class CacheCommandController extends CommandController
             }
         } catch (NoSuchCacheGroupException $e) {
             $this->outputLine($e->getMessage());
-            $this->sendAndExit(1);
+            $this->quit(1);
         }
     }
 

--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -79,7 +79,7 @@ class DatabaseCommandController extends CommandController
             $expandedSchemaUpdateTypes = SchemaUpdateType::expandSchemaUpdateTypes($schemaUpdateTypes);
         } catch (InvalidEnumerationValueException $e) {
             $this->outputLine(sprintf('<error>%s</error>', $e->getMessage()));
-            $this->sendAndExit(1);
+            $this->quit(1);
         }
 
         $result = $this->schemaService->updateSchema($expandedSchemaUpdateTypes, $dryRun);

--- a/Classes/Command/DocumentationCommandController.php
+++ b/Classes/Command/DocumentationCommandController.php
@@ -62,7 +62,7 @@ class DocumentationCommandController extends CommandController implements Single
         } catch (Service\Exception $exception) {
             $this->outputLine('An error occurred while trying to generate the XSD schema:');
             $this->outputLine('%s', [$exception->getMessage()]);
-            $this->sendAndExit(1);
+            $this->quit(1);
         }
         if ($targetFile === null) {
             echo $xsdSchema;

--- a/Classes/Command/SchedulerCommandController.php
+++ b/Classes/Command/SchedulerCommandController.php
@@ -33,21 +33,27 @@ class SchedulerCommandController extends CommandController
      *
      * <b>Example:</b> <code>typo3cms scheduler:run 42 --force</code>
      *
-     * @param int $taskId Uid of the task that should be executed (instead of all scheduled tasks)
+     * @param int $task Uid of the task that should be executed (instead of all scheduled tasks)
      * @param bool $force The execution can be forced with this flag. The task will then be executed even if it is not scheduled for execution yet. Only works, when a task is specified.
+     * @param int $taskId Deprecated option (same as --task)
      */
-    public function runCommand($taskId = null, $force = false)
+    public function runCommand($task = null, $force = false, $taskId = null)
     {
         if ($taskId !== null) {
-            if ($taskId <= 0) {
+            // @deprecated in 5.0 will be removed in 6.0
+            $this->outputLine('<warning>Using --task-id has been deprecated. Please use --task instead.</warning>');
+            $task = $taskId;
+        }
+        if ($task !== null) {
+            if ($task <= 0) {
                 $this->outputLine('Task Id must be higher than zero.');
-                $this->sendAndExit(1);
+                $this->quit(1);
             }
-            $this->executeSingleTask($taskId, $force);
+            $this->executeSingleTask($task, $force);
         } else {
             if ($force) {
                 $this->outputLine('Execution can only be forced when a single task is specified.');
-                $this->sendAndExit(2);
+                $this->quit(2);
             }
             $this->executeScheduledTasks();
         }

--- a/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
+++ b/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
@@ -107,6 +107,12 @@ class CommandControllerCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        // @deprecated in 5.0 will be removed in 6.0
+        $givenCommandName = $input->getArgument('command');
+        if ($givenCommandName !== $this->getName()) {
+            $output->writeln('<warning>Specifying the full command name has been deprecated.</warning>');
+            $output->writeln(sprintf('<warning>Please use "%s" as command name instead.</warning>', $this->getName()));
+        }
         // The command was found by Application, but it could be that a short name
         // is specified, which would not be detected by the Extbase code.
         // Therefore we enforce the full command name here.

--- a/Classes/Mvc/Cli/Symfony/Descriptor/TextDescriptor.php
+++ b/Classes/Mvc/Cli/Symfony/Descriptor/TextDescriptor.php
@@ -175,8 +175,7 @@ class TextDescriptor extends \Symfony\Component\Console\Descriptor\TextDescripto
                     $this->writeText("\n");
                     $spacingWidth = $width - Helper::strlen($name);
                     $command = $commands[$name];
-                    $commandAliases = $name === $command->getName() ? $this->getCommandAliasesText($command) : '';
-                    $this->writeText(sprintf('  <info>%s</info>%s%s', $name, str_repeat(' ', $spacingWidth), $commandAliases . $this->wordWrap($command->getDescription(), $indent, $maxWidth)), $options);
+                    $this->writeText(sprintf('  <info>%s</info>%s%s', $name, str_repeat(' ', $spacingWidth), $this->wordWrap($command->getDescription(), $indent, $maxWidth)), $options);
                 }
             }
 

--- a/Classes/Mvc/Controller/CommandController.php
+++ b/Classes/Mvc/Controller/CommandController.php
@@ -323,11 +323,12 @@ abstract class CommandController implements CommandControllerInterface
      * Should be used for commands that flush code caches.
      *
      * @param int $exitCode Exit code to return on exit
+     * @deprecated Will be removed with 6.0.0
      */
     protected function sendAndExit($exitCode = 0)
     {
-        $this->response->send();
-        exit($exitCode);
+        $this->outputLine('<warning>Using sendAndExit() has been deprecated. Please use quit() instead.</warning>');
+        $this->quit($exitCode);
     }
 
     /**

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -41,5 +41,6 @@ return [
         'backend:backend:unlock',
         'help:help',
         'referenceindex:update',
+        'scheduler:scheduler:run',
     ],
 ];

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -922,10 +922,12 @@ Executes tasks that are registered in the scheduler module.
 Options
 ^^^^^^^
 
-``--task-id``
+``--task``
   Uid of the task that should be executed (instead of all scheduled tasks)
 ``--force``
   The execution can be forced with this flag. The task will then be executed even if it is not scheduled for execution yet. Only works, when a task is specified.
+``--task-id``
+  Deprecated option (same as --task)
 
 
 


### PR DESCRIPTION
Command controller commands used to also work
with their full identifier. Mimik this behavior
again by setting the according alias.

Nevertheless we deprecate the usage of such
command names.