### PR TITLE
[BUGFIX] Correctly register class loading in non composer mode

### DIFF
--- a/Classes/Core/Kernel.php
+++ b/Classes/Core/Kernel.php
@@ -90,8 +90,17 @@ class Kernel
         if (Bootstrap::usesComposerClassLoading()) {
             return;
         }
-        $classesPaths = [__DIR__ . '/../../Classes', __DIR__ . '/../../Resources/Private/ExtensionArtifacts/src/'];
-        $this->classLoader->addPsr4('Helhum\\Typo3Console\\', $classesPaths);
+        $extensionBaseDir = dirname(__DIR__, 2) . '/';
+        $autoloadDefinition = json_decode(file_get_contents($extensionBaseDir . 'composer.json'), true)['autoload']['psr-4'];
+        foreach ($autoloadDefinition as $prefix => $paths) {
+            $paths = array_map(
+                function ($path) use ($extensionBaseDir) {
+                    return $extensionBaseDir . $path;
+                },
+                (array)$paths
+            );
+            $this->classLoader->addPsr4($prefix, $paths);
+        }
         $pharFile = __DIR__ . '/../../Libraries/symfony-process.phar';
         require 'phar://' . $pharFile . '/vendor/autoload.php';
     }

--- a/composer.json
+++ b/composer.json
@@ -56,10 +56,8 @@
         "psr-4": {
             "Helhum\\Typo3Console\\": [
                 "Classes/",
+                "Compatibility/",
                 "Resources/Private/ExtensionArtifacts/src/"
-            ],
-            "Helhum\\Typo3Console\\TYPO3v87\\": [
-                "Compatibility/TYPO3v87/"
             ]
         }
     },


### PR DESCRIPTION
In order for the compatibility layer to work, the Compatiblity
folder must also be registered in the class loader.

We now change the non composer class loading to register
all psr-4 namespaces directly from the composer.json file,
which will avoid issues in the future.

With this change we also simplify the autoload section
in our composer.json

Fixes: #655