### PR TITLE
[TASK] Consistently use constructor injection

### DIFF
--- a/Classes/Command/CleanupCommandController.php
+++ b/Classes/Command/CleanupCommandController.php
@@ -15,20 +15,22 @@ namespace Helhum\Typo3Console\Command;
 
 use Helhum\Typo3Console\Command\Delegation\ReferenceIndexUpdateDelegate;
 use Helhum\Typo3Console\Mvc\Controller\CommandController;
+use Helhum\Typo3Console\Service\Persistence\PersistenceIntegrityService;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Log\LogLevel;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-/**
- * Class CleanupCommandController
- */
 class CleanupCommandController extends CommandController
 {
     /**
-     * @var \Helhum\Typo3Console\Service\Persistence\PersistenceIntegrityService
-     * @inject
+     * @var PersistenceIntegrityService
      */
     protected $persistenceIntegrityService;
+
+    public function __construct(PersistenceIntegrityService $persistenceIntegrityService)
+    {
+        $this->persistenceIntegrityService = $persistenceIntegrityService;
+    }
 
     /**
      * Update reference index

--- a/Classes/Command/ConfigurationCommandController.php
+++ b/Classes/Command/ConfigurationCommandController.php
@@ -14,24 +14,27 @@ namespace Helhum\Typo3Console\Command;
  */
 
 use Helhum\Typo3Console\Mvc\Controller\CommandController;
+use Helhum\Typo3Console\Service\Configuration\ConfigurationService;
+use Helhum\Typo3Console\Service\Configuration\ConsoleRenderer\ConsoleRenderer;
 use TYPO3\CMS\Core\SingletonInterface;
 
-/**
- * Class ConfigurationCommandController
- */
 class ConfigurationCommandController extends CommandController implements SingletonInterface
 {
     /**
-     * @var \Helhum\Typo3Console\Service\Configuration\ConfigurationService
-     * @inject
+     * @var ConfigurationService
      */
     protected $configurationService;
 
     /**
-     * @var \Helhum\Typo3Console\Service\Configuration\ConsoleRenderer\ConsoleRenderer
-     * @inject
+     * @var ConsoleRenderer
      */
     protected $consoleRenderer;
+
+    public function __construct(ConfigurationService $configurationService, ConsoleRenderer $consoleRenderer)
+    {
+        $this->configurationService = $configurationService;
+        $this->consoleRenderer = $consoleRenderer;
+    }
 
     /**
      * Remove configuration option

--- a/Classes/Command/DocumentationCommandController.php
+++ b/Classes/Command/DocumentationCommandController.php
@@ -15,19 +15,23 @@ namespace Helhum\Typo3Console\Command;
 
 use Helhum\Typo3Console\Mvc\Controller\CommandController;
 use Helhum\Typo3Console\Service;
+use Helhum\Typo3Console\Service\XsdGenerator;
 use TYPO3\CMS\Core\SingletonInterface;
 
 /**
  * Command controller for Fluid documentation rendering
- *
  */
 class DocumentationCommandController extends CommandController implements SingletonInterface
 {
     /**
-     * @var \Helhum\Typo3Console\Service\XsdGenerator
-     * @inject
+     * @var XsdGenerator
      */
     protected $xsdGenerator;
+
+    public function __construct(XsdGenerator $xsdGenerator)
+    {
+        $this->xsdGenerator = $xsdGenerator;
+    }
 
     /**
      * Generate Fluid ViewHelper XSD Schema

--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -57,18 +57,13 @@ class ExtensionCommandController extends CommandController
      */
     protected $cacheService;
 
-    public function injectSignalSlotDispatcher(Dispatcher $signalSlotDispatcher)
-    {
+    public function __construct(
+        Dispatcher $signalSlotDispatcher,
+        PackageManager $packageManager,
+        CacheService $cacheService
+    ) {
         $this->signalSlotDispatcher = $signalSlotDispatcher;
-    }
-
-    public function injectPackageManager(PackageManager $packageManager)
-    {
         $this->packageManager = $packageManager;
-    }
-
-    public function injectCacheService(CacheService $cacheService)
-    {
         $this->cacheService = $cacheService;
     }
 

--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -16,12 +16,14 @@ namespace Helhum\Typo3Console\Command;
 use Helhum\Typo3Console\Annotation\Command\Definition;
 use Helhum\Typo3Console\Install\CliSetupRequestHandler;
 use Helhum\Typo3Console\Install\FolderStructure\ExtensionFactory;
+use Helhum\Typo3Console\Install\InstallStepActionExecutor;
 use Helhum\Typo3Console\Install\PackageStatesGenerator;
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
 use Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException;
 use Helhum\Typo3Console\Mvc\Controller\CommandController;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Package\PackageInterface;
+use TYPO3\CMS\Core\Package\PackageManager;
 
 /**
  * Alpha version of a setup command controller
@@ -30,16 +32,20 @@ use TYPO3\CMS\Core\Package\PackageInterface;
 class InstallCommandController extends CommandController
 {
     /**
-     * @var \TYPO3\CMS\Core\Package\PackageManager
-     * @inject
+     * @var PackageManager
      */
     protected $packageManager;
 
     /**
-     * @var \Helhum\Typo3Console\Install\InstallStepActionExecutor
-     * @inject
+     * @var InstallStepActionExecutor
      */
     protected $installStepActionExecutor;
+
+    public function __construct(PackageManager $packageManager, InstallStepActionExecutor $installStepActionExecutor)
+    {
+        $this->packageManager = $packageManager;
+        $this->installStepActionExecutor = $installStepActionExecutor;
+    }
 
     /**
      * TYPO3 Setup

--- a/Classes/Command/SchedulerCommandController.php
+++ b/Classes/Command/SchedulerCommandController.php
@@ -14,17 +14,19 @@ namespace Helhum\Typo3Console\Command;
  */
 
 use Helhum\Typo3Console\Mvc\Controller\CommandController;
+use TYPO3\CMS\Scheduler\Scheduler;
 
-/**
- * Class SchedulerCommandController
- */
 class SchedulerCommandController extends CommandController
 {
     /**
-     * @var \TYPO3\CMS\Scheduler\Scheduler
-     * @inject
+     * @var Scheduler
      */
     protected $scheduler;
+
+    public function __construct(Scheduler $scheduler)
+    {
+        $this->scheduler = $scheduler;
+    }
 
     /**
      * Run scheduler

--- a/Classes/Mvc/Cli/Command.php
+++ b/Classes/Mvc/Cli/Command.php
@@ -21,7 +21,9 @@ use Helhum\Typo3Console\Mvc\Cli\Symfony\Application;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Reflection\ClassSchema;
+use TYPO3\CMS\Extbase\Reflection\ReflectionService;
 
 /**
  * Represents a Command
@@ -51,7 +53,7 @@ class Command
     protected $extensionName;
 
     /**
-     * @var \TYPO3\CMS\Extbase\Reflection\ReflectionService
+     * @var ReflectionService
      */
     protected $reflectionService;
 
@@ -96,26 +98,20 @@ class Command
     private $controllerCommandMethod;
 
     /**
-     * @param \TYPO3\CMS\Extbase\Reflection\ReflectionService $reflectionService
-     */
-    public function injectReflectionService(\TYPO3\CMS\Extbase\Reflection\ReflectionService $reflectionService)
-    {
-        $this->reflectionService = $reflectionService;
-    }
-
-    /**
      * @param string $controllerClassName Class name of the controller providing the command
      * @param string $controllerCommandName Command name, i.e. the method name of the command, without the "Command" suffix
+     * @param ReflectionService $reflectionService
      * @throws InvalidArgumentException
      */
-    public function __construct(string $controllerClassName, string $controllerCommandName)
+    public function __construct(string $controllerClassName, string $controllerCommandName, ReflectionService $reflectionService)
     {
         $this->controllerClassName = $controllerClassName;
         $this->controllerCommandName = $controllerCommandName;
+        $this->reflectionService = $reflectionService;
         $this->controllerCommandMethod = $this->controllerCommandName . 'Command';
         $delimiter = strpos($controllerClassName, '\\') !== false ? '\\' : '_';
         $classNameParts = explode($delimiter, $controllerClassName);
-        if (isset($classNameParts[0]) && $classNameParts[0] === 'TYPO3' && isset($classNameParts[1]) && $classNameParts[1] === 'CMS') {
+        if (isset($classNameParts[0], $classNameParts[1]) && $classNameParts[0] === 'TYPO3' && $classNameParts[1] === 'CMS') {
             $classNameParts[0] .= '\\' . $classNameParts[1];
             unset($classNameParts[1]);
             $classNameParts = array_values($classNameParts);
@@ -134,7 +130,7 @@ class Command
             );
         }
         $this->extensionName = $classNameParts[1];
-        $extensionKey = \TYPO3\CMS\Core\Utility\GeneralUtility::camelCaseToLowerCaseUnderscored($this->extensionName);
+        $extensionKey = GeneralUtility::camelCaseToLowerCaseUnderscored($this->extensionName);
         $this->commandIdentifier = strtolower($extensionKey . ':' . substr($classNameParts[$numberOfClassNameParts - 1], 0, -17) . ':' . $controllerCommandName);
     }
 

--- a/Classes/Service/XsdGenerator.php
+++ b/Classes/Service/XsdGenerator.php
@@ -15,7 +15,11 @@ namespace Helhum\Typo3Console\Service;
 
 use Helhum\Typo3Console\Parser\ParsingException;
 use Helhum\Typo3Console\Parser\PhpParser;
+use TYPO3\CMS\Core\Package\PackageManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
+use TYPO3\CMS\Extbase\Reflection\DocCommentParser;
+use TYPO3\CMS\Extbase\Reflection\ReflectionService;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\CMS\Fluid\Core\ViewHelper\ArgumentDefinition;
 
@@ -26,16 +30,38 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\ArgumentDefinition;
 class XsdGenerator
 {
     /**
-     * @var \TYPO3\CMS\Core\Package\PackageManager
-     * @inject
+     * @var PackageManager
      */
     protected $packageManager;
 
     /**
-     * @var \TYPO3\CMS\Extbase\Object\ObjectManagerInterface
-     * @inject
+     * @var ObjectManagerInterface
      */
     protected $objectManager;
+
+    /**
+     * The doc comment parser.
+     *
+     * @var DocCommentParser
+     */
+    protected $docCommentParser;
+
+    /**
+     * @var ReflectionService
+     */
+    protected $reflectionService;
+
+    public function __construct(
+        PackageManager $packageManager,
+        ObjectManagerInterface $objectManager,
+        DocCommentParser $docCommentParser,
+        ReflectionService $reflectionService
+    ) {
+        $this->packageManager = $packageManager;
+        $this->objectManager = $objectManager;
+        $this->docCommentParser = $docCommentParser;
+        $this->reflectionService = $reflectionService;
+    }
 
     /**
      * Generate the XML Schema definition for a given namespace.
@@ -268,20 +294,6 @@ class XsdGenerator
     {
         return strpos($namespace, '\\') === false ? '_' : '\\';
     }
-
-    /**
-     * The doc comment parser.
-     *
-     * @var \TYPO3\CMS\Extbase\Reflection\DocCommentParser
-     * @inject
-     */
-    protected $docCommentParser;
-
-    /**
-     * @var \TYPO3\CMS\Extbase\Reflection\ReflectionService
-     * @inject
-     */
-    protected $reflectionService;
 
     /**
      * Get a tag name for a given ViewHelper class.

--- a/Compatibility/TYPO3v87/Mvc/Cli/Command.php
+++ b/Compatibility/TYPO3v87/Mvc/Cli/Command.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use TYPO3\CMS\Extbase\Reflection\MethodReflection;
+use TYPO3\CMS\Extbase\Reflection\ReflectionService;
 
 /**
  * Represents a Command
@@ -92,22 +93,16 @@ class Command
     private $inputDefinitions;
 
     /**
-     * @param \TYPO3\CMS\Extbase\Reflection\ReflectionService $reflectionService
-     */
-    public function injectReflectionService(\TYPO3\CMS\Extbase\Reflection\ReflectionService $reflectionService)
-    {
-        $this->reflectionService = $reflectionService;
-    }
-
-    /**
      * @param string $controllerClassName Class name of the controller providing the command
      * @param string $controllerCommandName Command name, i.e. the method name of the command, without the "Command" suffix
+     * @param ReflectionService $reflectionService
      * @throws InvalidArgumentException
      */
-    public function __construct(string $controllerClassName, string $controllerCommandName)
+    public function __construct(string $controllerClassName, string $controllerCommandName, ReflectionService $reflectionService)
     {
         $this->controllerClassName = $controllerClassName;
         $this->controllerCommandName = $controllerCommandName;
+        $this->reflectionService = $reflectionService;
         $delimiter = strpos($controllerClassName, '\\') !== false ? '\\' : '_';
         $classNameParts = explode($delimiter, $controllerClassName);
         if (isset($classNameParts[0]) && $classNameParts[0] === 'TYPO3' && isset($classNameParts[1]) && $classNameParts[1] === 'CMS') {
@@ -399,9 +394,6 @@ class Command
         if ($this->commandMethodDefinitions !== null) {
             return $this->commandMethodDefinitions;
         }
-        $this->commandMethodDefinitions = [];
-        $commandMethodReflection = $this->getCommandMethodReflection();
-        $annotations = $commandMethodReflection->getTagsValues();
         $this->commandMethodDefinitions = $this->parseDefinitions();
         return $this->commandMethodDefinitions;
     }


### PR DESCRIPTION
All classes especially command controllers now use
constructor injection for DI.

Only the base CommandController class is left with two
inject methods to not require subclasses to call the
parent constructor.