### PR TITLE
[BUGFIX] Gracefully exit when flushing file caches in pre-install state

### DIFF
--- a/Classes/Command/CacheCommandController.php
+++ b/Classes/Command/CacheCommandController.php
@@ -14,6 +14,7 @@ namespace Helhum\Typo3Console\Command;
  */
 
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
+use Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException;
 use Helhum\Typo3Console\Mvc\Controller\CommandController;
 use Helhum\Typo3Console\Service\CacheService;
 use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheGroupException;
@@ -50,17 +51,26 @@ class CacheCommandController extends CommandController
      *
      * @param bool $force Cache is forcibly flushed (low level operations are performed)
      * @param bool $filesOnly Only file caches are flushed
-     * @throws \Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException
+     * @throws FailedSubProcessCommandException
      */
     public function flushCommand($force = false, $filesOnly = false)
     {
         $exitCode = 0;
-        if (!$this->applicationIsFullyCapable()) {
+        $isApplicationFullyCapable = $this->isApplicationFullyCapable();
+        if (!$isApplicationFullyCapable) {
             $filesOnly = true;
         }
         if ($filesOnly) {
             $this->cacheService->flushFileCaches($force);
-            $this->commandDispatcher->executeCommand('cache:flushcomplete', ['--files-only' => true]);
+            try {
+                $this->commandDispatcher->executeCommand('cache:flushcomplete', ['--files-only' => true]);
+            } catch (FailedSubProcessCommandException $e) {
+                if ($isApplicationFullyCapable) {
+                    throw $e;
+                }
+                $this->output->getSymfonyConsoleOutput()->getErrorOutput()->writeln('<warning>Could not load extension configuration.</warning>');
+                $this->output->getSymfonyConsoleOutput()->getErrorOutput()->writeln('<warning>Some caches might not have been flushed.</warning>');
+            }
         } else {
             $this->cacheService->flush($force);
             $this->commandDispatcher->executeCommand('cache:flushcomplete');
@@ -76,7 +86,7 @@ class CacheCommandController extends CommandController
      * @return bool
      * @deprecated can be removed once this is converted into a native Symfony command. We can use the Application API then.
      */
-    private function applicationIsFullyCapable(): bool
+    private function isApplicationFullyCapable()
     {
         return file_exists(PATH_site . 'typo3conf/PackageStates.php') && file_exists(PATH_site . 'typo3conf/LocalConfiguration.php');
     }

--- a/Classes/Command/CacheCommandController.php
+++ b/Classes/Command/CacheCommandController.php
@@ -55,33 +55,30 @@ class CacheCommandController extends CommandController
     public function flushCommand($force = false, $filesOnly = false)
     {
         $exitCode = 0;
-        if (!$filesOnly) {
-            try {
-                $this->cacheService->flush($force);
-                $this->commandDispatcher->executeCommand('cache:flushcomplete');
-            } catch (\Throwable $e) {
-                $exitCode = 1;
-                $filesOnly = true;
-            } catch (\Exception $e) {
-                // @deprecated can be removed once PHP 5 / TYPO3 7.6 support is removed
-                $exitCode = 1;
-                $filesOnly = true;
-            }
+        if (!$this->applicationIsFullyCapable()) {
+            $filesOnly = true;
         }
         if ($filesOnly) {
             $this->cacheService->flushFileCaches($force);
             $this->commandDispatcher->executeCommand('cache:flushcomplete', ['--files-only' => true]);
-        }
-
-        if (isset($e)) {
-            $this->outputLine('<error>Flushing caches failed with error:</error>');
-            $this->outputLine('<error>"%s"</error>', [$e->getMessage()]);
-            $this->outputLine('<warning>Falling back to flushing file caches only.</warning>');
-            $this->outputLine('<warning>Use "--files-only" option to get rid of this warning"</warning>');
+        } else {
+            $this->cacheService->flush($force);
+            $this->commandDispatcher->executeCommand('cache:flushcomplete');
         }
 
         $this->outputLine('%slushed all %scaches.', [$force ? 'Force f' : 'F', $filesOnly ? 'file ' : '']);
         $this->quit($exitCode);
+    }
+
+    /**
+     * Check if we have all mandatory files to assume we have a fully configured / installed TYPO3
+     *
+     * @return bool
+     * @deprecated can be removed once this is converted into a native Symfony command. We can use the Application API then.
+     */
+    private function applicationIsFullyCapable(): bool
+    {
+        return file_exists(PATH_site . 'typo3conf/PackageStates.php') && file_exists(PATH_site . 'typo3conf/LocalConfiguration.php');
     }
 
     /**

--- a/Tests/Functional/Command/CacheCommandControllerTest.php
+++ b/Tests/Functional/Command/CacheCommandControllerTest.php
@@ -29,6 +29,42 @@ class CacheCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
+    public function cacheCanBeFlushedWhenNotSetUp()
+    {
+        $packageStatesFile = getenv('TYPO3_PATH_ROOT') . '/typo3conf/PackageStates.php';
+        $localConfFile = getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php';
+        rename($packageStatesFile, $packageStatesFile . '_');
+        rename($localConfFile, $localConfFile . '_');
+        try {
+            $output = $this->executeConsoleCommand('cache:flush');
+            $this->assertSame('Flushed all file caches.', $output);
+        } finally {
+            rename($packageStatesFile . '_', $packageStatesFile);
+            rename($localConfFile . '_', $localConfFile);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function cacheCanBeFlushedAsFilesOnlyWhenNotSetUp()
+    {
+        $packageStatesFile = getenv('TYPO3_PATH_ROOT') . '/typo3conf/PackageStates.php';
+        $localConfFile = getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php';
+        rename($packageStatesFile, $packageStatesFile . '_');
+        rename($localConfFile, $localConfFile . '_');
+        try {
+            $output = $this->executeConsoleCommand('cache:flush', ['--files-only' => true]);
+            $this->assertSame('Flushed all file caches.', $output);
+        } finally {
+            rename($packageStatesFile . '_', $packageStatesFile);
+            rename($localConfFile . '_', $localConfFile);
+        }
+    }
+
+    /**
+     * @test
+     */
     public function cacheCanBeForceFlushedFlushed()
     {
         $output = $this->executeConsoleCommand('cache:flush', ['--force' => true]);


### PR DESCRIPTION
To flush caches, we need to know which caches exist.
In TYPO3 extensions can provide their own caches in ext_localconf.php
So we need to load these files to be able to flush all caches.

However two introduced changes in TYPO3 hinder us to do so.

1. Exceptions are thrown when extension configuration does not exist.
The new extension configuration API in TYPO3 9.0 throws exceptions
and is used in ext_localconf.php files in core extensions.
Therefore it is never possible to load these files without having
a LocalConfiguration.php present, which contains such configuration.

2. Loading TCA now requires a database connection
Since we also load TCA in the same booting step with including
ext_localconf.php files, flushing caches will always fail,
when no database connection is configured (no LocalConfiguration.php present)

Therefore we now gracefully exit when flushing file caches fails
with no LocalConfiguration.php present.