### PR TITLE
[FEATURE] Use Symfony help also for command controller commands

### DIFF
--- a/Classes/Command/HelpCommandController.php
+++ b/Classes/Command/HelpCommandController.php
@@ -13,10 +13,7 @@ namespace Helhum\Typo3Console\Command;
  *
  */
 
-use Helhum\Typo3Console\Core\Booting\RunLevel;
-use Helhum\Typo3Console\Mvc\Cli\Command;
 use Helhum\Typo3Console\Mvc\Controller\CommandController;
-use TYPO3\CMS\Core\Core\Bootstrap;
 
 /**
  * A Command Controller which provides help for available commands
@@ -25,17 +22,6 @@ use TYPO3\CMS\Core\Core\Bootstrap;
  */
 class HelpCommandController extends CommandController
 {
-    /**
-     * @var \TYPO3\CMS\Extbase\Mvc\Cli\CommandManager
-     * @inject
-     */
-    protected $commandManager;
-
-    /**
-     * @var Command[]
-     */
-    protected $commands = [];
-
     /**
      * Help
      *
@@ -49,55 +35,7 @@ class HelpCommandController extends CommandController
      */
     public function helpCommand($commandIdentifier)
     {
-        $command = $this->commandManager->getCommandByIdentifier($commandIdentifier);
-        $commandArgumentDefinitions = $command->getArgumentDefinitions();
-        $this->outputLine('<comment>Usage:</comment>');
-        $this->outputLine('  ' . $this->commandManager->getShortestIdentifierForCommand($command) . ' ' . $command->getSynopsis(true));
-        $argumentDescriptions = [];
-        $optionDescriptions = [];
-        if ($command->hasArguments()) {
-            foreach ($commandArgumentDefinitions as $commandArgumentDefinition) {
-                $argumentDescription = $commandArgumentDefinition->getDescription();
-                $argumentDescription = $this->wordWrap($argumentDescription, 23);
-                if ($commandArgumentDefinition->isRequired()) {
-                    $argumentDescriptions[] = vsprintf('  <info>%-20s</info> %s', [$commandArgumentDefinition->getName(), $argumentDescription]);
-                } else {
-                    $optionDescriptions[] = vsprintf('  <info>%-20s</info> %s', [$commandArgumentDefinition->getDashedName(), $argumentDescription]);
-                }
-            }
-        }
-        if (count($argumentDescriptions) > 0) {
-            $this->outputLine();
-            $this->outputLine('<comment>Arguments:</comment>');
-            foreach ($argumentDescriptions as $argumentDescription) {
-                $this->outputLine($argumentDescription);
-            }
-        }
-        if (count($optionDescriptions) > 0) {
-            $this->outputLine();
-            $this->outputLine('<comment>Options:</comment>');
-            foreach ($optionDescriptions as $optionDescription) {
-                $this->outputLine($optionDescription);
-            }
-        }
-        if ($command->getDescription() !== '') {
-            $this->outputLine();
-            $this->outputLine('<comment>Help:</comment>');
-            $descriptionLines = explode(chr(10), $command->getDescription());
-            foreach ($descriptionLines as $descriptionLine) {
-                $this->outputLine('%-2s%s', [' ', $descriptionLine]);
-            }
-        }
-        $relatedCommandIdentifiers = $command->getRelatedCommandIdentifiers();
-        if ($relatedCommandIdentifiers !== []) {
-            $this->outputLine();
-            $this->outputLine('<comment>Related Commands:</comment>');
-            foreach ($relatedCommandIdentifiers as $relatedIdentifier) {
-                $command = $this->commandManager->getCommandByIdentifier($relatedIdentifier);
-                $this->outputLine('%-2s%s (%s)', [' ', $this->commandManager->getShortestIdentifierForCommand($command), $command->getShortDescription()]);
-            }
-        }
-        $this->outputLine();
+        // Intentionally empty for now (until command reference can render Symfony commands)
     }
 
     /**
@@ -117,47 +55,8 @@ class HelpCommandController extends CommandController
             }
         }
         $this->outputLine();
-        $this->outputLine('See <info>help</info> for an overview of all available commands');
+        $this->outputLine('See <info>list</info> for an overview of all available commands');
         $this->outputLine('or <info>help</info> <command> for a detailed description of the corresponding command.');
         $this->quit(1);
-    }
-
-    /**
-     * Builds an index of available commands. For each of them a Command object is
-     * added to the commands array of this class.
-     *
-     * @return void
-     */
-    protected function buildCommandsIndex()
-    {
-        $availableCommands = $this->commandManager->getAvailableCommands();
-        $runLevel = Bootstrap::getInstance()->getEarlyInstance(RunLevel::class);
-
-        foreach ($availableCommands as $command) {
-            if ($command->isInternal()) {
-                continue;
-            }
-
-            $shortCommandIdentifier = $this->commandManager->getShortestIdentifierForCommand($command);
-
-            if ($runLevel->getMaximumAvailableRunLevel() === RunLevel::LEVEL_COMPILE && !$runLevel->isCommandAvailable($shortCommandIdentifier)) {
-                continue;
-            }
-
-            $this->commands[$shortCommandIdentifier] = $command;
-        }
-
-        ksort($this->commands);
-    }
-
-    /**
-     * @param string $stringToWrap
-     * @param int $indent
-     * @return string
-     */
-    protected function wordWrap($stringToWrap, $indent)
-    {
-        $formatter = $this->output->getSymfonyConsoleOutput()->getFormatter();
-        return wordwrap($formatter->format($stringToWrap), $this->output->getMaximumLineLength() - $indent, PHP_EOL . str_repeat(' ', $indent), true);
     }
 }

--- a/Classes/Mvc/Cli/Command.php
+++ b/Classes/Mvc/Cli/Command.php
@@ -256,8 +256,9 @@ class Command
             if ($commandParameterDefinition['array']) {
                 $dataType = 'array';
             }
+            $default = $commandParameterDefinition['defaultValue'] ?? null;
             $required = $commandParameterDefinition['optional'] !== true;
-            $argumentDefinition = new CommandArgumentDefinition($commandParameterName, $required, $description, $dataType);
+            $argumentDefinition = new CommandArgumentDefinition($commandParameterName, $required, $description, $dataType, $default);
             if ($required) {
                 $this->requiredArguments[] = $argumentDefinition;
             } else {

--- a/Classes/Mvc/Cli/CommandArgumentDefinition.php
+++ b/Classes/Mvc/Cli/CommandArgumentDefinition.php
@@ -53,19 +53,26 @@ class CommandArgumentDefinition
     private $dataType;
 
     /**
+     * @var mixed
+     */
+    private $defaultValue;
+
+    /**
      * Constructor
      *
      * @param string $name name of the command argument (= parameter name)
      * @param bool $required defines whether this argument is required or optional
      * @param string $description description of the argument
      * @param string $dataType data type (boolean, string or array)
+     * @param mixed $defaultValue
      */
-    public function __construct($name, $required, $description, $dataType)
+    public function __construct($name, $required, $description, $dataType, $defaultValue = null)
     {
         $this->name = $name;
         $this->required = $required;
         $this->description = $description;
         $this->dataType = $dataType;
+        $this->defaultValue = $defaultValue;
     }
 
     /**
@@ -118,6 +125,14 @@ class CommandArgumentDefinition
     public function getDataType(): string
     {
         return $this->dataType;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDefaultValue()
+    {
+        return $this->defaultValue;
     }
 
     /**

--- a/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
+++ b/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
@@ -55,6 +55,14 @@ class CommandControllerCommand extends Command
         parent::__construct($name);
     }
 
+    /**
+     * @return CommandDefinition
+     */
+    public function getCommandDefinition(): CommandDefinition
+    {
+        return $this->commandDefinition;
+    }
+
     public function isEnabled()
     {
         if (!$this->application->isFullyCapable()

--- a/Classes/Mvc/Cli/Symfony/Command/HelpCommand.php
+++ b/Classes/Mvc/Cli/Symfony/Command/HelpCommand.php
@@ -26,7 +26,6 @@ namespace Helhum\Typo3Console\Mvc\Cli\Symfony\Command;
  * The TYPO3 project - inspiring people to share!
  */
 
-use Helhum\Typo3Console\Mvc\Cli\RequestHandler;
 use Helhum\Typo3Console\Mvc\Cli\Symfony\Descriptor\TextDescriptor;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\DescriptorHelper;
@@ -77,22 +76,14 @@ class HelpCommand extends \Symfony\Component\Console\Command\HelpCommand
             $this->command = $this->getApplication()->find($input->getArgument('command_name'));
         }
 
-        if ($this->command instanceof CommandControllerCommand) {
-            // An Extbase command was originally called, but is now required to show the help information
-            if ($isRaw = $input->getOption('raw')) {
-                $output->setDecorated(false);
-            }
-            (new RequestHandler())->handle([$input->getFirstArgument(), 'help', $this->command->getName()], $input, $output);
-        } else {
-            // Any other Symfony command should just show up the regular info
-            $helper = new DescriptorHelper();
-            $helper->register('txt', new TextDescriptor());
-            $helper->describe($output, $this->command, [
-                'format' => $input->getOption('format'),
-                'raw_text' => $input->getOption('raw'),
-                'screen_width' => (new Terminal())->getWidth() - 4,
-            ]);
-        }
+        $helper = new DescriptorHelper();
+        // Add our own descriptor
+        $helper->register('txt', new TextDescriptor());
+        $helper->describe($output, $this->command, [
+            'format' => $input->getOption('format'),
+            'raw_text' => $input->getOption('raw'),
+            'screen_width' => (new Terminal())->getWidth() - 4,
+        ]);
         $this->command = null;
     }
 }


### PR DESCRIPTION
Remove all of our own code and instead convert the command definition
to a Symfony input definiton and let the descriptor do its job