### PR TITLE
[BUGFIX] Do not call last install step twice

### DIFF
--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -196,6 +196,8 @@ class CliSetupRequestHandler
             }
             $response = $this->executeActionWithArguments($actionName, $actionArguments['arguments'], $actionArguments['options']);
             if ($this->checkIfActionNeedsExecution($actionName)->actionNeedsExecution()) {
+                // @deprecated Can be removed once TYPO3 8.7 support is removed. Then it will be safe to call the action only once
+                // and just assume it completed
                 $response = $this->executeActionWithArguments($actionName, $actionArguments['arguments'], $actionArguments['options']);
             }
             $messages = $response->getMessages();

--- a/Classes/Install/InstallStepActionExecutor.php
+++ b/Classes/Install/InstallStepActionExecutor.php
@@ -69,7 +69,7 @@ class InstallStepActionExecutor
         $actionMethod = 'execute' . ucfirst($actionName) . 'Action';
         $checkMethod = 'check' . ucfirst($actionName) . 'Action';
         $messages = [];
-        $needsExecution = true;
+        $needsExecution = file_exists(PATH_site . 'FIRST_INSTALL');
         if (is_callable([$this->installerController, $checkMethod])) {
             $needsExecution = !\json_decode($this->installerController->$checkMethod()->getBody(), true)['success'];
         }

--- a/Tests/Functional/Command/Install/InstallCommandControllerTest.php
+++ b/Tests/Functional/Command/Install/InstallCommandControllerTest.php
@@ -94,6 +94,15 @@ class InstallCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
+    public function siteSetupCreatedHomepageOnlyOnce()
+    {
+        $queryResult = $this->executeMysqlQuery('SELECT count(*) FROM `pages`;');
+        $this->assertSame('1', preg_replace('/\s+/', '', $queryResult));
+    }
+
+    /**
+     * @test
+     */
     public function folderStructureIsCreated()
     {
         $indexFile = getenv('TYPO3_PATH_ROOT') . '/typo3temp/index.html';

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,9 @@ environment:
 
   matrix:
     - TYPO3_VERSION: '~9.0.0'
-      PHP_VERSION: '7.2.0-Win32-VC15'
+      PHP_VERSION: '7.2.1-Win32-VC15'
     - TYPO3_VERSION: '~8.7'
-      PHP_VERSION: '7.1.12-Win32-VC14'
+      PHP_VERSION: '7.1.13-Win32-VC14'
     - TYPO3_VERSION: '~8.7'
       PHP_VERSION: '7.0.26-Win32-VC14'
 
@@ -33,7 +33,7 @@ install:
   - IF NOT EXIST c:\php mkdir c:\php
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
-  - IF NOT EXIST php-installed.txt appveyor DownloadFile http://windows.php.net/downloads/releases/php-%PHP_VERSION%-x86.zip
+  - IF NOT EXIST php-installed.txt appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-%PHP_VERSION%-x86.zip
   - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%-x86.zip -y >nul
   - IF NOT EXIST php-installed.txt del /Q *.zip
   - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini


### PR DESCRIPTION
Because TYPO3 core installer class does not implement
the method to check whether this last step was executed
and we checked if the action needs to be executed again
right after execution and by default we assumed yes,
the action was triggered twice.

Since this action deletes the first install file,
we change the default whether the action needs to
be executed to existence of this file.

Fixes: #668