### PR TITLE
[BUGFIX] Use Symfony application description to render reference

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/Commands/ export-ignore
 /Resources/Private/ExtensionArtifacts/src/ export-ignore
 /Resources/Private/ExtensionArtifacts/ext_localconf.php export-ignore
 /Tests/ export-ignore

--- a/Classes/Command/CacheCommandController.php
+++ b/Classes/Command/CacheCommandController.php
@@ -122,7 +122,7 @@ class CacheCommandController extends CommandController
      * - pages
      * - system
      *
-     * <b>Example:</b> <code>%command.full_name% cache:flushgroups pages,all</code>
+     * <b>Example:</b> <code>%command.full_name% pages,all</code>
      *
      * @param array $groups An array of names (specified as comma separated values) of cache groups to flush
      */
@@ -142,7 +142,7 @@ class CacheCommandController extends CommandController
      *
      * Flushes caches by tags, optionally only caches in specified groups.
      *
-     * <b>Example:</b> <code>%command.full_name% cache:flushtags news_123 --groups pages,all</code>
+     * <b>Example:</b> <code>%command.full_name% news_123 --groups pages,all</code>
      *
      * @param array $tags Array of tags (specified as comma separated values) to flush.
      * @param array $groups Optional array of groups (specified as comma separated values) for which to flush tags. If no group is specified, caches of all groups are flushed.

--- a/Classes/Command/CleanupCommandController.php
+++ b/Classes/Command/CleanupCommandController.php
@@ -37,7 +37,7 @@ class CleanupCommandController extends CommandController
      *
      * Updates reference index to ensure data integrity
      *
-     * <b>Example:</b> <code>%command.full_name% cleanup:updatereferenceindex --dry-run --verbose</code>
+     * <b>Example:</b> <code>%command.full_name% --dry-run --verbose</code>
      *
      * @param bool $dryRun If set, index is only checked without performing any action
      * @param bool $showProgress Whether or not to output a progress bar

--- a/Classes/Command/ConfigurationCommandController.php
+++ b/Classes/Command/ConfigurationCommandController.php
@@ -44,7 +44,7 @@ class ConfigurationCommandController extends CommandController implements Single
      * For this command to succeed, the configuration option(s) must be in
      * LocalConfiguration.php and not be overridden elsewhere.
      *
-     * <b>Example:</b> <code>%command.full_name% configuration:remove DB,EXT/EXTCONF/realurl</code>
+     * <b>Example:</b> <code>%command.full_name% DB,EXT/EXTCONF/realurl</code>
      *
      * @param array $paths Path to system configuration that should be removed. Multiple paths can be specified separated by comma
      * @param bool $force If set, does not ask for confirmation
@@ -78,7 +78,7 @@ class ConfigurationCommandController extends CommandController implements Single
      * If the currently active configuration differs from the value in LocalConfiguration.php
      * the difference between these values is shown.
      *
-     * <b>Example:</b> <code>%command.full_name% configuration:show DB</code>
+     * <b>Example:</b> <code>%command.full_name% DB</code>
      *
      * @param string $path Path to system configuration option
      */
@@ -111,7 +111,7 @@ class ConfigurationCommandController extends CommandController implements Single
      * Shows active system configuration by path.
      * Shows the configuration value that is currently effective, no matter where and how it is set.
      *
-     * <b>Example:</b> <code>%command.full_name% configuration:showActive DB --json</code>
+     * <b>Example:</b> <code>%command.full_name% DB --json</code>
      *
      * @param string $path Path to system configuration
      * @param bool $json If set, the configuration is shown as JSON
@@ -131,9 +131,9 @@ class ConfigurationCommandController extends CommandController implements Single
      *
      * Shows local configuration option value by path.
      * Shows the value which is stored in LocalConfiguration.php.
-     * Note that this value could be overridden. Use <code>%command.full_name% configuration:show <path></code> to see if this is the case.
+     * Note that this value could be overridden. Use <code>typo3cms configuration:show <path></code> to see if this is the case.
      *
-     * <b>Example:</b> <code>%command.full_name% configuration:showlocal DB</code>
+     * <b>Example:</b> <code>%command.full_name% DB</code>
      *
      * @param string $path Path to local system configuration
      * @param bool $json If set, the configuration is shown as JSON
@@ -154,7 +154,7 @@ class ConfigurationCommandController extends CommandController implements Single
      *
      * Set system configuration option value by path.
      *
-     * <b>Example:</b> <code>%command.full_name% configuration:set SYS/fileCreateMask 0664</code>
+     * <b>Example:</b> <code>%command.full_name% SYS/fileCreateMask 0664</code>
      *
      * @param string $path Path to system configuration
      * @param string $value Value for system configuration

--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -74,7 +74,7 @@ class DatabaseCommandController extends CommandController
      *
      * To avoid shell matching all types with wildcards should be quoted.
      *
-     * <b>Example:</b> <code>%command.full_name% database:updateschema "*.add,*.change"</code>
+     * <b>Example:</b> <code>%command.full_name% "*.add,*.change"</code>
      *
      * @param array $schemaUpdateTypes List of schema update types (default: "safe")
      * @param bool $dryRun If set the updates are only collected and shown, but not executed
@@ -121,9 +121,9 @@ class DatabaseCommandController extends CommandController
      * The mysql binary must be available in the path for this command to work.
      * This obviously only works when MySQL is used as DBMS.
      *
-     * <b>Example (import):</b> <code>ssh remote.server '/path/to/%command.full_name% database:export' | %command.full_name% database:import</code>
-     * <b>Example (select):</b> <code>echo 'SELECT username from be_users WHERE admin=1;' | %command.full_name% database:import</code>
-     * <b>Example (interactive):</b> <code>%command.full_name% database:import --interactive</code>
+     * <b>Example (import):</b> <code>ssh remote.server '/path/to/typo3cms database:export' | %command.full_name%</code>
+     * <b>Example (select):</b> <code>echo 'SELECT username from be_users WHERE admin=1;' | %command.full_name%</code>
+     * <b>Example (interactive):</b> <code>%command.full_name% --interactive</code>
      *
      * <warning>This command passes the plain text database password to the command line process.</warning>
      * This means, that users that have the permission to observe running processes,
@@ -154,7 +154,7 @@ class DatabaseCommandController extends CommandController
      *
      * A comma-separated list of tables can be passed to exclude from the export:
      *
-     * <b>Example:</b> <code>%command.full_name% database:export --exclude-tables be_sessions,fe_sessions,sys_log</code>
+     * <b>Example:</b> <code>%command.full_name% --exclude-tables be_sessions,fe_sessions,sys_log</code>
      *
      * <warning>This command passes the plain text database password to the command line process.</warning>
      * This means, that users that have the permission to observe running processes,

--- a/Classes/Command/HelpCommandController.php
+++ b/Classes/Command/HelpCommandController.php
@@ -23,22 +23,6 @@ use Helhum\Typo3Console\Mvc\Controller\CommandController;
 class HelpCommandController extends CommandController
 {
     /**
-     * Help
-     *
-     * Display help for a command
-     *
-     * The help command displays help for a given command:
-     * %command.full_name% help <command identifier>
-     *
-     * @param string $commandIdentifier Identifier of a command for more details
-     * @return void
-     */
-    public function helpCommand($commandIdentifier)
-    {
-        // Intentionally empty for now (until command reference can render Symfony commands)
-    }
-
-    /**
      * Displays an error message
      *
      * @internal

--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -127,7 +127,7 @@ class InstallCommandController extends CommandController
      *
      * This updates your composer.json and composer.lock without any other changes.
      *
-     * <b>Example:</b> <code>%command.full_name% install:generatepackagestates</code>
+     * <b>Example:</b> <code>%command.full_name%</code>
      *
      * @param array $frameworkExtensions TYPO3 system extensions that should be marked as active. Extension keys separated by comma.
      * @param array $excludedExtensions Extensions which should stay inactive. This does not affect provided framework extensions or framework extensions that are required or part as minimal usable system.
@@ -180,7 +180,7 @@ class InstallCommandController extends CommandController
      *
      * This command creates the required folder structure needed for TYPO3 including extensions.
      * It is recommended to be executed <b>after</b> executing
-     * <code>%command.full_name% install:generatepackagestates</code>, to ensure proper generation of
+     * <code>typo3cms install:generatepackagestates</code>, to ensure proper generation of
      * required folders for all active extensions.
      *
      * @see typo3_console:install:generatepackagestates

--- a/Classes/Command/SchedulerCommandController.php
+++ b/Classes/Command/SchedulerCommandController.php
@@ -33,7 +33,7 @@ class SchedulerCommandController extends CommandController
      *
      * Executes tasks that are registered in the scheduler module.
      *
-     * <b>Example:</b> <code>%command.full_name% scheduler:run 42 --force</code>
+     * <b>Example:</b> <code>%command.full_name% 42 --force</code>
      *
      * @param int $task Uid of the task that should be executed (instead of all scheduled tasks)
      * @param bool $force The execution can be forced with this flag. The task will then be executed even if it is not scheduled for execution yet. Only works, when a task is specified.

--- a/Classes/Mvc/Cli/CommandCollection.php
+++ b/Classes/Mvc/Cli/CommandCollection.php
@@ -34,6 +34,14 @@ use TYPO3\CMS\Extbase\Mvc\Cli\CommandManager;
 class CommandCollection implements CommandLoaderInterface
 {
     /**
+     * Only use for rendering the reference
+     *
+     * @var bool
+     * @internal
+     */
+    public static $rendersReference = false;
+
+    /**
      * @var BaseCommand[]
      */
     private $commands;
@@ -77,7 +85,7 @@ class CommandCollection implements CommandLoaderInterface
      */
     public function get($name): BaseCommand
     {
-        if (!isset($this->commands[$name]) || !$this->runLevel->isCommandAvailable($name)) {
+        if (!isset($this->commands[$name]) || !$this->isCommandAvailable($name)) {
             throw new CommandNotFoundException(sprintf('A command with name "%s" could not be found.', $name), 1518812618);
         }
         $command = $this->commands[$name]['closure']();
@@ -93,7 +101,7 @@ class CommandCollection implements CommandLoaderInterface
      */
     public function has($name): bool
     {
-        return isset($this->commands[$name]) && $this->runLevel->isCommandAvailable($name);
+        return isset($this->commands[$name]) && $this->isCommandAvailable($name);
     }
 
     /**
@@ -113,6 +121,14 @@ class CommandCollection implements CommandLoaderInterface
     {
         $this->populateCommands();
         $this->populateCommandControllerCommands($commandManager);
+    }
+
+    private function isCommandAvailable(string $name): bool
+    {
+        if (self::$rendersReference) {
+            return true;
+        }
+        return $this->runLevel->isCommandAvailable($name);
     }
 
     private function populateCommands()

--- a/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
+++ b/Classes/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
@@ -43,6 +43,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CommandControllerCommand extends Command
 {
     /**
+     * Only use for rendering the reference
+     *
+     * @var bool
+     * @internal
+     */
+    public static $rendersReference = false;
+
+    /**
      * @var CommandDefinition
      */
     private $commandDefinition;
@@ -65,8 +73,16 @@ class CommandControllerCommand extends Command
         return $commandInputDefinition;
     }
 
+    public function getRelatedCommandNames()
+    {
+        return $this->commandDefinition->getRelatedCommandIdentifiers();
+    }
+
     public function isEnabled(): bool
     {
+        if (self::$rendersReference) {
+            return true;
+        }
         if ($this->application->isComposerManaged()
             && $this->getName() === 'extension:dumpautoload'
         ) {
@@ -155,6 +171,9 @@ class CommandControllerCommand extends Command
                 'extension:removeinactive',
             ], true)
         ) {
+            if (self::$rendersReference) {
+                return false;
+            }
             return true;
         }
         return $this->commandDefinition->isInternal();

--- a/Commands/CreateReferenceCommand/.gitignore
+++ b/Commands/CreateReferenceCommand/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/composer.lock

--- a/Commands/CreateReferenceCommand/Configuration/Console/Commands.php
+++ b/Commands/CreateReferenceCommand/Configuration/Console/Commands.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'commands' => [
+        'commandreference:render' => [
+            'class' => \Typo3Console\CreateReferenceCommand\Command\CommandReferenceRenderCommand::class,
+        ],
+    ],
+    'runLevels' => [
+        'typo3-console/create-reference-command:commandreference:render' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+    ],
+    'bootingSteps' => [
+    ],
+];

--- a/Commands/CreateReferenceCommand/Resources/Templates/CommandReferenceTemplate.txt
+++ b/Commands/CreateReferenceCommand/Resources/Templates/CommandReferenceTemplate.txt
@@ -1,0 +1,75 @@
+{namespace d=Typo3Console\CreateReferenceCommand\ViewHelpers}
+.. include:: ../Includes.txt
+
+
+.. _typo3_console-command-reference:
+
+{title -> d:format.underline(withCharacter: '=')}
+
+.. note::
+
+  This reference uses ``{commandName}`` as the command to invoke. If you are on
+  Windows, this will probably not work, there you need to use ``{commandName}.bat``
+  instead.
+  In Composer based installations, the ``{commandName}`` binary will be located
+  in the binary directory specified in the root composer.json (by default ``vendor/bin``)
+
+
+The following reference was automatically generated from code.
+
+<d:format.underline withCharacter="-">*TYPO3 Console*</d:format.underline>
+
+Application Options
+*******************
+
+The following options can be used with every command:
+
+<f:for each="{applicationOptions}" key="name" as="description">``{name}``
+  {description.description -> f:format.raw()}
+</f:for>
+
+<f:for each="{allCommandsByPackageKey}" as="allCommands" key="packageKey">
+.. _`{title}: {packageKey}`:
+
+Available Commands
+******************
+
+<f:for each="{allCommands}" as="command">
+.. _`{title}: {packageKey} {command.identifier}`:
+
+<d:format.underline withCharacter="*">``{command.identifier}``</d:format.underline>
+
+**{command.shortDescription}**
+
+{command.description -> f:format.raw()}
+
+<f:if condition="{command.arguments}">Arguments
+^^^^^^^^^
+
+<f:for each="{command.arguments}" key="name" as="description">``{name}``
+  {description -> f:format.raw()}
+</f:for>
+</f:if>
+
+<f:if condition="{command.options}">Options
+^^^^^^^
+
+<f:for each="{command.options}" key="name" as="description">``{name}``
+  {description.description -> f:format.raw()}
+
+- Accept value: {description.acceptValue}
+- Is value required: {description.isValueRequired}
+- Is multiple: {description.isMultiple}
+- Default: {description.default -> f:format.raw()}
+
+</f:for>
+</f:if>
+
+<f:if condition="{command.relatedCommands}">Related commands
+^^^^^^^^^^^^^^^^
+
+<f:for each="{command.relatedCommands}" key="relatedCommandIdentifier" as="relatedCommandDescription">``{relatedCommandIdentifier}``
+  {relatedCommandDescription -> f:format.raw()}
+</f:for>
+</f:if>
+</f:for></f:for>

--- a/Commands/CreateReferenceCommand/composer.json
+++ b/Commands/CreateReferenceCommand/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "typo3-console/create-reference-command",
+    "description": "TYPO3 Console command that creates the command reference",
+    "license": "GPL-2.0-or-later",
+    "type": "typo3-console-command",
+    "authors": [
+        {
+            "name": "Helmut Hummel",
+            "email": "info@helhum.io"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Typo3Console\\CreateReferenceCommand\\": "src/"
+        }
+    },
+    "require": {
+        "php": ">=7.0 <7.3",
+        "helhum/typo3-console": "^5.0"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
+}

--- a/Commands/CreateReferenceCommand/src/Command/CommandReferenceRenderCommand.php
+++ b/Commands/CreateReferenceCommand/src/Command/CommandReferenceRenderCommand.php
@@ -1,0 +1,201 @@
+<?php
+namespace Typo3Console\CreateReferenceCommand\Command;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+/*                                                                        *
+ * This script belongs to the Flow package "TYPO3.DocTools".              *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU Lesser General Public License, either version 3   *
+ * of the License, or (at your option) any later version.                 *
+ *                                                                        *
+ * The TYPO3 project - inspiring people to share!                         *
+ *                                                                        */
+
+use Helhum\Typo3Console\Mvc\Cli\CommandCollection;
+use Helhum\Typo3Console\Mvc\Cli\Symfony\Application;
+use Helhum\Typo3Console\Mvc\Cli\Symfony\Command\CommandControllerCommand;
+use Symfony\Component\Console\Descriptor\ApplicationDescription;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Fluid\View\StandaloneView;
+
+/**
+ * "Command Reference" command controller for the Documentation package.
+ * Used to create reference documentation for TYPO3 Console CLI commands.
+ */
+class CommandReferenceRenderCommand extends \Symfony\Component\Console\Command\Command
+{
+    private $skipCommands = [
+        'commandreference:render',
+        'server:run',
+    ];
+
+    protected function configure()
+    {
+        $this->setDefinition(
+            new InputDefinition(
+                [
+                    new InputArgument(
+                        'skipCommands',
+                        InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
+                        'Skip these commands from rendering',
+                        []
+                    ),
+                ]
+            )
+        )
+        ->setDescription('Renders command reference documentation from source code');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->skipCommands = $input->getArgument('skipCommands') ?: $this->skipCommands;
+        return $this->renderReference($output);
+    }
+
+    /**
+     * Render a CLI command reference to reStructuredText.
+     *
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function renderReference(OutputInterface $output): int
+    {
+        CommandCollection::$rendersReference = true;
+        CommandControllerCommand::$rendersReference = true;
+        $_SERVER['PHP_SELF'] = Application::COMMAND_NAME;
+        $application = $this->getApplication();
+        $applicationDescription = new ApplicationDescription($application);
+        $commands = $applicationDescription->getCommands();
+        $allCommands = [];
+        foreach ($commands as $command) {
+            if (in_array($command->getName(), $this->skipCommands, true)) {
+                continue;
+            }
+
+            $argumentDescriptions = [];
+            $optionDescriptions = [];
+            $command->mergeApplicationDefinition(false);
+            $commandDefinition = $command->getNativeDefinition();
+            foreach ($commandDefinition->getArguments() as $argument) {
+                $argumentDescriptions[$argument->getName()] = $this->transformMarkup($argument->getDescription());
+            }
+
+            foreach ($commandDefinition->getOptions() as $option) {
+                if ($application->getDefinition()->hasOption($option->getName())) {
+                    // We don't want global options to be rendered multiple times in the reference
+                    continue;
+                }
+                $optionDescriptions[$this->getOptionName($option)] = [
+                    'description' => $this->transformMarkup($option->getDescription()),
+                    'acceptValue' => $option->acceptValue() ? 'yes' : 'no',
+                    'isValueRequired' => $option->isValueRequired() ? 'yes' : 'no',
+                    'isMultiple' => $option->isArray() ? 'yes' : 'no',
+                    'default' => str_replace(["\n", TYPO3_version], ['', '<Current-TYPO3-Version>'], var_export($option->getDefault(), true)),
+                ];
+            }
+
+            $relatedCommands = [];
+            if (is_callable([$command, 'getRelatedCommandNames'])) {
+                $relatedCommandIdentifiers = $command->getRelatedCommandNames();
+                foreach ($relatedCommandIdentifiers as $relatedCommandIdentifier) {
+                    $commandParts = explode(':', $relatedCommandIdentifier);
+                    $shortCommandIdentifier = $relatedCommandIdentifier;
+                    if (count($commandParts) === 3) {
+                        $shortCommandIdentifier = $commandParts[1] . ':' . $commandParts[2];
+                    }
+                    if (isset($commands[$relatedCommandIdentifier])) {
+                        $relatedCommand = $commands[$relatedCommandIdentifier];
+                        $relatedCommands[$relatedCommandIdentifier] = $relatedCommand->getDescription();
+                    } elseif (isset($commands[$shortCommandIdentifier])) {
+                        $relatedCommand = $commands[$shortCommandIdentifier];
+                        $relatedCommands[$shortCommandIdentifier] = $relatedCommand->getDescription();
+                    } else {
+                        $relatedCommands[$relatedCommandIdentifier] = '*Command not available*';
+                    }
+                }
+            }
+
+            $allCommands[$command->getName()] = [
+                'identifier' => $command->getName(),
+                'shortDescription' => $this->transformMarkup($command->getDescription()),
+                'description' => $this->transformMarkup($command->getHelp() ? $command->getProcessedHelp() : ''),
+                'options' => $optionDescriptions,
+                'arguments' => $argumentDescriptions,
+                'relatedCommands' => $relatedCommands,
+            ];
+        }
+        CommandCollection::$rendersReference = false;
+        CommandControllerCommand::$rendersReference = false;
+
+        $applicationOptions = [];
+        foreach ($application->getDefinition()->getOptions() as $option) {
+            $applicationOptions[$this->getOptionName($option)] = [
+                'description' => $this->transformMarkup($option->getDescription()),
+                'acceptValue' => $option->acceptValue() ? 'yes' : 'no',
+                'isValueRequired' => $option->isValueRequired() ? 'yes' : 'no',
+                'isMultiple' => $option->isArray() ? 'yes' : 'no',
+                'default' => str_replace("\n", '', var_export($option->getDefault(), true)),
+            ];
+        }
+
+        $standaloneView = new StandaloneView();
+        $templatePathAndFilename = __DIR__ . '/../../Resources/Templates/CommandReferenceTemplate.txt';
+        $standaloneView->setTemplatePathAndFilename($templatePathAndFilename);
+        $standaloneView->assignMultiple(
+            [
+                'title' => 'Command Reference',
+                'commandName' => Application::COMMAND_NAME,
+                'applicationOptions' => $applicationOptions,
+                'allCommandsByPackageKey' => ['typo3_console' => $allCommands],
+            ]
+        );
+
+        $renderedOutputFile = getenv('TYPO3_PATH_COMPOSER_ROOT') . '/Documentation/CommandReference/Index.rst';
+        file_put_contents($renderedOutputFile, $standaloneView->render());
+        $output->writeln('DONE.');
+        return 0;
+    }
+
+    private function getOptionName(InputOption $option)
+    {
+        $name = '--' . $option->getName();
+        if ($option->getShortcut()) {
+            $name .= '|-' . implode('|-', explode('|', $option->getShortcut()));
+        }
+        return $name;
+    }
+
+    /**
+     * @param string $input
+     * @return string
+     */
+    private function transformMarkup($input): string
+    {
+        $output = preg_replace('|\<b>(((?!\</b>).)*)\</b>|', '**$1**', $input);
+        $output = preg_replace('|\<i>(((?!\</i>).)*)\</i>|', '*$1*', $output);
+        $output = preg_replace('|\<u>(((?!\</u>).)*)\</u>|', '*$1*', $output);
+        $output = preg_replace('|\<em>(((?!\</em>).)*)\</em>|', '*$1*', $output);
+        $output = preg_replace('|\<comment>(((?!\</comment>).)*)\</comment>|', '**$1**', $output);
+        $output = preg_replace('|\<warning>(((?!\</warning>).)*)\</warning>|', '**$1**', $output);
+        $output = preg_replace('|\<strike>(((?!\</strike>).)*)\</strike>|', '[$1]', $output);
+        $output = preg_replace('|\<code>(((?!\</code>).)*)\</code>|', '``$1``', $output);
+        $output = preg_replace('|\<info>(((?!\</info>).)*)\</info>|', '``$1``', $output);
+        return $output;
+    }
+}

--- a/Commands/CreateReferenceCommand/src/ViewHelpers/Format/IndentViewHelper.php
+++ b/Commands/CreateReferenceCommand/src/ViewHelpers/Format/IndentViewHelper.php
@@ -1,0 +1,48 @@
+<?php
+namespace Typo3Console\CreateReferenceCommand\ViewHelpers\Format;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+/*                                                                        *
+ * This script belongs to the Flow package "TYPO3.DocTools".              *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU Lesser General Public License, either version 3   *
+ * of the License, or (at your option) any later version.                 *
+ *                                                                        *
+ * The TYPO3 project - inspiring people to share!                         *
+ *                                                                        */
+
+/**
+ * Renders it's children and replaces every newline by a combination of
+ * newline and $indent.
+ */
+class IndentViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
+{
+    public function initializeArguments()
+    {
+        $this->registerArgument('indent', 'string', 'String used to indent', false, "\t");
+        $this->registerArgument('inline', 'boolean', 'If TRUE, the first line will not be indented', false, false);
+    }
+
+    /**
+     * @return string The formatted value
+     */
+    public function render()
+    {
+        $indent = $this->arguments['indent'];
+        $inline = $this->arguments['inline'];
+        $string = $this->renderChildren();
+        return ($inline === false ? $indent : '') . str_replace("\n", "\n" . $indent, $string);
+    }
+}

--- a/Commands/CreateReferenceCommand/src/ViewHelpers/Format/UnderlineViewHelper.php
+++ b/Commands/CreateReferenceCommand/src/ViewHelpers/Format/UnderlineViewHelper.php
@@ -1,0 +1,46 @@
+<?php
+namespace Typo3Console\CreateReferenceCommand\ViewHelpers\Format;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+/*                                                                        *
+ * This script belongs to the Flow package "TYPO3.DocTools".              *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU Lesser General Public License, either version 3   *
+ * of the License, or (at your option) any later version.                 *
+ *                                                                        *
+ * The TYPO3 project - inspiring people to share!                         *
+ *                                                                        */
+
+/**
+ * Returns the string, a newline character and an underline made of
+ * $withCharacter as long as the original string.
+ */
+class UnderlineViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
+{
+    public function initializeArguments()
+    {
+        $this->registerArgument('withCharacter', 'string', 'The padding string', false, '-');
+    }
+
+    /**
+     * @return string The formatted value
+     */
+    public function render()
+    {
+        $withCharacter = $this->arguments['withCharacter'];
+        $string = $this->renderChildren();
+        return $string . chr(10) . str_repeat($withCharacter, strlen($string));
+    }
+}

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -44,7 +44,6 @@ return [
         'extensionmanager:extension:dumpclassloadinginformation',
         'extensionmanager:extension:install',
         'extensionmanager:extension:uninstall',
-        'help:help',
         'help:error',
         'scheduler:scheduler:run',
     ],

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -18,11 +18,137 @@ Command Reference
 
 The following reference was automatically generated from code.
 
+*TYPO3 Console*
+---------------
+
+Application Options
+*******************
+
+The following options can be used with every command:
+
+``--help|-h``
+  Display this help message
+``--quiet|-q``
+  Do not output any message
+``--verbose|-v|-vv|-vvv``
+  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+``--ansi``
+  Force ANSI output
+``--no-ansi``
+  Disable ANSI output
+``--no-interaction|-n``
+  Do not ask any interactive question
+
+
 
 .. _`Command Reference: typo3_console`:
 
-Extension *typo3_console*
--------------------------
+Available Commands
+******************
+
+
+.. _`Command Reference: typo3_console help`:
+
+``help``
+********
+
+**Displays help for a command**
+
+The ``help`` command displays help for a given command:
+
+  ``php typo3cms help list``
+
+You can also output the help in other formats by using the **--format** option:
+
+  ``php typo3cms help --format=xml list``
+
+To display the list of available commands, please use the ``list`` command.
+
+Arguments
+^^^^^^^^^
+
+``command_name``
+  The command name
+
+
+
+Options
+^^^^^^^
+
+``--format``
+  The output format (txt, xml, json, or md)
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: 'txt'
+
+``--raw``
+  To output raw command help
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
+
+
+
+
+
+.. _`Command Reference: typo3_console list`:
+
+``list``
+********
+
+**Lists commands**
+
+The ``list`` command lists all commands:
+
+  ``php typo3cms list``
+
+You can also display the commands for a specific namespace:
+
+  ``php typo3cms list test``
+
+You can also output the information in other formats by using the **--format** option:
+
+  ``php typo3cms list --format=xml``
+
+It's also possible to get raw list of commands (useful for embedding command runner):
+
+  ``php typo3cms list --raw``
+
+Arguments
+^^^^^^^^^
+
+``namespace``
+  The namespace name
+
+
+
+Options
+^^^^^^^
+
+``--raw``
+  To output raw command list
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
+``--format``
+  The output format (txt, xml, json, or md)
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: 'txt'
+
+
+
+
 
 
 .. _`Command Reference: typo3_console backend:createadmin`:
@@ -37,9 +163,9 @@ Create a new user with administrative access.
 Arguments
 ^^^^^^^^^
 
-``--username``
+``username``
   Username of the user
-``--password``
+``password``
   Password of the user
 
 
@@ -64,6 +190,12 @@ Options
 
 ``--redirect-url``
   URL to redirect to when the backend is accessed
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: NULL
+
 
 
 
@@ -155,8 +287,20 @@ Options
 
 ``--force``
   Cache is forcibly flushed (low level operations are performed)
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 ``--files-only``
   Only file caches are flushed
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 
 
 
@@ -182,7 +326,7 @@ Valid group names are by default:
 Arguments
 ^^^^^^^^^
 
-``--groups``
+``groups``
   An array of names (specified as comma separated values) of cache groups to flush
 
 
@@ -205,7 +349,7 @@ Flushes caches by tags, optionally only caches in specified groups.
 Arguments
 ^^^^^^^^^
 
-``--tags``
+``tags``
   Array of tags (specified as comma separated values) to flush.
 
 
@@ -215,6 +359,12 @@ Options
 
 ``--groups``
   Optional array of groups (specified as comma separated values) for which to flush tags. If no group is specified, caches of all groups are flushed.
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: NULL
+
 
 
 
@@ -253,8 +403,20 @@ Options
 
 ``--dry-run``
   If set, index is only checked without performing any action
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 ``--show-progress``
   Whether or not to output a progress bar
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 
 
 
@@ -277,7 +439,7 @@ LocalConfiguration.php and not be overridden elsewhere.
 Arguments
 ^^^^^^^^^
 
-``--paths``
+``paths``
   Path to system configuration that should be removed. Multiple paths can be specified separated by comma
 
 
@@ -287,6 +449,12 @@ Options
 
 ``--force``
   If set, does not ask for confirmation
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 
 
 
@@ -306,9 +474,9 @@ Set system configuration option value by path.
 Arguments
 ^^^^^^^^^
 
-``--path``
+``path``
   Path to system configuration
-``--value``
+``value``
   Value for system configuration
 
 
@@ -333,7 +501,7 @@ the difference between these values is shown.
 Arguments
 ^^^^^^^^^
 
-``--path``
+``path``
   Path to system configuration option
 
 
@@ -352,12 +520,12 @@ Arguments
 Shows active system configuration by path.
 Shows the configuration value that is currently effective, no matter where and how it is set.
 
-**Example:** ``typo3cms configuration:showActive DB --json``
+**Example:** ``typo3cms configuration:showactive DB --json``
 
 Arguments
 ^^^^^^^^^
 
-``--path``
+``path``
   Path to system configuration
 
 
@@ -367,6 +535,12 @@ Options
 
 ``--json``
   If set, the configuration is shown as JSON
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 
 
 
@@ -388,7 +562,7 @@ Note that this value could be overridden. Use ``typo3cms configuration:show <pat
 Arguments
 ^^^^^^^^^
 
-``--path``
+``path``
   Path to local system configuration
 
 
@@ -398,6 +572,12 @@ Options
 
 ``--json``
   If set, the configuration is shown as JSON
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 
 
 
@@ -437,6 +617,12 @@ Options
 ``--exclude-tables``
   Comma-separated list of table names to exclude from the export
 
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: array ()
+
+
 
 
 
@@ -469,6 +655,12 @@ Options
 
 ``--interactive``
   Open an interactive mysql shell using the TYPO3 connection settings.
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 
 
 
@@ -504,15 +696,25 @@ To avoid shell matching all types with wildcards should be quoted.
 
 **Example:** ``typo3cms database:updateschema "*.add,*.change"``
 
+Arguments
+^^^^^^^^^
+
+``schemaUpdateTypes``
+  List of schema update types (default: "safe")
+
 
 
 Options
 ^^^^^^^
 
-``--schema-update-types``
-  List of schema update types (default: "safe")
 ``--dry-run``
   If set the updates are only collected and shown, but not executed
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 
 
 
@@ -534,7 +736,7 @@ in your Fluid template by adding the xmlns:* attribute(s):
 Arguments
 ^^^^^^^^^
 
-``--php-namespace``
+``phpNamespace``
   Namespace of the Fluid ViewHelpers without leading backslash (for example 'TYPO3\Fluid\ViewHelpers' or 'Tx_News_ViewHelpers'). NOTE: Quote and/or escape this argument as needed to avoid backslashes from being interpreted!
 
 
@@ -544,8 +746,20 @@ Options
 
 ``--xsd-namespace``
   Unique target namespace used in the XSD schema (for example "http://yourdomain.org/ns/viewhelpers"). Defaults to "http://typo3.org/ns/<php namespace>".
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: NULL
+
 ``--target-file``
   File path and name of the generated XSD schema. If not specified the schema will be output to standard output.
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: NULL
+
 
 
 
@@ -566,7 +780,7 @@ This command is deprecated (and hidden) in Composer mode.
 Arguments
 ^^^^^^^^^
 
-``--extension-keys``
+``extensionKeys``
   Extension keys to activate. Separate multiple extension keys with comma.
 
 
@@ -590,7 +804,7 @@ This command is deprecated (and hidden) in Composer mode.
 Arguments
 ^^^^^^^^^
 
-``--extension-keys``
+``extensionKeys``
   Extension keys to deactivate. Separate multiple extension keys with comma.
 
 
@@ -635,10 +849,28 @@ Options
 
 ``--active``
   Only show active extensions
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 ``--inactive``
   Only show inactive extensions
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 ``--raw``
   Enable machine readable output (just extension keys separated by line feed)
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 
 
 
@@ -666,6 +898,12 @@ Options
 ``--force``
   The option has to be specified, otherwise nothing happens
 
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
+
 
 
 
@@ -687,7 +925,7 @@ Set up means:
 Arguments
 ^^^^^^^^^
 
-``--extension-keys``
+``extensionKeys``
   Extension keys to set up. Separate multiple extension keys with comma.
 
 
@@ -739,32 +977,8 @@ Submits a frontend request to TYPO3 on the specified URL.
 Arguments
 ^^^^^^^^^
 
-``--request-url``
+``requestUrl``
   URL to make a frontend request.
-
-
-
-
-
-
-
-.. _`Command Reference: typo3_console help`:
-
-``help``
-********
-
-**Help**
-
-Display help for a command
-
-The help command displays help for a given command:
-typo3cms help <command identifier>
-
-Arguments
-^^^^^^^^^
-
-``--command-identifier``
-  Identifier of a command for more details
 
 
 
@@ -857,10 +1071,28 @@ Options
 
 ``--framework-extensions``
   TYPO3 system extensions that should be marked as active. Extension keys separated by comma.
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: array ()
+
 ``--excluded-extensions``
   Extensions which should stay inactive. This does not affect provided framework extensions or framework extensions that are required or part as minimal usable system.
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: array ()
+
 ``--activate-default``
   (DEPRECATED) If true, ``typo3/cms`` extensions that are marked as TYPO3 factory default, will be activated, even if not in the list of configured active framework extensions.
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 
 
 
@@ -883,34 +1115,124 @@ Options
 
 ``--force``
   Force installation of TYPO3, even if ``LocalConfiguration.php`` file already exists.
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 ``--skip-integrity-check``
   Skip the checking for clean state before executing setup. This allows a pre-defined ``LocalConfiguration.php`` to be present. Handle with care. It might lead to unexpected or broken installation results.
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 ``--skip-extension-setup``
   Skip setting up extensions after TYPO3 is set up. Defaults to false in composer setups and to true in non composer setups.
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 ``--database-user-name``
   User name for database server
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: ''
+
 ``--database-user-password``
   User password for database server
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: ''
+
 ``--database-host-name``
   Host name of database server
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: ''
+
 ``--database-port``
   TCP Port of database server
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: ''
+
 ``--database-socket``
   Unix Socket to connect to (if localhost is given as hostname and this is kept empty, a socket connection will be established)
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: ''
+
 ``--database-name``
   Name of the database
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: ''
+
 ``--use-existing-database``
   If set an empty database with the specified name will be used. Otherwise a database with the specified name is created.
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 ``--admin-user-name``
   User name of the administrative backend user account to be created
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: ''
+
 ``--admin-password``
   Password of the administrative backend user account to be created
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: ''
+
 ``--site-name``
   Site Name
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: 'New TYPO3 Console site'
+
 ``--site-setup-type``
   Can be either ``no`` (which unsurprisingly does nothing at all) or ``site`` (which creates an empty root page and setup)
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: 'none'
+
 ``--non-interactive``
   Deprecated. Use ``--no-interaction`` instead.
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 
 
 
@@ -934,10 +1256,28 @@ Options
 
 ``--task``
   Uid of the task that should be executed (instead of all scheduled tasks)
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: NULL
+
 ``--force``
   The execution can be forced with this flag. The task will then be executed even if it is not scheduled for execution yet. Only works, when a task is specified.
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 ``--task-id``
   Deprecated option (same as --task)
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: NULL
+
 
 
 
@@ -960,6 +1300,12 @@ Options
 ``--arguments``
   Arguments for the wizard prefixed with the identifier, e.g. ``compatibility7Extension[install]=0``; multiple arguments separated with comma
 
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: array ()
+
+
 
 
 
@@ -975,15 +1321,25 @@ This command is especially useful **before** switching sources to a new TYPO3 ve
 It checks the version constraints of all third party extensions against a given TYPO3 version.
 It therefore relies on the constraints to be correct.
 
+Arguments
+^^^^^^^^^
+
+``extensionKeys``
+  Extension keys to check. Separate multiple extension keys with comma.
+
 
 
 Options
 ^^^^^^^
 
-``--extension-keys``
-  Extension keys to check. Separate multiple extension keys with comma.
 ``--typo3-version``
   TYPO3 version to check against. Defaults to current TYPO3 version.
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: '<Current-TYPO3-Version>'
+
 
 
 
@@ -1006,6 +1362,12 @@ Options
 ``--all``
   If set, all wizards will be listed, even the once marked as ready or done
 
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
+
 
 
 
@@ -1022,7 +1384,7 @@ Options
 Arguments
 ^^^^^^^^^
 
-``--identifier``
+``identifier``
   Identifier of the wizard that should be executed
 
 
@@ -1032,8 +1394,20 @@ Options
 
 ``--arguments``
   Arguments for the wizard prefixed with the identifier, e.g. ``compatibility7Extension[install]=0``
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: array ()
+
 ``--force``
   Force execution, even if the wizard has been marked as done
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
 
 
 

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+    "repositories": [
+        {"type": "path", "url": "Commands/*"}
+    ],
     "name": "helhum/typo3-console",
     "description": "A reliable and powerful command line interface for TYPO3 CMS",
     "keywords": [
@@ -43,7 +46,7 @@
         "typo3/cms-filemetadata": "^8.7.10 || ~9.1.0 || 9.2.*@dev",
 
         "typo3-console/php-server-command": "^0.2",
-        "typo3-console/create-reference-command": "^2.2",
+        "typo3-console/create-reference-command": "@dev",
         "symfony/filesystem": "^3.2",
         "nimut/testing-framework": "3.*@dev"
     },


### PR DESCRIPTION
Instead of maintaining a separate repo for the command,
that renders the reference, we include it in our main repo now.

With this change, we rework the rendering to use a Symfony application
description instead of the command manager a base to generate
the reference.

Result is a more consistent reference, that matches the existing commands
better than before.

This also enables us to slowly migrate from command controllers
to native Symfony commands, but still have these in the reference.