### PR TITLE
[FEATURE] Make compatible with Symfony >= 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,16 @@ before_install:
 
 install:
   - export COMPOSER_ROOT_VERSION=5.0.0
-  - composer require typo3/cms-backend="$TYPO3_VERSION" typo3/cms-core="$TYPO3_VERSION" typo3/cms-extbase="$TYPO3_VERSION" typo3/cms-extensionmanager="$TYPO3_VERSION" typo3/cms-fluid="$TYPO3_VERSION" typo3/cms-install="$TYPO3_VERSION" typo3/cms-scheduler="$TYPO3_VERSION"
+  - |
+    composer require \
+      typo3/cms-backend="$TYPO3_VERSION" \
+      typo3/cms-core="$TYPO3_VERSION" \
+      typo3/cms-extbase="$TYPO3_VERSION" \
+      typo3/cms-extensionmanager="$TYPO3_VERSION" \
+      typo3/cms-fluid="$TYPO3_VERSION" \
+      typo3/cms-install="$TYPO3_VERSION" \
+      typo3/cms-scheduler="$TYPO3_VERSION" \
+      $PREFER_LOWEST
   - git checkout composer.json
 
 # Test scripts
@@ -71,6 +80,9 @@ jobs:
     - stage: test
       php: 7.0
       env: TYPO3_VERSION=^8.7
+    - stage: test
+      php: 7.0
+      env: TYPO3_VERSION=^8.7 PREFER_LOWEST="--prefer-lowest"
     - stage: test
       php: 7.2
       env: TYPO3_VERSION="~9.0.0"
@@ -116,7 +128,6 @@ jobs:
           if [ -n "$TYPO3_ORG_USERNAME" ] && [ -n "$TYPO3_ORG_PASSWORD" ]; then
             echo -e "Preparing upload of release ${TRAVIS_TAG} to TER\n";
             # Install requirements
-            composer require --dev typo3/cms ^8.7
             composer require --dev helhum/ter-client dev-master
             # Cleanup before we upload
             git reset --hard HEAD && git clean -fx

--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -21,7 +21,6 @@ use Helhum\Typo3Console\Database\Schema\SchemaUpdateType;
 use Helhum\Typo3Console\Mvc\Controller\CommandController;
 use Helhum\Typo3Console\Service\Database\SchemaService;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessBuilder;
 use TYPO3\CMS\Core\Type\Exception\InvalidEnumerationValueException;
 
 /**
@@ -136,10 +135,7 @@ class DatabaseCommandController extends CommandController
      */
     public function importCommand($interactive = false)
     {
-        $mysqlCommand = new MysqlCommand(
-            $this->connectionConfiguration->build(),
-            new ProcessBuilder()
-        );
+        $mysqlCommand = new MysqlCommand($this->connectionConfiguration->build());
         $exitCode = $mysqlCommand->mysql(
             $interactive ? [] : ['--skip-column-names'],
             STDIN,
@@ -179,10 +175,7 @@ class DatabaseCommandController extends CommandController
         $additionalArguments[] = '--single-transaction';
         $additionalArguments[] = '--quick';
 
-        $mysqlCommand = new MysqlCommand(
-            $dbConfig,
-            new ProcessBuilder()
-        );
+        $mysqlCommand = new MysqlCommand($this->connectionConfiguration->build());
         $exitCode = $mysqlCommand->mysqldump(
             $additionalArguments,
             $this->buildOutputClosure()

--- a/Classes/Command/FrontendCommandController.php
+++ b/Classes/Command/FrontendCommandController.php
@@ -35,7 +35,7 @@ class FrontendCommandController extends CommandController
         ];
         // No other solution atm than to fake a CLI request type
         $code = str_replace('{arguments}', var_export($arguments, true), $template);
-        $process = new PhpProcess($code, null, null, null);
+        $process = new PhpProcess($code, null, null, 0);
         $process->mustRun();
         $rawResponse = json_decode($process->getOutput());
         if ($rawResponse === null || $rawResponse->status === 'failure') {

--- a/Classes/Core/Kernel.php
+++ b/Classes/Core/Kernel.php
@@ -85,13 +85,7 @@ class Kernel
             return;
         }
         $classesPaths = [__DIR__ . '/../../Classes', __DIR__ . '/../../Resources/Private/ExtensionArtifacts/src/'];
-        $classLoader = new ClassLoader();
-        $classLoader->addPsr4('Helhum\\Typo3Console\\', $classesPaths);
-        spl_autoload_register(function ($className) use ($classLoader) {
-            if ($file = $classLoader->findFile($className)) {
-                require $file;
-            }
-        });
+        $this->classLoader->addPsr4('Helhum\\Typo3Console\\', $classesPaths);
         $pharFile = __DIR__ . '/../../Libraries/symfony-process.phar';
         require 'phar://' . $pharFile . '/vendor/autoload.php';
     }

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,11 @@
         "typo3/cms-fluid": "^8.7.7 || ~9.0.0",
         "typo3/cms-install": "^8.7.7 || ~9.0.0",
         "typo3/cms-scheduler": "^8.7.7 || ~9.0.0",
+        "typo3/cms-saltedpasswords": "^8.7.7 || ~9.0.0",
 
         "doctrine/annotations": "^1.4",
-        "symfony/console": "^3.2",
-        "symfony/process": "^3.2"
+        "symfony/console": "^3.3.6 || ^4.0",
+        "symfony/process": "^3.3.6 || ^4.0"
     },
     "require-dev": {
         "typo3/cms-reports": "^8.7.7 || ~9.0.0 || 9.1.*@dev",
@@ -92,7 +93,7 @@
         "extension-create-libs": [
             "mkdir -p Libraries/temp",
             "[ -f $HOME/.composer/vendor/bin/phar-composer ] || composer global require clue/phar-composer",
-            "if [ ! -f Libraries/symfony-process.phar ]; then cd Libraries/temp && composer require symfony/process=^3.2 && composer config classmap-authoritative true && composer config prepend-autoloader false && composer dump-autoload -o; fi",
+            "if [ ! -f Libraries/symfony-process.phar ]; then cd Libraries/temp && composer require symfony/console=^3.3.6 symfony/process=^3.3.6 && composer config classmap-authoritative true && composer config prepend-autoloader true && composer dump-autoload -o; fi",
             "[ -f Libraries/symfony-process.phar ] || $HOME/.composer/vendor/bin/phar-composer build Libraries/temp/ Libraries/symfony-process.phar",
             "chmod -x Libraries/*.phar",
             "rm -rf Libraries/temp"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,7 +19,6 @@
         <env name="TYPO3_INSTALL_DB_PASSWORD" value="" />
         <env name="TYPO3_INSTALL_DB_DBNAME" value="travis_console_test" />
         <env name="TYPO3_VERSION" value="^8.7" />
-        <env name="TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS" value="scheduler" />
     </php>
     <testsuites>
         <testsuite name="TYPO3 Console Unit Tests">


### PR DESCRIPTION
Remove usages of ProcessBuilder as this class was removed
with Symfony 4.0.0

Raise minimum Symfony version to 3.3.6 as only as of then
the Process class can deal with array as command line
and this is the version currently shipped with TYPO3 ^8

Add --prefer-lowest to our builds to be sure we still run
with lowest possible package versions