### PR TITLE
[FEATURE] Allow to specify php.ini path for sub processes

### DIFF
--- a/Classes/Mvc/Cli/CommandDispatcher.php
+++ b/Classes/Mvc/Cli/CommandDispatcher.php
@@ -130,6 +130,10 @@ class CommandDispatcher
             throw new RuntimeException('The "php" binary could not be found.', 1485128615);
         }
         $processBuilder->setPrefix($php);
+        if (getenv('PHP_INI_PATH')) {
+            $processBuilder->add('-c');
+            $processBuilder->add(getenv('PHP_INI_PATH'));
+        }
         $processBuilder->add($typo3CommandPath);
         $processBuilder->addEnvironmentVariables(['TYPO3_CONSOLE_SUB_PROCESS' => true]);
         return new self($processBuilder);

--- a/Classes/Mvc/Cli/Symfony/Application.php
+++ b/Classes/Mvc/Cli/Symfony/Application.php
@@ -23,7 +23,10 @@ use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -104,6 +107,20 @@ class Application extends BaseApplication
     public function renderException(\Exception $exception, OutputInterface $output)
     {
         (new ExceptionRenderer())->render($exception, $output, $this);
+    }
+
+    protected function getDefaultInputDefinition()
+    {
+        return new InputDefinition([
+            new InputArgument('command', InputArgument::REQUIRED, 'The command to execute'),
+
+            new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display this help message'),
+            new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Do not output any message'),
+            new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
+            new InputOption('--ansi', '', InputOption::VALUE_NONE, 'Force ANSI output'),
+            new InputOption('--no-ansi', '', InputOption::VALUE_NONE, 'Disable ANSI output'),
+            new InputOption('--no-interaction', '-n', InputOption::VALUE_NONE, 'Do not ask any interactive question'),
+        ]);
     }
 
     /**


### PR DESCRIPTION
When the env var PHP_INI_PATH is set, we instruct PHP
to load it for sub processes.

Fixes: #528