### PR TITLE
[BUGFIX] Initialize TCA in cache service

### DIFF
--- a/Classes/Service/CacheService.php
+++ b/Classes/Service/CacheService.php
@@ -212,6 +212,7 @@ class CacheService implements SingletonInterface
             // Already initialized
             return;
         }
+        Scripts::initializePersistence($this->bootstrap);
         Scripts::initializeAuthenticatedOperations($this->bootstrap);
     }
 


### PR DESCRIPTION
Before loading ext_tables.php of extensions, we need
to make sure TCA is loaded.