### PR TITLE
[BUGFIX] Fix setup during composer run

### DIFF
--- a/Classes/Core/Kernel.php
+++ b/Classes/Core/Kernel.php
@@ -14,6 +14,7 @@ namespace Helhum\Typo3Console\Core;
  */
 
 use Composer\Autoload\ClassLoader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use Helhum\Typo3Console\Core\Booting\RunLevel;
 use Helhum\Typo3Console\Core\Booting\Scripts;
 use Helhum\Typo3Console\Mvc\Cli\CommandCollection;
@@ -56,6 +57,9 @@ class Kernel
         $this->ensureRequiredEnvironment();
         $this->bootstrap = Bootstrap::getInstance();
         $this->bootstrap->initializeClassLoader($classLoader);
+        // Initialize basic annotation loader until TYPO3 does so as well
+        AnnotationRegistry::registerLoader('class_exists');
+
         // We need to be sure all classes can be loaded in non composer mode as early as possible
         $this->initializeNonComposerClassLoading();
         $this->runLevel = new RunLevel($this->bootstrap);

--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -252,8 +252,7 @@ class CliSetupRequestHandler
             if ($argumentDefinition->acceptsValue()) {
                 $currentActionArguments['options'][$argumentDefinition->getDashedName()] = $value;
             } else {
-                $value = (bool)$value;
-                if ($value) {
+                if ((bool)$value) {
                     $currentActionArguments['options'][] = $argumentDefinition->getDashedName();
                 }
             }

--- a/Compatibility/TYPO3v87/Core/Booting/CompatibilityScripts.php
+++ b/Compatibility/TYPO3v87/Core/Booting/CompatibilityScripts.php
@@ -14,7 +14,6 @@ namespace Helhum\Typo3Console\TYPO3v87\Core\Booting;
  */
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use TYPO3\CMS\Core\Core\Bootstrap;
 
 class CompatibilityScripts
@@ -38,8 +37,6 @@ class CompatibilityScripts
 
     private static function initializeAnnotationReader()
     {
-        AnnotationRegistry::registerLoader('class_exists');
-
         /*
          * All annotations defined by and for Extbase need to be
          * ignored during their deprecation. Later, their usage may and


### PR DESCRIPTION
Since composer still uses symfony/* in versions 2.7.x
and we conflict in some areas with that version,
we need to adapt our code a bit so that the triggered
code is able to run with symfony/*