### PR TITLE
Allows you to create backend users from cli

### DIFF
--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -25,6 +25,29 @@ Extension *typo3_console*
 -------------------------
 
 
+.. _`Command Reference: typo3_console backend:createadmin`:
+
+``backend:createadmin``
+***********************
+
+**Create admin backend user**
+
+Create a new user with administrative access.
+
+Arguments
+^^^^^^^^^
+
+``--username``
+  Username of the user
+``--password``
+  Password of the user
+
+
+
+
+
+
+
 .. _`Command Reference: typo3_console backend:lock`:
 
 ``backend:lock``


### PR DESCRIPTION
I've created a suggestion on how to do the "create user", but I'm not fully happy due to duplicate code from the core.

The adjustments made are more or less copy/paste from the core from the InstallTool Important Actions.

typo3/sysext/install/Classes/Controller/Action/Tool/ImportantActions.php Line: 157-211 
typo3/sysext/install/Classes/Controller/Action/AbstractAction.php Line: 203-213

I haven't find a better way to do this, but duplicate code is really not prefered. 

If you have any suggestions I will be happy to adjust the code.


