### PR TITLE
[BUGFIX] Output command method return value, but deprecate it

### DIFF
--- a/Classes/Mvc/Controller/CommandController.php
+++ b/Classes/Mvc/Controller/CommandController.php
@@ -259,10 +259,10 @@ abstract class CommandController implements CommandControllerInterface
             $preparedArguments[] = $argument->getValue();
         }
         $commandResult = $this->{$this->commandMethodName}(...$preparedArguments);
-        if (is_string($commandResult) && $commandResult !== '') {
-            $this->response->appendContent($commandResult);
-        } elseif (is_object($commandResult) && method_exists($commandResult, '__toString')) {
-            $this->response->appendContent((string)$commandResult);
+        if ($commandResult !== null) {
+            $this->outputLine((string)$commandResult);
+            $this->outputLine('<warning>Returning a string from a command method is deprecated.</warning>');
+            $this->outputLine('<warning>Please use $this->outputLine() instead.</warning>');
         }
     }
 


### PR DESCRIPTION
In previous versions of typo3 console and in the pure
TYPO3 implementation the command method return value
is set as response content. This content is then later
just echo'ed out, not respecting the output object that is used
otherwise, which means formatting is never applied.

For the sake of backwards compatibility we now output the
command method result again, but properly use the output object
and at the same time deprecate this functionality, as it
isn't very helpful to implicitly output something while
it is equally simple to use the output API explicitly.

Fixes: #658