### PR TITLE
[TASK] Bring back and deprecate extension:(de)activate commands

### DIFF
--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -116,14 +116,19 @@ class InstallCommandController extends CommandController
      * <b>Example:</b> <code>%command.full_name% install:generatepackagestates</code>
      *
      * @param array $frameworkExtensions TYPO3 system extensions that should be marked as active. Extension keys separated by comma.
-     * @param bool $activateDefault If true, <code>typo3/cms</code> extensions that are marked as TYPO3 factory default, will be activated, even if not in the list of configured active framework extensions.
      * @param array $excludedExtensions Extensions which should stay inactive. This does not affect provided framework extensions or framework extensions that are required or part as minimal usable system.
+     * @param bool $activateDefault (DEPRECATED) If true, <code>typo3/cms</code> extensions that are marked as TYPO3 factory default, will be activated, even if not in the list of configured active framework extensions.
      */
-    public function generatePackageStatesCommand(array $frameworkExtensions = [], $activateDefault = false, array $excludedExtensions = [])
+    public function generatePackageStatesCommand(array $frameworkExtensions = [], array $excludedExtensions = [], $activateDefault = false)
     {
+        if ($activateDefault && Bootstrap::usesComposerClassLoading()) {
+            // @deprecated for composer usage in 5.0 will be removed with 6.0
+            $this->outputLine('<warning>Using --activate-default is deprecated in composer managed TYPO3 installations.</warning>');
+            $this->outputLine('<warning>Instead of requiring typo3/cms in your project, you should consider only requiring individual packages you need.</warning>');
+        }
         $frameworkExtensions = $frameworkExtensions ?: explode(',', (string)getenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS'));
         $packageStatesGenerator = new PackageStatesGenerator($this->packageManager);
-        $activatedExtensions = $packageStatesGenerator->generate($frameworkExtensions, $activateDefault, $excludedExtensions);
+        $activatedExtensions = $packageStatesGenerator->generate($frameworkExtensions, $excludedExtensions, $activateDefault);
 
         try {
             // Make sure file caches are empty after generating package states file

--- a/Classes/Install/PackageStatesGenerator.php
+++ b/Classes/Install/PackageStatesGenerator.php
@@ -40,11 +40,11 @@ class PackageStatesGenerator
 
     /**
      * @param array $frameworkExtensionsToActivate
-     * @param bool $activateDefaultExtensions
      * @param array $excludedExtensions
+     * @param bool $activateDefaultExtensions
      * @return PackageInterface[]
      */
-    public function generate(array $frameworkExtensionsToActivate = [], $activateDefaultExtensions = false, array $excludedExtensions = [])
+    public function generate(array $frameworkExtensionsToActivate = [], array $excludedExtensions = [], $activateDefaultExtensions = false)
     {
         $this->ensureDirectoryExists(PATH_site . 'typo3conf');
         $this->packageManager->scanAvailablePackages();

--- a/Classes/Mvc/Cli/CommandDispatcher.php
+++ b/Classes/Mvc/Cli/CommandDispatcher.php
@@ -14,6 +14,7 @@ namespace Helhum\Typo3Console\Mvc\Cli;
  */
 
 use Composer\Script\Event as ScriptEvent;
+use Helhum\Typo3Console\Mvc\Cli\Symfony\Application;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\ProcessBuilder;
@@ -54,10 +55,10 @@ class CommandDispatcher
      */
     public static function createFromComposerRun(ScriptEvent $event, ProcessBuilder $processBuilder = null, PhpExecutableFinder $phpFinder = null)
     {
-        $name = 'typo3cms';
+        $name = Application::COMMAND_NAME;
         $searchDirs = [
             $event->getComposer()->getConfig()->get('bin-dir'),
-            dirname(dirname(dirname(__DIR__))) . '/Scripts',
+            dirname(__DIR__, 3),
         ];
         foreach ($searchDirs as $dir) {
             $file = $dir . DIRECTORY_SEPARATOR . $name;
@@ -67,7 +68,7 @@ class CommandDispatcher
             }
         }
         if (!isset($typo3CommandPath)) {
-            throw new RuntimeException('The "typo3cms" binary could not be found.', 1494778973);
+            throw new RuntimeException(sprintf('The "%s" binary could not be found.', Application::COMMAND_NAME), 1494778973);
         }
         $processBuilder = $processBuilder ?: new ProcessBuilder();
         $processBuilder->addEnvironmentVariables(['TYPO3_CONSOLE_PLUGIN_RUN' => true]);
@@ -87,7 +88,7 @@ class CommandDispatcher
      */
     public static function createFromCommandRun(ProcessBuilder $processBuilder = null, PhpExecutableFinder $phpFinder = null)
     {
-        if (!isset($_SERVER['argv'][0]) && strpos($_SERVER['argv'][0], 'typo3cms') === false) {
+        if (!isset($_SERVER['argv'][0]) && strpos($_SERVER['argv'][0], Application::COMMAND_NAME) === false) {
             throw new RuntimeException('Tried to create typo3 command runner from wrong context', 1484945065);
         }
         $typo3CommandPath = $_SERVER['argv'][0];
@@ -106,16 +107,16 @@ class CommandDispatcher
     public static function createFromTestRun($typo3CommandPath = null)
     {
         if (!isset($_SERVER['argv'][0]) && strpos($_SERVER['argv'][0], 'phpunit') === false) {
-            throw new RuntimeException('Tried to create typo3cms command runner from wrong context', 1493570522);
+            throw new RuntimeException(sprintf('Tried to create %s command runner from wrong context', Application::COMMAND_NAME), 1493570522);
         }
-        $typo3CommandPath = $typo3CommandPath ?: dirname(dirname(dirname(__DIR__))) . '/typo3cms';
+        $typo3CommandPath = $typo3CommandPath ?: dirname(__DIR__, 3) . '/' . Application::COMMAND_NAME;
         return self::create($typo3CommandPath);
     }
 
     /**
-     * Basic factory method, which need the exact path to the typo3cms binary to create the dispatcher
+     * Basic factory method, which need the exact path to the typo3 console binary to create the dispatcher
      *
-     * @param string $typo3CommandPath Absolute path to the typo3cms binary
+     * @param string $typo3CommandPath Absolute path to the typo3 console binary
      * @param ProcessBuilder $processBuilder
      * @param PhpExecutableFinder $phpFinder
      * @throws RuntimeException

--- a/Classes/Mvc/Cli/ConsoleOutput.php
+++ b/Classes/Mvc/Cli/ConsoleOutput.php
@@ -28,6 +28,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Terminal;
 
 /**
  * A wrapper for Symfony ConsoleOutput and related helpers
@@ -60,6 +61,11 @@ class ConsoleOutput
     protected $table;
 
     /**
+     * @var Terminal
+     */
+    private $terminal;
+
+    /**
      * Creates and initializes the Symfony I/O instances
      *
      * @param Output|null $output
@@ -79,6 +85,7 @@ class ConsoleOutput
         $this->output->getFormatter()->setStyle('del', new OutputFormatterStyle('red'));
         $this->output->getFormatter()->setStyle('code', new OutputFormatterStyle(null, null, ['bold']));
         $this->input = $input;
+        $this->terminal = new Terminal();
     }
 
     /**
@@ -96,7 +103,7 @@ class ConsoleOutput
      */
     public function getMaximumLineLength()
     {
-        return 79;
+        return $this->terminal->getWidth() - 2;
     }
 
     /**

--- a/Classes/Mvc/Cli/Symfony/Application.php
+++ b/Classes/Mvc/Cli/Symfony/Application.php
@@ -32,6 +32,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Application extends BaseApplication
 {
     const TYPO3_CONSOLE_VERSION = '5.0.0';
+    const COMMAND_NAME = 'typo3cms';
 
     /**
      * @var RunLevel

--- a/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
+++ b/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
@@ -68,12 +68,7 @@ class CommandControllerCommand extends Command
     public function isEnabled(): bool
     {
         if ($this->application->isComposerManaged()
-            && in_array($this->getName(), [
-                // Remove commands than don't make sense when application is composer managed
-                'extension:dumpautoload',
-                'extension:activate',
-                'extension:deactivate',
-            ], true)
+            && $this->getName() === 'extension:dumpautoload'
         ) {
             return false;
         }
@@ -152,6 +147,15 @@ class CommandControllerCommand extends Command
 
     public function isHidden(): bool
     {
+        if ($this->application->isComposerManaged()
+            && in_array($this->getName(), [
+                // Hide commands than don't make sense when application is composer managed, but should still work for a while
+                'extension:activate',
+                'extension:deactivate',
+            ], true)
+        ) {
+            return true;
+        }
         return $this->commandDefinition->isInternal();
     }
 }

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -856,10 +856,10 @@ Options
 
 ``--framework-extensions``
   TYPO3 system extensions that should be marked as active. Extension keys separated by comma.
-``--activate-default``
-  If true, ``typo3/cms`` extensions that are marked as TYPO3 factory default, will be activated, even if not in the list of configured active framework extensions.
 ``--excluded-extensions``
   Extensions which should stay inactive. This does not affect provided framework extensions or framework extensions that are required or part as minimal usable system.
+``--activate-default``
+  (DEPRECATED) If true, ``typo3/cms`` extensions that are marked as TYPO3 factory default, will be activated, even if not in the list of configured active framework extensions.
 
 
 

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -542,7 +542,7 @@ Options
 Activates one or more extensions by key.
 Marks extensions as active, sets them up and clears caches for every activated extension.
 
-This command is only available in non composer mode.
+This command is deprecated (and hidden) in Composer mode.
 
 Arguments
 ^^^^^^^^^
@@ -572,7 +572,7 @@ Options
 Deactivates one or more extensions by key.
 Marks extensions as inactive in the system and clears caches for every deactivated extension.
 
-This command is only available in non composer mode.
+This command is deprecated (and hidden) in Composer mode.
 
 Arguments
 ^^^^^^^^^

--- a/Resources/Private/ExtensionArtifacts/src/Hook/ExtensionInstallation.php
+++ b/Resources/Private/ExtensionArtifacts/src/Hook/ExtensionInstallation.php
@@ -13,6 +13,7 @@ namespace Helhum\Typo3Console\Hook;
  *
  */
 
+use Helhum\Typo3Console\Mvc\Cli\Symfony\Application;
 use TYPO3\CMS\Core\Database\DatabaseConnection;
 use TYPO3\CMS\Core\Messaging\AbstractMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -39,7 +40,7 @@ class ExtensionInstallation
         if (self::EXTKEY !== $keyOfInstalledExtension) {
             return;
         }
-        $scriptName = $this->isWindowsOs() ? 'Scripts/typo3cms.bat' : 'typo3cms';
+        $scriptName = $this->isWindowsOs() ? 'Scripts/' . Application::COMMAND_NAME . '.bat' : Application::COMMAND_NAME;
         $success = $this->safeCopy(PATH_site . self::BINARY_PATH . $scriptName, PATH_site . basename($scriptName));
         if (!$success) {
             self::addFlashMessage(sprintf(self::COPY_FAILED_MESSAGE, $scriptName), sprintf(self::COPY_FAILED_MESSAGE_TITLE, $scriptName, PATH_site), AbstractMessage::WARNING);
@@ -78,7 +79,7 @@ class ExtensionInstallation
     }
 
     /**
-     * Copy typo3cms command to root directory taking several possible situations into account
+     * Copy typo3 console binary to root directory taking several possible situations into account
      *
      * @param string $fullSourcePath Path to the script that should be copied (depending on OS)
      * @param string $fullTargetPath Target path to which the script should be copied to
@@ -105,7 +106,7 @@ class ExtensionInstallation
             $proxyFileContent = str_replace(
                 'require __DIR__ . \'/Scripts/typo3-console.php\';',
                 '// In non Composer mode we\'re copied into TYPO3 web root
-    require __DIR__ . \'/typo3conf/ext/typo3_console/Scripts/typo3-console.php\';',
+require __DIR__ . \'/typo3conf/ext/typo3_console/Scripts/typo3-console.php\';',
                 $proxyFileContent
             );
             $success = file_put_contents($fullTargetPath, $proxyFileContent);

--- a/Tests/Functional/Command/UpgradeCommandControllerTest.php
+++ b/Tests/Functional/Command/UpgradeCommandControllerTest.php
@@ -15,6 +15,7 @@ namespace Helhum\Typo3Console\Tests\Functional\Command;
 
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
 use Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException;
+use Helhum\Typo3Console\Mvc\Cli\Symfony\Application;
 
 class UpgradeCommandControllerTest extends AbstractCommandTest
 {
@@ -93,7 +94,7 @@ class UpgradeCommandControllerTest extends AbstractCommandTest
     {
         $this->consoleRootPath = getenv('TYPO3_PATH_COMPOSER_ROOT');
         $this->typo3RootPath = getenv('TYPO3_PATH_ROOT');
-        $this->commandDispatcher = CommandDispatcher::createFromTestRun($instancePath . '/vendor/helhum/typo3-console-test/typo3cms');
+        $this->commandDispatcher = CommandDispatcher::createFromTestRun($instancePath . '/vendor/helhum/typo3-console-test/' . Application::COMMAND_NAME);
         if (!is_dir($instancePath)) {
             mkdir($instancePath);
         }

--- a/Tests/Unit/Install/PackageStatesGeneratorTest.php
+++ b/Tests/Unit/Install/PackageStatesGeneratorTest.php
@@ -69,7 +69,7 @@ class PackageStatesGeneratorTest extends UnitTestCase
         $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
         $packageManagerProphecy->getActivePackages()->shouldBeCalled();
         $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
-        $packageStatesGenerator->generate([], false, ['foo']);
+        $packageStatesGenerator->generate([], ['foo'], false);
     }
 
     /**
@@ -149,7 +149,7 @@ class PackageStatesGeneratorTest extends UnitTestCase
         $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
         $packageManagerProphecy->getActivePackages()->shouldBeCalled();
         $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
-        $packageStatesGenerator->generate([], true);
+        $packageStatesGenerator->generate([], [], true);
     }
 
     /**
@@ -176,7 +176,7 @@ class PackageStatesGeneratorTest extends UnitTestCase
         $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
         $packageManagerProphecy->getActivePackages()->shouldBeCalled();
         $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
-        $packageStatesGenerator->generate([], true, ['foo']);
+        $packageStatesGenerator->generate([], ['foo'], true);
     }
 
     /**
@@ -228,7 +228,7 @@ class PackageStatesGeneratorTest extends UnitTestCase
         $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
         $packageManagerProphecy->getActivePackages()->shouldBeCalled();
         $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
-        $packageStatesGenerator->generate(['foo'], false, ['foo']);
+        $packageStatesGenerator->generate(['foo'], ['foo'], false);
     }
 
     /**
@@ -280,7 +280,7 @@ class PackageStatesGeneratorTest extends UnitTestCase
         $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
         $packageManagerProphecy->getActivePackages()->shouldBeCalled();
         $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
-        $packageStatesGenerator->generate(['foo'], false, ['foo']);
+        $packageStatesGenerator->generate(['foo'], ['foo'], false);
     }
 
     /**
@@ -332,6 +332,6 @@ class PackageStatesGeneratorTest extends UnitTestCase
         $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
         $packageManagerProphecy->getActivePackages()->shouldBeCalled();
         $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
-        $packageStatesGenerator->generate(['foo'], false, ['foo']);
+        $packageStatesGenerator->generate(['foo'], ['foo'], false);
     }
 }


### PR DESCRIPTION
Instead of removing them without deprecation, we deprecate them now,
so we can remove them with TYPO3 Console 6