### PR TITLE
Fix master build on travis

### DIFF
--- a/Commands/CreateReferenceCommand/src/Command/CommandReferenceRenderCommand.php
+++ b/Commands/CreateReferenceCommand/src/Command/CommandReferenceRenderCommand.php
@@ -42,7 +42,9 @@ class CommandReferenceRenderCommand extends \Symfony\Component\Console\Command\C
 {
     private $skipCommands = [
         'commandreference:render',
+        'language:update',
         'server:run',
+        'swiftmailer:spool:send',
     ];
 
     protected function configure()

--- a/Tests/Functional/Command/UpgradeCommandControllerTest.php
+++ b/Tests/Functional/Command/UpgradeCommandControllerTest.php
@@ -153,7 +153,7 @@ class UpgradeCommandControllerTest extends AbstractCommandTest
                 '--no-update',
             ]
         );
-        $output = $this->executeComposerCommand(['update', 'typo3/*']);
+        $output = $this->executeComposerCommand(['update', 'typo3/*', 'doctrine/dbal', '--with-all-dependencies']);
         if (DIRECTORY_SEPARATOR === '\\') {
             $output = preg_replace('/[^\x09-\x0d\x1b\x20-\xff]/', '', $output);
         }


### PR DESCRIPTION
Since TYPO3 master updated doctrine/dbal we need to
update that package as well when upgrading code.

Also exclude swiftmailer command from our reference.