### PR TITLE
[BUGFIX] Catch install step exceptions and output error

### DIFF
--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -146,7 +146,10 @@ class CliSetupRequestHandler
                 $this->output->outputLine('<info>No execution needed, skipped step!</info>');
                 return;
             }
-            $actionArguments = [];
+            $actionArguments = [
+                'arguments' => [],
+                'options' => [],
+            ];
             foreach ($command->getArgumentDefinitions() as $argumentDefinition) {
                 $isPasswordArgument = strpos($argumentDefinition->getOptionName(), 'password') !== false;
                 $isRequired = $argumentDefinition->isArgument();
@@ -191,9 +194,9 @@ class CliSetupRequestHandler
                     $this->setActionArgument($actionArguments, $argumentValue !== null ? $argumentValue : $argumentDefinition->getDefaultValue(), $argumentDefinition);
                 }
             }
-            $response = $this->executeActionWithArguments($actionName, $actionArguments);
+            $response = $this->executeActionWithArguments($actionName,  $actionArguments['arguments'], $actionArguments['options']);
             if ($this->checkIfActionNeedsExecution($actionName)->actionNeedsExecution()) {
-                $response = $this->executeActionWithArguments($actionName, $actionArguments);
+                $response = $this->executeActionWithArguments($actionName, $actionArguments['arguments'], $actionArguments['options']);
             }
             $messages = $response->getMessages();
             if (empty($messages)) {
@@ -224,11 +227,14 @@ class CliSetupRequestHandler
      *
      * @param string $actionName Name of the install step
      * @param array $arguments Arguments for the install step
+     * @param array $options Options for the install step
      * @return InstallStepResponse
      */
-    private function executeActionWithArguments($actionName, array $arguments = [])
+    private function executeActionWithArguments($actionName, array $arguments = [], array $options = [])
     {
         $actionName = strtolower($actionName);
+        // Arguments must come first then options, to avoid argument values to be passed to boolean flags
+        $arguments = array_merge($arguments, $options);
         $response = @unserialize($this->commandDispatcher->executeCommand('install:' . $actionName, $arguments));
         if ($response === false && $actionName === 'defaultconfiguration') {
             // This action terminates with exit, (trying to initiate a HTTP redirect)
@@ -241,14 +247,14 @@ class CliSetupRequestHandler
     private function setActionArgument(&$currentActionArguments, $value, CommandArgumentDefinition $argumentDefinition)
     {
         if ($argumentDefinition->isArgument()) {
-            $currentActionArguments[] = $value;
+            $currentActionArguments['arguments'][] = $value;
         } else {
             if ($argumentDefinition->acceptsValue()) {
-                $currentActionArguments[$argumentDefinition->getDashedName()] = $value;
+                $currentActionArguments['options'][$argumentDefinition->getDashedName()] = $value;
             } else {
                 $value = (bool)$value;
                 if ($value) {
-                    $currentActionArguments[] = $argumentDefinition->getDashedName();
+                    $currentActionArguments['options'][] = $argumentDefinition->getDashedName();
                 }
             }
         }

--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -194,7 +194,7 @@ class CliSetupRequestHandler
                     $this->setActionArgument($actionArguments, $argumentValue !== null ? $argumentValue : $argumentDefinition->getDefaultValue(), $argumentDefinition);
                 }
             }
-            $response = $this->executeActionWithArguments($actionName,  $actionArguments['arguments'], $actionArguments['options']);
+            $response = $this->executeActionWithArguments($actionName, $actionArguments['arguments'], $actionArguments['options']);
             if ($this->checkIfActionNeedsExecution($actionName)->actionNeedsExecution()) {
                 $response = $this->executeActionWithArguments($actionName, $actionArguments['arguments'], $actionArguments['options']);
             }

--- a/Classes/Mvc/Cli/CommandDispatcher.php
+++ b/Classes/Mvc/Cli/CommandDispatcher.php
@@ -139,7 +139,7 @@ class CommandDispatcher
      * Execute a command in a sub process
      *
      * @param string $command Command identifier
-     * @param array $arguments Argument names will automatically be converted to dashed version, fi not provided like so
+     * @param array $arguments Argument names will automatically be converted to dashed version, if not provided like so
      * @param array $environment Environment vars to be added to the command
      * @param resource|string|\Traversable|null $input Inpupt (stdin) for the command
      * @throws FailedSubProcessCommandException
@@ -168,20 +168,13 @@ class CommandDispatcher
             if (is_array($argumentValue)) {
                 $argumentValue = implode(',', $argumentValue);
             }
-            if (strpos($argumentValue, '=') !== false) {
-                // Big WTF in argument parsing here
-                // If the value contains a = we need to separate the name and value with a = ourselves
-                // to get the parser to correctly read our value
-                $processBuilder->add($dashedName . '=' . $argumentValue);
-            } else {
-                $processBuilder->add($dashedName);
-                if ($argumentValue !== null) {
-                    if ($argumentValue === false) {
-                        // Convert boolean false to 'false' instead of empty string to correctly pass the value to the sub command
-                        $processBuilder->add('false');
-                    } else {
-                        $processBuilder->add($argumentValue);
-                    }
+            $processBuilder->add($dashedName);
+            if ($argumentValue !== null) {
+                if ($argumentValue === false) {
+                    // Convert boolean false to 'false' instead of empty string to correctly pass the value to the sub command
+                    $processBuilder->add('false');
+                } else {
+                    $processBuilder->add($argumentValue);
                 }
             }
         }

--- a/Compatibility/TYPO3v87/Install/InstallStepActionExecutor.php
+++ b/Compatibility/TYPO3v87/Install/InstallStepActionExecutor.php
@@ -19,6 +19,7 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Install\Controller\Action\ActionInterface;
 use TYPO3\CMS\Install\Controller\Action\Step\StepInterface;
 use TYPO3\CMS\Install\Controller\Exception\RedirectException;
+use TYPO3\CMS\Install\Status\ErrorStatus;
 
 /**
  * This class is responsible for properly creating install tool step actions
@@ -93,7 +94,15 @@ class InstallStepActionExecutor
             return new InstallStepResponse(true, $messages, true);
         }
         if ($needsExecution && !$dryRun) {
-            $messages = $action->execute();
+            try {
+                $messages = $action->execute();
+            } catch (\Throwable $e) {
+                $errorMessage = new ErrorStatus();
+                $errorMessage->setMessage($e->getMessage());
+                $messages = [
+                    $errorMessage,
+                ];
+            }
             $this->silentConfigurationUpgrade->executeSilentConfigurationUpgradesIfNeeded();
             $needsExecution = false;
         }


### PR DESCRIPTION
Instead of letting the installer fail, we catch exceptions
that can occur when executing an install step and output
the exception message as error message.

Fixes: #621