### PR TITLE
[FEATURE] Prefer global option over declaring local ones

### DIFF
--- a/Classes/Command/CleanupCommandController.php
+++ b/Classes/Command/CleanupCommandController.php
@@ -40,11 +40,11 @@ class CleanupCommandController extends CommandController
      * <b>Example:</b> <code>%command.full_name% cleanup:updatereferenceindex --dry-run --verbose</code>
      *
      * @param bool $dryRun If set, index is only checked without performing any action
-     * @param bool $verbose Whether or not to output results
      * @param bool $showProgress Whether or not to output a progress bar
      */
-    public function updateReferenceIndexCommand($dryRun = false, $verbose = false, $showProgress = false)
+    public function updateReferenceIndexCommand($dryRun = false, $showProgress = false)
     {
+        $verbose = $this->output->getSymfonyConsoleOutput()->isVerbose();
         $this->outputLine('<info>' . ($dryRun ? 'Checking' : 'Updating') . ' reference index. This may take a while …</info>');
 
         $operation = $dryRun ? 'checkReferenceIndex' : 'updateReferenceIndex';

--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -78,12 +78,12 @@ class DatabaseCommandController extends CommandController
      * <b>Example:</b> <code>%command.full_name% database:updateschema "*.add,*.change"</code>
      *
      * @param array $schemaUpdateTypes List of schema update types (default: "safe")
-     * @param bool $verbose If set, database queries performed are shown in output
      * @param bool $dryRun If set the updates are only collected and shown, but not executed
      * @Definition\Argument(name="schemaUpdateTypes")
      */
-    public function updateSchemaCommand(array $schemaUpdateTypes = ['safe'], $verbose = false, $dryRun = false)
+    public function updateSchemaCommand(array $schemaUpdateTypes = ['safe'], $dryRun = false)
     {
+        $verbose = $this->output->getSymfonyConsoleOutput()->isVerbose();
         try {
             $expandedSchemaUpdateTypes = SchemaUpdateType::expandSchemaUpdateTypes($schemaUpdateTypes);
         } catch (InvalidEnumerationValueException $e) {

--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -76,12 +76,12 @@ class ExtensionCommandController extends CommandController
      * This command is deprecated (and hidden) in Composer mode.
      *
      * @param array $extensionKeys Extension keys to activate. Separate multiple extension keys with comma.
-     * @param bool $verbose Whether or not to output results
      * @throws \TYPO3\CMS\Extensionmanager\Exception\ExtensionManagerException
      */
-    public function activateCommand(array $extensionKeys, $verbose = false)
+    public function activateCommand(array $extensionKeys)
     {
         // @deprecated for composer usage in 5.0 will be removed with 6.0
+        $verbose = $this->output->getSymfonyConsoleOutput()->isVerbose();
         $this->showDeprecationMessageIfApplicable();
         $this->emitPackagesMayHaveChangedSignal();
         $activatedExtensions = [];
@@ -160,10 +160,10 @@ class ExtensionCommandController extends CommandController
      * - Writing default extension configuration
      *
      * @param array $extensionKeys Extension keys to set up. Separate multiple extension keys with comma.
-     * @param bool $verbose Whether or not to output results
      */
-    public function setupCommand(array $extensionKeys, $verbose = false)
+    public function setupCommand(array $extensionKeys)
     {
+        $verbose = $this->output->getSymfonyConsoleOutput()->isVerbose();
         $packages = [];
         foreach ($extensionKeys as $extensionKey) {
             $packages[] = $this->packageManager->getPackage($extensionKey);
@@ -220,11 +220,10 @@ class ExtensionCommandController extends CommandController
      * @see typo3_console:extension:setup
      * @see typo3_console:install:generatepackagestates
      * @see typo3_console:cache:flush
-     *
-     * @param bool $verbose Whether or not to output results
      */
-    public function setupActiveCommand($verbose = false)
+    public function setupActiveCommand()
     {
+        $verbose = $this->output->getSymfonyConsoleOutput()->isVerbose();
         $this->setupExtensions($this->packageManager->getActivePackages(), $verbose);
     }
 

--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -53,7 +53,6 @@ class InstallCommandController extends CommandController
      * Use as command line replacement for the web installation process.
      * Manually enter details on the command line or non interactive for automated setups.
      *
-     * @param bool $nonInteractive If specified, optional arguments are not requested, but default values are assumed.
      * @param bool $force Force installation of TYPO3, even if <code>LocalConfiguration.php</code> file already exists.
      * @param bool $skipIntegrityCheck Skip the checking for clean state before executing setup. This allows a pre-defined <code>LocalConfiguration.php</code> to be present. Handle with care. It might lead to unexpected or broken installation results.
      * @param bool $skipExtensionSetup Skip setting up extensions after TYPO3 is set up. Defaults to false in composer setups and to true in non composer setups.
@@ -68,9 +67,9 @@ class InstallCommandController extends CommandController
      * @param string $adminPassword Password of the administrative backend user account to be created
      * @param string $siteName Site Name
      * @param string $siteSetupType Can be either <code>no</code> (which unsurprisingly does nothing at all) or <code>site</code> (which creates an empty root page and setup)
+     * @param bool $nonInteractive Deprecated. Use <code>--no-interaction</code> instead.
      */
     public function setupCommand(
-        $nonInteractive = false,
         $force = false,
         $skipIntegrityCheck = false,
         $skipExtensionSetup = false,
@@ -84,13 +83,21 @@ class InstallCommandController extends CommandController
         $adminUserName = '',
         $adminPassword = '',
         $siteName = 'New TYPO3 Console site',
-        $siteSetupType = 'none'
+        $siteSetupType = 'none',
+        $nonInteractive = false
     ) {
+        $noInteraction = $this->output->getSymfonyConsoleInput()->getOption('no-interaction');
+        if ($nonInteractive) {
+            // @deprecated in 5.0 will be removed with 6.0
+            $this->outputLine('<warning>Option --non-interactive is deprecated. Please use --no-interaction instead.</warning>');
+            $noInteraction = true;
+        }
+
         $this->outputLine();
         $this->outputLine('<i>Welcome to the TYPO3 Console installer!</i>');
 
         if (!$skipIntegrityCheck) {
-            $this->ensureInstallationPossible($nonInteractive, $force);
+            $this->ensureInstallationPossible($noInteraction, $force);
         }
         $skipExtensionSetup |= !Bootstrap::usesComposerClassLoading();
 

--- a/Classes/Command/UpgradeCommandController.php
+++ b/Classes/Command/UpgradeCommandController.php
@@ -76,11 +76,11 @@ class UpgradeCommandController extends CommandController
     /**
      * List upgrade wizards
      *
-     * @param bool $verbose If set, a more verbose description for each wizard is shown, if not set only the title is shown
      * @param bool $all If set, all wizards will be listed, even the once marked as ready or done
      */
-    public function listCommand($verbose = false, $all = false)
+    public function listCommand($all = false)
     {
+        $verbose = $this->output->getSymfonyConsoleOutput()->isVerbose();
         $messages = [];
         $wizards = $this->upgradeHandling->executeInSubProcess('listWizards', [], $messages);
 
@@ -120,10 +120,10 @@ class UpgradeCommandController extends CommandController
      * Execute all upgrade wizards that are scheduled for execution
      *
      * @param array $arguments Arguments for the wizard prefixed with the identifier, e.g. <code>compatibility7Extension[install]=0</code>; multiple arguments separated with comma
-     * @param bool $verbose If set, output of the wizards will be shown, including all SQL Queries that were executed
      */
-    public function allCommand(array $arguments = [], $verbose = false)
+    public function allCommand(array $arguments = [])
     {
+        $verbose = $this->output->getSymfonyConsoleOutput()->isVerbose();
         $this->outputLine(PHP_EOL . '<i>Initiating TYPO3 upgrade</i>' . PHP_EOL);
 
         $messages = [];

--- a/Classes/Mvc/Cli/ConsoleOutput.php
+++ b/Classes/Mvc/Cli/ConsoleOutput.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Mvc\Cli;
 
 /*
@@ -94,6 +95,14 @@ class ConsoleOutput
     public function getSymfonyConsoleOutput()
     {
         return $this->output;
+    }
+
+    /**
+     * @return Input
+     */
+    public function getSymfonyConsoleInput(): Input
+    {
+        return $this->getInput();
     }
 
     /**

--- a/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
+++ b/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
@@ -33,6 +33,7 @@ use Helhum\Typo3Console\Mvc\Cli\Symfony\Application;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -57,12 +58,11 @@ class CommandControllerCommand extends Command
         parent::__construct($name);
     }
 
-    /**
-     * @return CommandDefinition
-     */
-    public function getCommandDefinition(): CommandDefinition
+    public function getNativeDefinition()
     {
-        return $this->commandDefinition;
+        $commandInputDefinition = new InputDefinition($this->commandDefinition->getInputDefinitions(true));
+        $commandInputDefinition->addOptions($this->application->getDefinition()->getOptions());
+        return $commandInputDefinition;
     }
 
     public function isEnabled(): bool

--- a/Classes/Mvc/Cli/Symfony/Descriptor/TextDescriptor.php
+++ b/Classes/Mvc/Cli/Symfony/Descriptor/TextDescriptor.php
@@ -22,7 +22,6 @@ namespace Helhum\Typo3Console\Mvc\Cli\Symfony\Descriptor;
  * file that was distributed with this source code.
  */
 
-use Helhum\Typo3Console\Mvc\Cli\Symfony\Command\CommandControllerCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Descriptor\ApplicationDescription;
@@ -127,11 +126,7 @@ class TextDescriptor extends \Symfony\Component\Console\Descriptor\TextDescripto
         }
         $this->writeText("\n");
 
-        if ($command instanceof CommandControllerCommand) {
-            $definition = new InputDefinition($command->getCommandDefinition()->getInputDefinitions(true));
-        } else {
-            $definition = $command->getNativeDefinition();
-        }
+        $definition = $command->getNativeDefinition();
 
         if ($definition->getOptions() || $definition->getArguments()) {
             $this->writeText("\n");

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -253,8 +253,6 @@ Options
 
 ``--dry-run``
   If set, index is only checked without performing any action
-``--verbose``
-  Whether or not to output results
 ``--show-progress``
   Whether or not to output a progress bar
 
@@ -513,8 +511,6 @@ Options
 
 ``--schema-update-types``
   List of schema update types (default: "safe")
-``--verbose``
-  If set, database queries performed are shown in output
 ``--dry-run``
   If set the updates are only collected and shown, but not executed
 
@@ -574,12 +570,6 @@ Arguments
   Extension keys to activate. Separate multiple extension keys with comma.
 
 
-
-Options
-^^^^^^^
-
-``--verbose``
-  Whether or not to output results
 
 
 
@@ -702,12 +692,6 @@ Arguments
 
 
 
-Options
-^^^^^^^
-
-``--verbose``
-  Whether or not to output results
-
 
 
 
@@ -728,12 +712,6 @@ As an additional benefit no caches are flushed, which significantly improves per
 and avoids unnecessary cache clearing.
 
 
-
-Options
-^^^^^^^
-
-``--verbose``
-  Whether or not to output results
 
 
 
@@ -903,8 +881,6 @@ Manually enter details on the command line or non interactive for automated setu
 Options
 ^^^^^^^
 
-``--non-interactive``
-  If specified, optional arguments are not requested, but default values are assumed.
 ``--force``
   Force installation of TYPO3, even if ``LocalConfiguration.php`` file already exists.
 ``--skip-integrity-check``
@@ -933,6 +909,8 @@ Options
   Site Name
 ``--site-setup-type``
   Can be either ``no`` (which unsurprisingly does nothing at all) or ``site`` (which creates an empty root page and setup)
+``--non-interactive``
+  Deprecated. Use ``--no-interaction`` instead.
 
 
 
@@ -981,8 +959,6 @@ Options
 
 ``--arguments``
   Arguments for the wizard prefixed with the identifier, e.g. ``compatibility7Extension[install]=0``; multiple arguments separated with comma
-``--verbose``
-  If set, output of the wizards will be shown, including all SQL Queries that were executed
 
 
 
@@ -1027,8 +1003,6 @@ Options
 Options
 ^^^^^^^
 
-``--verbose``
-  If set, a more verbose description for each wizard is shown, if not set only the title is shown
 ``--all``
   If set, all wizards will be listed, even the once marked as ready or done
 


### PR DESCRIPTION
Instead of always re-declaring options like --verbose,
use the global option.

Now all global options are shown for every command help