### PR TITLE
[BUGFIX] Make low level cache flush work again

### DIFF
--- a/Classes/Command/CacheCommandController.php
+++ b/Classes/Command/CacheCommandController.php
@@ -58,6 +58,7 @@ class CacheCommandController extends CommandController
         if (!$filesOnly) {
             try {
                 $this->cacheService->flush($force);
+                $this->commandDispatcher->executeCommand('cache:flushcomplete');
             } catch (\Throwable $e) {
                 $exitCode = 1;
                 $filesOnly = true;
@@ -66,7 +67,6 @@ class CacheCommandController extends CommandController
                 $exitCode = 1;
                 $filesOnly = true;
             }
-            $this->commandDispatcher->executeCommand('cache:flushcomplete');
         }
         if ($filesOnly) {
             $this->cacheService->flushFileCaches($force);

--- a/Classes/Service/CacheService.php
+++ b/Classes/Service/CacheService.php
@@ -68,6 +68,7 @@ class CacheService implements SingletonInterface
     public function flush($force = false)
     {
         $this->ensureDatabaseIsInitialized();
+        $this->reEnableCoreCaches();
         if ($force) {
             $this->forceFlushCoreFileAndDatabaseCaches();
         }

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -19,6 +19,7 @@ return [
         'typo3_console:install:defaultconfiguration' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:install:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
         'typo3_console:cache:flush' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        'typo3_console:cache:flushcomplete' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:configuration:show' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
         'typo3_console:configuration:showactive' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
         'typo3_console:configuration:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,


### PR DESCRIPTION
The command cache:flushcomplete must not boot to
a level where a db connection is needed, otherwise
it will fail before we reach the cache service.

On the other hand, we need to re enable the core caches
also when flushing database caches, so that the will
in fact be flushed and we are not operating with the
fake database backend