### PR TITLE
[BUGFIX] Do not initialize TCA without DB connection

### DIFF
--- a/Classes/Core/Booting/RunLevel.php
+++ b/Classes/Core/Booting/RunLevel.php
@@ -221,6 +221,7 @@ class RunLevel
         $this->addStep($sequence, 'helhum.typo3console:database');
         // Fix core caches that were disabled beforehand
         $this->addStep($sequence, 'helhum.typo3console:enablecorecaches');
+        $this->addStep($sequence, 'helhum.typo3console:persistence');
         $this->addStep($sequence, 'helhum.typo3console:authentication');
 
         return $sequence;
@@ -273,6 +274,9 @@ class RunLevel
             // @deprecated can be removed if TYPO3 8 support is removed
             case 'helhum.typo3console:database':
                 $sequence->addStep(new Step('helhum.typo3console:database', [CompatibilityScripts::class, 'initializeDatabaseConnection']), 'helhum.typo3console:errorhandling');
+                break;
+            case 'helhum.typo3console:persistence':
+                $sequence->addStep(new Step('helhum.typo3console:persistence', [Scripts::class, 'initializePersistence']), 'helhum.typo3console:extensionconfiguration');
                 break;
             case 'helhum.typo3console:authentication':
                 $sequence->addStep(new Step('helhum.typo3console:authentication', [Scripts::class, 'initializeAuthenticatedOperations']), 'helhum.typo3console:extensionconfiguration');

--- a/Classes/Core/Booting/Scripts.php
+++ b/Classes/Core/Booting/Scripts.php
@@ -167,6 +167,13 @@ class Scripts
         ExtensionManagementUtility::loadExtLocalconf();
         $bootstrap->setFinalCachingFrameworkCacheConfiguration();
         $bootstrap->unsetReservedGlobalVariables();
+    }
+
+    /**
+     * @param Bootstrap $bootstrap
+     */
+    public static function initializePersistence(Bootstrap $bootstrap)
+    {
         ExtensionManagementUtility::loadBaseTca();
     }
 

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -30,10 +30,10 @@ return [
         'typo3_console:upgrade:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
     ],
     'bootingSteps' => [
-        // @deprecated Step can be removed once TYPO3 8 support is removed
-        'typo3_console:install:databasedata' => ['helhum.typo3console:database'],
-        'typo3_console:install:defaultconfiguration' => ['helhum.typo3console:database'],
-        'typo3_console:database:updateschema' => ['helhum.typo3console:database'],
+        // @deprecated database step can be removed once TYPO3 8 support is removed
+        'typo3_console:install:databasedata' => ['helhum.typo3console:database', 'helhum.typo3console:persistence'],
+        'typo3_console:install:defaultconfiguration' => ['helhum.typo3console:database', 'helhum.typo3console:persistence'],
+        'typo3_console:database:updateschema' => ['helhum.typo3console:database', 'helhum.typo3console:persistence'],
     ],
     'replace' => [
         'extbase',


### PR DESCRIPTION
Since TYPO3 introduced the requirement to have a DB
connection when generating TCA caches, we cannot initialize

TCA early in the bootstrap, but must postpone it to a later stage
when we can be sure a database connection can be established.