### PR TITLE
[!!!] Hide extension:de/activate in composer mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,13 @@ branches:
     - develop
     - /^([0-9]+\.){1,2}(x|[0-9]+)$/
 
-matrix:
-  fast_finish: true
-  include:
-    - php: 7.1
-      env: TYPO3_VERSION=^8.7
-    - php: 7.0
-      env: TYPO3_VERSION=^8.7
-    - php: 7.0
-      env: TYPO3_VERSION="dev-master as 8.7.7"
-    - php: 7.1
-      env: TYPO3_VERSION="dev-master as 8.7.7"
-  allow_failures:
-    - env: TYPO3_VERSION="dev-master as 8.7.7"
+php:
+  - 7.1
+  - 7.0
+
+env:
+  - TYPO3_VERSION=^8.7
+  - TYPO3_VERSION="dev-master as 8.7.7"
 
 cache:
   directories:
@@ -61,24 +55,29 @@ script:
   - >
     echo "Running unit and functional tests…";
     .Build/bin/phpunit;
+jobs:
+  fast_finish: true
+  allow_failures:
+    - env: TYPO3_VERSION="dev-master as 8.7.7"
+  include:
+    - stage: deploy to ter
+      php: 7.1
+      install: skip
+      before_script: skip
+      script:
+        - |
+          if [ -n "$TRAVIS_TAG" ] && [ -n "$TYPO3_ORG_USERNAME" ] && [ -n "$TYPO3_ORG_PASSWORD" ]; then
+            echo -e "Preparing upload of release ${TRAVIS_TAG} to TER\n";
+            # Cleanup before we upload
+            composer require --dev typo3/cms ^8.7 --update-with-dependencies
+            composer require --dev helhum/ter-client dev-master
+            git reset --hard HEAD && git clean -fx
 
-after_script:
-  - >
-    if [ -n "$TRAVIS_TAG" ] && [ -n "$TYPO3_ORG_USERNAME" ] && [ -n "$TYPO3_ORG_PASSWORD" ]; then
-      echo -e "Preparing upload of release ${TRAVIS_TAG} to TER\n"
-      curl -sSL https://raw.githubusercontent.com/alrra/travis-after-all/1.4.4/lib/travis-after-all.js | node
-      if [ $? -eq 0 ]; then
-        # Cleanup before we upload
-        composer require --dev typo3/cms ^8.7 --update-with-dependencies
-        composer require --dev helhum/ter-client dev-master
-        git reset --hard HEAD && git clean -fx
+            # Build extension files
+            composer extension-release
 
-        # Build extension files
-        composer extension-release
-
-        # Upload
-        TAG_MESSAGE=`git tag -n10 -l $TRAVIS_TAG | sed 's/^[0-9.]*[ ]*//g'`
-        echo "Uploading release ${TRAVIS_TAG} to TER"
-        .Build/bin/ter-client upload typo3_console . -u "$TYPO3_ORG_USERNAME" -p "$TYPO3_ORG_PASSWORD" -m "$TAG_MESSAGE"
-      fi;
-    fi;
+            # Upload
+            TAG_MESSAGE=`git tag -n10 -l $TRAVIS_TAG | sed 's/^[0-9.]*[ ]*//g'`
+            echo "Uploading release ${TRAVIS_TAG} to TER"
+            .Build/bin/ter-client upload typo3_console . -u "$TYPO3_ORG_USERNAME" -p "$TYPO3_ORG_PASSWORD" -m "$TAG_MESSAGE"
+          fi;

--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -17,7 +17,6 @@ use Helhum\Typo3Console\Extension\ExtensionSetup;
 use Helhum\Typo3Console\Extension\ExtensionSetupResultRenderer;
 use Helhum\Typo3Console\Install\FolderStructure\ExtensionFactory;
 use Helhum\Typo3Console\Mvc\Controller\CommandController;
-use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Core\ClassLoadingInformation;
 use TYPO3\CMS\Core\Package\PackageInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -63,19 +62,14 @@ class ExtensionCommandController extends CommandController
      * Activates one or more extensions by key.
      * Marks extensions as active, sets them up and clears caches for every activated extension.
      *
+     * This command is only available in non composer mode.
+     *
      * @param array $extensionKeys Extension keys to activate. Separate multiple extension keys with comma.
      * @param bool $verbose Whether or not to output results
      * @throws \TYPO3\CMS\Extensionmanager\Exception\ExtensionManagerException
      */
     public function activateCommand(array $extensionKeys, $verbose = false)
     {
-        if (getenv('TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES') && Bootstrap::usesComposerClassLoading()) {
-            $this->output->outputLine('<warning>This command has been deprecated to be used in composer mode, as it might lead to unexpected results</warning>');
-            $this->output->outputLine('<warning>The PackageStates.php file that tracks which extension should be active,</warning>');
-            $this->output->outputLine('<warning>is now generated automatically when installing the console with composer.</warning>');
-            $this->output->outputLine('<warning>To set up all active extensions correctly, please use the extension:setupactive command</warning>');
-        }
-
         $this->emitPackagesMayHaveChangedSignal();
         $activatedExtensions = [];
         $extensionsToSetUp = [];
@@ -110,18 +104,13 @@ class ExtensionCommandController extends CommandController
      * Deactivates one or more extensions by key.
      * Marks extensions as inactive in the system and clears caches for every deactivated extension.
      *
+     * This command is only available in non composer mode.
+     *
      * @param array $extensionKeys Extension keys to deactivate. Separate multiple extension keys with comma.
      * @throws \TYPO3\CMS\Extensionmanager\Exception\ExtensionManagerException
      */
     public function deactivateCommand(array $extensionKeys)
     {
-        if (getenv('TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES') && Bootstrap::usesComposerClassLoading()) {
-            $this->output->outputLine('<warning>This command has been deprecated to be used in composer mode, as it might lead to unexpected results</warning>');
-            $this->output->outputLine('<warning>The PackageStates.php file that tracks which extension should be active,</warning>');
-            $this->output->outputLine('<warning>is now generated automatically when installing the console with composer.</warning>');
-            $this->output->outputLine('<warning>To set up all active extensions correctly, please use the extension:setupactive command</warning>');
-        }
-
         foreach ($extensionKeys as $extensionKey) {
             $this->extensionInstaller->uninstall($extensionKey);
         }
@@ -259,7 +248,7 @@ class ExtensionCommandController extends CommandController
      * This command is only needed during development. The extension manager takes care
      * creating or updating this info properly during extension (de-)activation.
      *
-     * @throws \TYPO3\CMS\Extbase\Mvc\Exception\StopActionException
+     * This command is only available in non composer mode.
      */
     public function dumpAutoloadCommand()
     {

--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -263,13 +263,8 @@ class ExtensionCommandController extends CommandController
      */
     public function dumpAutoloadCommand()
     {
-        if (Bootstrap::usesComposerClassLoading()) {
-            $this->output->outputLine('<error>Class loading information is managed by Composer. Use "composer dump-autoload" command to update the information.</error>');
-            $this->quit(1);
-        } else {
-            ClassLoadingInformation::dumpClassLoadingInformation();
-            $this->output->outputLine('Class Loading information has been updated.');
-        }
+        ClassLoadingInformation::dumpClassLoadingInformation();
+        $this->output->outputLine('Class Loading information has been updated.');
     }
 
     /**

--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -219,10 +219,14 @@ class ExtensionCommandController extends CommandController
      * This is a one way command with no way back. Don't blame anybody if this command destroys your data.
      * <comment>Handle with care!</comment>
      *
+     * This command is deprecated.
+     * Instead of adding extensions and then removing them, just don't add them in the first place.
+     *
      * @param bool $force The option has to be specified, otherwise nothing happens
      */
     public function removeInactiveCommand($force = false)
     {
+        $this->outputLine('<warning>This command is deprecated and will be removed with TYPO3 Console 6.0</warning>');
         if ($force) {
             $activePackages = $this->packageManager->getActivePackages();
             $this->packageManager->scanAvailablePackages();

--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -129,11 +129,6 @@ class InstallCommandController extends CommandController
      */
     public function generatePackageStatesCommand(array $frameworkExtensions = [], $activateDefault = false, array $excludedExtensions = [])
     {
-        $ranFromComposerPlugin = getenv('TYPO3_CONSOLE_PLUGIN_RUN') || !getenv('TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES');
-        if (!$ranFromComposerPlugin && Bootstrap::usesComposerClassLoading()) {
-            $this->output->outputLine('<warning>This command is now always automatically executed after Composer has written the autoload information.</warning>');
-            $this->output->outputLine('<warning>It is therefore deprecated to be used in Composer mode.</warning>');
-        }
         $frameworkExtensions = $frameworkExtensions ?: explode(',', (string)getenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS'));
         $packageStatesGenerator = new PackageStatesGenerator($this->packageManager);
         $activatedExtensions = $packageStatesGenerator->generate($frameworkExtensions, $activateDefault, $excludedExtensions);

--- a/Classes/Command/SchedulerCommandController.php
+++ b/Classes/Command/SchedulerCommandController.php
@@ -41,7 +41,7 @@ class SchedulerCommandController extends CommandController
     {
         if ($taskId !== null) {
             // @deprecated in 5.0 will be removed in 6.0
-            $this->outputLine('<warning>Using --task-id has been deprecated. Please use --task instead.</warning>');
+            $this->outputLine('<warning>Using --task-id is deprecated. Please use --task instead.</warning>');
             $task = $taskId;
         }
         if ($task !== null) {

--- a/Classes/Core/Kernel.php
+++ b/Classes/Core/Kernel.php
@@ -75,7 +75,7 @@ class Kernel
      */
     private function initializeNonComposerClassLoading()
     {
-        if ($this->bootstrap::usesComposerClassLoading()) {
+        if (Bootstrap::usesComposerClassLoading()) {
             return;
         }
         $classesPaths = [__DIR__ . '/../../Classes', __DIR__ . '/../../Resources/Private/ExtensionArtifacts/src/'];
@@ -154,7 +154,7 @@ class Kernel
             GeneralUtility::makeInstance(PackageManager::class)
         );
 
-        $application = new Application($this->runLevel);
+        $application = new Application($this->runLevel, Bootstrap::usesComposerClassLoading());
         $application->addCommandsIfAvailable($commandRegistry);
 
         $commandIdentifier = $input->getFirstArgument() ?: '';

--- a/Classes/Core/Kernel.php
+++ b/Classes/Core/Kernel.php
@@ -154,7 +154,8 @@ class Kernel
             GeneralUtility::makeInstance(PackageManager::class)
         );
 
-        $application = new Application($this->runLevel, Bootstrap::usesComposerClassLoading());
+        $composerMode = !getenv('CONSOLE_NON_COMPOSER_TEST') && Bootstrap::usesComposerClassLoading();
+        $application = new Application($this->runLevel, $composerMode);
         $application->addCommandsIfAvailable($commandRegistry);
 
         $commandIdentifier = $input->getFirstArgument() ?: '';

--- a/Classes/Mvc/Cli/Symfony/Application.php
+++ b/Classes/Mvc/Cli/Symfony/Application.php
@@ -37,10 +37,16 @@ class Application extends BaseApplication
      */
     private $runLevel;
 
-    public function __construct(RunLevel $runLevel = null)
+    /**
+     * @var bool
+     */
+    private $composerManaged;
+
+    public function __construct(RunLevel $runLevel = null, bool $composerManaged = true)
     {
         parent::__construct('TYPO3 Console', self::TYPO3_CONSOLE_VERSION);
         $this->runLevel = $runLevel;
+        $this->composerManaged = $composerManaged;
     }
 
     /**
@@ -53,6 +59,17 @@ class Application extends BaseApplication
     public function isFullyCapable(): bool
     {
         return $this->runLevel->getMaximumAvailableRunLevel() === RunLevel::LEVEL_FULL;
+    }
+
+    /**
+     * Whether this application is composer managed.
+     * Can be used to enable or disable commands or arguments/ options
+     *
+     * @return bool
+     */
+    public function isComposerManaged(): bool
+    {
+        return $this->composerManaged;
     }
 
     /**

--- a/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
+++ b/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Mvc\Cli\Symfony\Command;
 
 /*
@@ -63,14 +64,14 @@ class CommandControllerCommand extends Command
         return $this->commandDefinition;
     }
 
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         if (!$this->application->isFullyCapable()
             && in_array($this->getName(), [
                 // Although these commands are technically available
                 // they call other hidden commands in sub processes
                 // that need all capabilities. Therefore we disable these commands here.
-                // This can be removed, once the implement Symfony commands directly.
+                // This can be removed, once they implement Symfony commands directly.
                 'upgrade:all',
                 'upgrade:list',
                 'upgrade:wizard',
@@ -107,7 +108,7 @@ class CommandControllerCommand extends Command
     public function setApplication(BaseApplication $application = null)
     {
         if ($application !== null && !$application instanceof Application) {
-            throw new \RuntimeException('Extbase commands only work with TYPO3 Console Applications', 1506381781);
+            throw new \RuntimeException('Command controller commands only work with TYPO3 Console Applications', 1506381781);
         }
         $this->application = $application;
         parent::setApplication($application);
@@ -130,7 +131,7 @@ class CommandControllerCommand extends Command
         // @deprecated in 5.0 will be removed in 6.0
         $givenCommandName = $input->getArgument('command');
         if ($givenCommandName === $this->getAliases()[0]) {
-            $output->writeln('<warning>Specifying the full command name has been deprecated.</warning>');
+            $output->writeln('<warning>Specifying the full command name is deprecated.</warning>');
             $output->writeln(sprintf('<warning>Please use "%s" as command name instead.</warning>', $this->getName()));
         }
         $response = (new RequestHandler())->handle($this->commandDefinition, $input, $output);

--- a/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
+++ b/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
@@ -70,6 +70,8 @@ class CommandControllerCommand extends Command
             && in_array($this->getName(), [
                 // Remove commands than don't make sense when application is composer managed
                 'extension:dumpautoload',
+                'extension:activate',
+                'extension:deactivate',
             ], true)
         ) {
             return false;

--- a/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
+++ b/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
@@ -66,6 +66,14 @@ class CommandControllerCommand extends Command
 
     public function isEnabled(): bool
     {
+        if ($this->application->isComposerManaged()
+            && in_array($this->getName(), [
+                // Remove commands than don't make sense when application is composer managed
+                'extension:dumpautoload',
+            ], true)
+        ) {
+            return false;
+        }
         if (!$this->application->isFullyCapable()
             && in_array($this->getName(), [
                 // Although these commands are technically available

--- a/Classes/Mvc/Controller/CommandController.php
+++ b/Classes/Mvc/Controller/CommandController.php
@@ -327,7 +327,7 @@ abstract class CommandController implements CommandControllerInterface
      */
     protected function sendAndExit($exitCode = 0)
     {
-        $this->outputLine('<warning>Using sendAndExit() has been deprecated. Please use quit() instead.</warning>');
+        $this->outputLine('<warning>Using sendAndExit() is deprecated. Please use quit() instead.</warning>');
         $this->quit($exitCode);
     }
 

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -25,6 +25,7 @@ return [
         'typo3_console:configuration:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:database:import' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:database:updateschema' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
+        'typo3_console:extension:dumpautoload' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:upgrade:subprocess' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
         'typo3_console:upgrade:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
     ],

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -542,6 +542,8 @@ Options
 Activates one or more extensions by key.
 Marks extensions as active, sets them up and clears caches for every activated extension.
 
+This command is only available in non composer mode.
+
 Arguments
 ^^^^^^^^^
 
@@ -570,6 +572,8 @@ Options
 Deactivates one or more extensions by key.
 Marks extensions as inactive in the system and clears caches for every deactivated extension.
 
+This command is only available in non composer mode.
+
 Arguments
 ^^^^^^^^^
 
@@ -593,6 +597,8 @@ Updates class loading information in non Composer managed TYPO3 installations.
 
 This command is only needed during development. The extension manager takes care
 creating or updating this info properly during extension (de-)activation.
+
+This command is only available in non composer mode.
 
 
 

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -636,6 +636,9 @@ Directories of inactive extension are **removed** from ``typo3/sysext`` and ``ty
 This is a one way command with no way back. Don't blame anybody if this command destroys your data.
 **Handle with care!**
 
+This command is deprecated.
+Instead of adding extensions and then removing them, just don't add them in the first place.
+
 
 
 Options

--- a/Tests/Functional/Command/AbstractCommandTest.php
+++ b/Tests/Functional/Command/AbstractCommandTest.php
@@ -190,10 +190,10 @@ abstract class AbstractCommandTest extends \PHPUnit_Framework_TestCase
         return $process->getOutput() . $process->getErrorOutput();
     }
 
-    protected function executeConsoleCommand($command, array $arguments = [])
+    protected function executeConsoleCommand($command, array $arguments = [], array $environment = [])
     {
         try {
-            return $this->commandDispatcher->executeCommand($command, $arguments);
+            return $this->commandDispatcher->executeCommand($command, $arguments, $environment);
         } catch (FailedSubProcessCommandException $e) {
             $this->fail(sprintf('Console command "%s" failed with message: "%s", output: "%s"', $e->getCommandLine(), $e->getErrorMessage(), $e->getOutputMessage()));
         }

--- a/Tests/Functional/Command/ExtensionCommandControllerTest.php
+++ b/Tests/Functional/Command/ExtensionCommandControllerTest.php
@@ -67,14 +67,14 @@ class ExtensionCommandControllerTest extends AbstractCommandTest
         $this->backupDatabase();
         $this->installFixtureExtensionCode('ext_test');
 
-        $output = $this->executeConsoleCommand('extension:activate', ['ext_test']);
+        $output = $this->executeConsoleCommand('extension:activate', ['ext_test'], ['CONSOLE_NON_COMPOSER_TEST' => 1]);
         $this->assertContains('Extension "ext_test" is now active.', $output);
         $this->assertContains('Extension "ext_test" is now set up.', $output);
 
         $output = $this->executeConsoleCommand('database:updateschema');
         $this->assertContains('No schema updates were performed for update types:', $output);
 
-        $output = $this->executeConsoleCommand('extension:deactivate', ['ext_test']);
+        $output = $this->executeConsoleCommand('extension:deactivate', ['ext_test'], ['CONSOLE_NON_COMPOSER_TEST' => 1]);
         $this->assertContains('Extension "ext_test" is now inactive.', $output);
 
         $this->removeFixtureExtensionCode('ext_test');
@@ -89,18 +89,18 @@ class ExtensionCommandControllerTest extends AbstractCommandTest
         $this->backupDatabase();
         $this->installFixtureExtensionCode('ext_test');
 
-        $output = $this->executeConsoleCommand('extension:activate', ['ext_test']);
+        $output = $this->executeConsoleCommand('extension:activate', ['ext_test'], ['CONSOLE_NON_COMPOSER_TEST' => 1]);
         $this->assertContains('Extension "ext_test" is now active.', $output);
         $this->assertContains('Extension "ext_test" is now set up.', $output);
 
-        $output = $this->executeConsoleCommand('extension:activate', ['core']);
+        $output = $this->executeConsoleCommand('extension:activate', ['core'], ['CONSOLE_NON_COMPOSER_TEST' => 1]);
         $this->assertNotContains('is now active.', $output);
         $this->assertContains('Extension "core" is now set up.', $output);
 
         $output = $this->executeConsoleCommand('database:updateschema');
         $this->assertContains('No schema updates were performed for update types:', $output);
 
-        $output = $this->executeConsoleCommand('extension:deactivate', ['ext_test']);
+        $output = $this->executeConsoleCommand('extension:deactivate', ['ext_test'], ['CONSOLE_NON_COMPOSER_TEST' => 1]);
         $this->assertContains('Extension "ext_test" is now inactive.', $output);
 
         $this->removeFixtureExtensionCode('ext_test');
@@ -123,7 +123,7 @@ class ExtensionCommandControllerTest extends AbstractCommandTest
         $output = $this->executeConsoleCommand('database:updateschema');
         $this->assertContains('No schema updates were performed for update types:', $output);
 
-        $output = $this->executeConsoleCommand('extension:deactivate', ['ext_test']);
+        $output = $this->executeConsoleCommand('extension:deactivate', ['ext_test'], ['CONSOLE_NON_COMPOSER_TEST' => 1]);
         $this->assertContains('Extension "ext_test" is now inactive.', $output);
 
         $this->removeFixtureExtensionCode('ext_test');

--- a/Tests/Functional/Command/UpgradeCommandControllerTest.php
+++ b/Tests/Functional/Command/UpgradeCommandControllerTest.php
@@ -43,14 +43,14 @@ class UpgradeCommandControllerTest extends AbstractCommandTest
     public function checkExtensionConstraintsReturnsErrorCodeOnFailure()
     {
         $this->installFixtureExtensionCode('ext_test');
-        $this->executeConsoleCommand('extension:activate', ['ext_test']);
+        $this->executeConsoleCommand('extension:activate', ['ext_test'], ['CONSOLE_NON_COMPOSER_TEST' => 1]);
         try {
             $this->commandDispatcher->executeCommand('upgrade:checkextensionconstraints', ['--typo3-version' => '3.6.0']);
         } catch (FailedSubProcessCommandException $e) {
             $this->assertSame(1, $e->getExitCode());
             $this->assertContains('"ext_test" requires TYPO3 versions 4.5.0', $e->getOutputMessage());
         }
-        $this->executeConsoleCommand('extension:deactivate', ['ext_test']);
+        $this->executeConsoleCommand('extension:deactivate', ['ext_test'], ['CONSOLE_NON_COMPOSER_TEST' => 1]);
         $this->removeFixtureExtensionCode('ext_test');
     }
 


### PR DESCRIPTION
When TYPO3 is composer managed, these commands were
deprecated to be used. Instead a fully automated
workflow using package states generation and
extension:setupactive command should be used.