### PR TITLE
Do not install "parallel" on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,70 +58,68 @@ jobs:
       before_script: skip
       script:
         - errors=$(find . -name \*.php ! -path "./.Build/*" -exec php -d display_errors=stderr -l {} 2>&1 >/dev/null \;) && echo "$errors" && test -z "$errors"
-#    - <<: *lint
-#      php: 7.0
     - <<: *lint
-      php: 5.5
+      php: 7.0
 
-#    - stage: test
-#      php: 7.1
-#      env: TYPO3_VERSION=^8.7
-#    - stage: test
-#      php: 7.0
-#      env: TYPO3_VERSION=^8.7
-#    - stage: test
-#      php: 7.1
-#      env: TYPO3_VERSION="dev-master as 8.7.7"
-#    - stage: test
-#      php: 7.0
-#      env: TYPO3_VERSION="dev-master as 8.7.7"
-#
-#    - stage: test
-#      php: 7.1
-#      env: Consistency checks
-#      before_install: skip
-#      install: skip
-#      before_script: skip
-#      script:
-#        - >
-#          if [ -n "$TRAVIS_TAG" ]; then
-#            composer set-version $TRAVIS_TAG
-#            test -z "$(git diff --shortstat 2> /dev/null | tail -n1)";
-#          fi
-#        - composer extension-create-libs && ls -la Libraries/*.phar | grep -v ^-rwx
-#        - git clean -dffx
-#
-#    - stage: test
-#      env: Sonar code scanner
-#      before_install: skip
-#      install: skip
-#      before_script:
-#      script:
-#        - >
-#          if [ -n "$SONAR_TOKEN" ]; then
-#            sonar-scanner
-#          fi
-#
-#    - stage: publish in ter
-#      php: 7.1
-#      before_install: skip
-#      install: skip
-#      before_script: skip
-#      script:
-#        - |
-#          if [ -n "$TRAVIS_TAG" ] && [ -n "$TYPO3_ORG_USERNAME" ] && [ -n "$TYPO3_ORG_PASSWORD" ]; then
-#            echo -e "Preparing upload of release ${TRAVIS_TAG} to TER\n";
-#            # Install requirements
-#            composer require --dev typo3/cms ^8.7
-#            composer require --dev helhum/ter-client dev-master
-#            # Cleanup before we upload
-#            git reset --hard HEAD && git clean -fx
-#
-#            # Build extension files
-#            composer extension-release
-#
-#            # Upload
-#            TAG_MESSAGE=`git tag -n10 -l $TRAVIS_TAG | sed 's/^[0-9.]*[ ]*//g'`
-#            echo "Uploading release ${TRAVIS_TAG} to TER"
-#            .Build/bin/ter-client upload typo3_console . -u "$TYPO3_ORG_USERNAME" -p "$TYPO3_ORG_PASSWORD" -m "$TAG_MESSAGE"
-#          fi;
+    - stage: test
+      php: 7.1
+      env: TYPO3_VERSION=^8.7
+    - stage: test
+      php: 7.0
+      env: TYPO3_VERSION=^8.7
+    - stage: test
+      php: 7.1
+      env: TYPO3_VERSION="dev-master as 8.7.7"
+    - stage: test
+      php: 7.0
+      env: TYPO3_VERSION="dev-master as 8.7.7"
+
+    - stage: test
+      php: 7.1
+      env: Consistency checks
+      before_install: skip
+      install: skip
+      before_script: skip
+      script:
+        - >
+          if [ -n "$TRAVIS_TAG" ]; then
+            composer set-version $TRAVIS_TAG
+            test -z "$(git diff --shortstat 2> /dev/null | tail -n1)";
+          fi
+        - composer extension-create-libs && ls -la Libraries/*.phar | grep -v ^-rwx
+        - git clean -dffx
+
+    - stage: test
+      env: Sonar code scanner
+      before_install: skip
+      install: skip
+      before_script:
+      script:
+        - >
+          if [ -n "$SONAR_TOKEN" ]; then
+            sonar-scanner
+          fi
+
+    - stage: publish in ter
+      php: 7.1
+      before_install: skip
+      install: skip
+      before_script: skip
+      script:
+        - |
+          if [ -n "$TRAVIS_TAG" ] && [ -n "$TYPO3_ORG_USERNAME" ] && [ -n "$TYPO3_ORG_PASSWORD" ]; then
+            echo -e "Preparing upload of release ${TRAVIS_TAG} to TER\n";
+            # Install requirements
+            composer require --dev typo3/cms ^8.7
+            composer require --dev helhum/ter-client dev-master
+            # Cleanup before we upload
+            git reset --hard HEAD && git clean -fx
+
+            # Build extension files
+            composer extension-release
+
+            # Upload
+            TAG_MESSAGE=`git tag -n10 -l $TRAVIS_TAG | sed 's/^[0-9.]*[ ]*//g'`
+            echo "Uploading release ${TRAVIS_TAG} to TER"
+            .Build/bin/ter-client upload typo3_console . -u "$TYPO3_ORG_USERNAME" -p "$TYPO3_ORG_PASSWORD" -m "$TAG_MESSAGE"
+          fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 sudo: required
 addons:
-  apt:
-    packages:
-      - parallel
   sonarcloud:
     organization: "helhum-github"
     branches:
@@ -60,7 +57,7 @@ jobs:
       install: skip
       before_script: skip
       script:
-        - find . -name \*.php ! -path "./.Build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;;
+        - errors=$(find . -name \*.php ! -path "./.Build/*" -exec php -d display_errors=stderr -l {} 2>&1 >/dev/null \;) && echo "$errors" && test -z "$errors"
     - <<: *lint
       php: 7.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,68 +58,70 @@ jobs:
       before_script: skip
       script:
         - errors=$(find . -name \*.php ! -path "./.Build/*" -exec php -d display_errors=stderr -l {} 2>&1 >/dev/null \;) && echo "$errors" && test -z "$errors"
+#    - <<: *lint
+#      php: 7.0
     - <<: *lint
-      php: 7.0
+      php: 5.5
 
-    - stage: test
-      php: 7.1
-      env: TYPO3_VERSION=^8.7
-    - stage: test
-      php: 7.0
-      env: TYPO3_VERSION=^8.7
-    - stage: test
-      php: 7.1
-      env: TYPO3_VERSION="dev-master as 8.7.7"
-    - stage: test
-      php: 7.0
-      env: TYPO3_VERSION="dev-master as 8.7.7"
-
-    - stage: test
-      php: 7.1
-      env: Consistency checks
-      before_install: skip
-      install: skip
-      before_script: skip
-      script:
-        - >
-          if [ -n "$TRAVIS_TAG" ]; then
-            composer set-version $TRAVIS_TAG
-            test -z "$(git diff --shortstat 2> /dev/null | tail -n1)";
-          fi
-        - composer extension-create-libs && ls -la Libraries/*.phar | grep -v ^-rwx
-        - git clean -dffx
-
-    - stage: test
-      env: Sonar code scanner
-      before_install: skip
-      install: skip
-      before_script:
-      script:
-        - >
-          if [ -n "$SONAR_TOKEN" ]; then
-            sonar-scanner
-          fi
-
-    - stage: publish in ter
-      php: 7.1
-      before_install: skip
-      install: skip
-      before_script: skip
-      script:
-        - |
-          if [ -n "$TRAVIS_TAG" ] && [ -n "$TYPO3_ORG_USERNAME" ] && [ -n "$TYPO3_ORG_PASSWORD" ]; then
-            echo -e "Preparing upload of release ${TRAVIS_TAG} to TER\n";
-            # Install requirements
-            composer require --dev typo3/cms ^8.7
-            composer require --dev helhum/ter-client dev-master
-            # Cleanup before we upload
-            git reset --hard HEAD && git clean -fx
-
-            # Build extension files
-            composer extension-release
-
-            # Upload
-            TAG_MESSAGE=`git tag -n10 -l $TRAVIS_TAG | sed 's/^[0-9.]*[ ]*//g'`
-            echo "Uploading release ${TRAVIS_TAG} to TER"
-            .Build/bin/ter-client upload typo3_console . -u "$TYPO3_ORG_USERNAME" -p "$TYPO3_ORG_PASSWORD" -m "$TAG_MESSAGE"
-          fi;
+#    - stage: test
+#      php: 7.1
+#      env: TYPO3_VERSION=^8.7
+#    - stage: test
+#      php: 7.0
+#      env: TYPO3_VERSION=^8.7
+#    - stage: test
+#      php: 7.1
+#      env: TYPO3_VERSION="dev-master as 8.7.7"
+#    - stage: test
+#      php: 7.0
+#      env: TYPO3_VERSION="dev-master as 8.7.7"
+#
+#    - stage: test
+#      php: 7.1
+#      env: Consistency checks
+#      before_install: skip
+#      install: skip
+#      before_script: skip
+#      script:
+#        - >
+#          if [ -n "$TRAVIS_TAG" ]; then
+#            composer set-version $TRAVIS_TAG
+#            test -z "$(git diff --shortstat 2> /dev/null | tail -n1)";
+#          fi
+#        - composer extension-create-libs && ls -la Libraries/*.phar | grep -v ^-rwx
+#        - git clean -dffx
+#
+#    - stage: test
+#      env: Sonar code scanner
+#      before_install: skip
+#      install: skip
+#      before_script:
+#      script:
+#        - >
+#          if [ -n "$SONAR_TOKEN" ]; then
+#            sonar-scanner
+#          fi
+#
+#    - stage: publish in ter
+#      php: 7.1
+#      before_install: skip
+#      install: skip
+#      before_script: skip
+#      script:
+#        - |
+#          if [ -n "$TRAVIS_TAG" ] && [ -n "$TYPO3_ORG_USERNAME" ] && [ -n "$TYPO3_ORG_PASSWORD" ]; then
+#            echo -e "Preparing upload of release ${TRAVIS_TAG} to TER\n";
+#            # Install requirements
+#            composer require --dev typo3/cms ^8.7
+#            composer require --dev helhum/ter-client dev-master
+#            # Cleanup before we upload
+#            git reset --hard HEAD && git clean -fx
+#
+#            # Build extension files
+#            composer extension-release
+#
+#            # Upload
+#            TAG_MESSAGE=`git tag -n10 -l $TRAVIS_TAG | sed 's/^[0-9.]*[ ]*//g'`
+#            echo "Uploading release ${TRAVIS_TAG} to TER"
+#            .Build/bin/ter-client upload typo3_console . -u "$TYPO3_ORG_USERNAME" -p "$TYPO3_ORG_PASSWORD" -m "$TAG_MESSAGE"
+#          fi;


### PR DESCRIPTION
We currently only use "parallel" for php linting,
which is fast enough without parallel execution.

By not installing "parallel" setting up the build
machines is slightly faster.