### PR TITLE
[!!!][FEATURE] Do not lock tables when dumping sql in database:export

### DIFF
--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -176,6 +176,9 @@ class DatabaseCommandController extends CommandController
             $additionalArguments[] = sprintf('--ignore-table=%s.%s', $dbConfig['dbname'], $table);
         }
 
+        $additionalArguments[] = '--single-transaction';
+        $additionalArguments[] = '--quick';
+
         $mysqlCommand = new MysqlCommand(
             $dbConfig,
             new ProcessBuilder()

--- a/Tests/Functional/Command/DatabaseCommandControllerTest.php
+++ b/Tests/Functional/Command/DatabaseCommandControllerTest.php
@@ -113,19 +113,11 @@ class DatabaseCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
-    public function databaseCanBeExportedAndImported()
+    public function sqlCanBeImported()
     {
-        $this->markTestSkipped('TODO: find out why the input is not correctly passed to stdin');
-        $this->backupDatabase();
-        $sqlDump = $this->executeConsoleCommand('database:export');
-        $this->executeMysqlQuery('DROP DATABASE ' . getenv('TYPO3_INSTALL_DB_DBNAME'), false);
-        $this->executeMysqlQuery('CREATE DATABASE ' . getenv('TYPO3_INSTALL_DB_DBNAME'), false);
-        $this->executeConsoleCommand('database:import', [], [], $sqlDump);
-
-        $queryResult = $this->executeMysqlQuery('SELECT uid FROM be_users WHERE username="_cli_"');
-        $this->assertSame('1', trim($queryResult));
-
-        $this->restoreDatabase();
+        $sql = 'SELECT username from be_users where username="_cli_";';
+        $output = $this->executeConsoleCommand('database:import', [], [], $sql);
+        $this->assertSame('_cli_', trim($output));
     }
 
     /**


### PR DESCRIPTION
Instead we use --single-transaction, which might lead to
inconsistent results on MyIsam tables, but that still
is ok for our purpose (which is not creating backups)

Because the changes of behaviour for this command,
it is justified to mark this as breaking change,
although you may only be affected when you need
100% consistency and don't have all tables on InnoDB.

Fixes: #432