### PR TITLE
[BUGFIX] Search for correct substring in existing binary on updates

### DIFF
--- a/Resources/Private/ExtensionArtifacts/src/Hook/ExtensionInstallation.php
+++ b/Resources/Private/ExtensionArtifacts/src/Hook/ExtensionInstallation.php
@@ -130,7 +130,9 @@ require __DIR__ . \'/typo3conf/ext/typo3_console/Scripts/typo3-console.php\';',
 
     protected static function isTypo3CmsBinary($fullTargetPath)
     {
-        return strpos(file_get_contents($fullTargetPath), 'typo3-console.php') !== false;
+        $binaryContent = file_get_contents($fullTargetPath);
+        return strpos($binaryContent, 'typo3cms.php') !== false
+            || strpos($binaryContent, 'typo3-console.php') !== false;
     }
 
     /**


### PR DESCRIPTION
When updating the standalone extension (non-composer mode) in the
Extension Manager make sure to use the correct check for an existing
typo3cms binary.

Fixes: #657