### PR TITLE
[BUGFIX] Provide compatibility with TYPO3 master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,9 @@ install:
       typo3/cms-extbase="$TYPO3_VERSION" \
       typo3/cms-extensionmanager="$TYPO3_VERSION" \
       typo3/cms-fluid="$TYPO3_VERSION" \
+      typo3/cms-frontend="$TYPO3_VERSION" \
       typo3/cms-install="$TYPO3_VERSION" \
+      typo3/cms-saltedpasswords="$TYPO3_VERSION" \
       typo3/cms-scheduler="$TYPO3_VERSION" \
       $PREFER_LOWEST
   - git checkout composer.json
@@ -73,16 +75,16 @@ jobs:
 
     - stage: test
       php: 7.2
-      env: TYPO3_VERSION=^8.7
+      env: TYPO3_VERSION=^8.7.10
     - stage: test
       php: 7.1
-      env: TYPO3_VERSION=^8.7
+      env: TYPO3_VERSION=^8.7.10
     - stage: test
       php: 7.0
-      env: TYPO3_VERSION=^8.7
+      env: TYPO3_VERSION=^8.7.10
     - stage: test
       php: 7.0
-      env: TYPO3_VERSION=^8.7 PREFER_LOWEST="--prefer-lowest"
+      env: TYPO3_VERSION=^8.7.10 PREFER_LOWEST="--prefer-lowest"
     - stage: test
       php: 7.2
       env: TYPO3_VERSION="~9.1.0"

--- a/Classes/Core/Kernel.php
+++ b/Classes/Core/Kernel.php
@@ -189,7 +189,6 @@ class Kernel
      */
     public function terminate(int $exitCode = 0)
     {
-        $this->bootstrap->shutdown();
         if ($exitCode > 255) {
             $exitCode = 255;
         }

--- a/Tests/Functional/Command/UpgradeCommandControllerTest.php
+++ b/Tests/Functional/Command/UpgradeCommandControllerTest.php
@@ -99,9 +99,13 @@ class UpgradeCommandControllerTest extends AbstractCommandTest
             mkdir($instancePath);
         }
         putenv('TYPO3_PATH_COMPOSER_ROOT=' . $instancePath);
+        $_ENV['TYPO3_PATH_COMPOSER_ROOT'] = $instancePath;
         putenv('TYPO3_PATH_ROOT=' . $instancePath . '/web');
+        $_ENV['TYPO3_PATH_ROOT'] = $instancePath . '/web';
         putenv('TYPO3_PATH_WEB=' . $instancePath . '/web');
+        $_ENV['TYPO3_PATH_WEB'] = $instancePath . '/web';
         putenv('TYPO3_INSTALL_DB_DBNAME=' . getenv('TYPO3_INSTALL_DB_DBNAME') . '_up');
+        $_ENV['TYPO3_INSTALL_DB_DBNAME'] = getenv('TYPO3_INSTALL_DB_DBNAME') . '_up';
         chdir($instancePath);
 
         file_put_contents($instancePath . '/composer.json', '{}');

--- a/Tests/Functional/Fixtures/Extensions/ext_test/ext_tables.sql
+++ b/Tests/Functional/Fixtures/Extensions/ext_test/ext_tables.sql
@@ -1,5 +1,5 @@
 CREATE TABLE pages (
-	author_email varchar(255) DEFAULT '' NOT NULL
+	author_email varchar(242) DEFAULT '' NOT NULL
 );
 
 CREATE TABLE tx_exttest_cattest (

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
   - IF NOT EXIST c:\php mkdir c:\php
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
-  - IF NOT EXIST php-installed.txt appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-%PHP_VERSION%-x86.zip
+  - IF NOT EXIST php-installed.txt curl -fsS -o php-%PHP_VERSION%-x86.zip http://windows.php.net/downloads/releases/archives/php-%PHP_VERSION%-x86.zip
   - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%-x86.zip -y >nul
   - IF NOT EXIST php-installed.txt del /Q *.zip
   - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini
@@ -45,12 +45,12 @@ install:
   - IF NOT EXIST php-installed.txt echo extension=php_mbstring.dll >> php.ini
   - IF NOT EXIST php-installed.txt echo extension=php_fileinfo.dll >> php.ini
   - IF NOT EXIST php-installed.txt echo extension=php_mysqli.dll >> php.ini
-  - IF NOT EXIST php-installed.txt appveyor DownloadFile https://getcomposer.org/composer.phar
+  - IF NOT EXIST php-installed.txt curl -fsS -o composer.phar https://getcomposer.org/composer.phar
   - IF NOT EXIST php-installed.txt echo @php %%~dp0composer.phar %%* > composer.bat
   - IF NOT EXIST php-installed.txt type nul >> php-installed.txt
 
   - cd c:\t3c
-  - composer require "typo3/cms-backend=%TYPO3_VERSION%" "typo3/cms-core=%TYPO3_VERSION%" "typo3/cms-extbase=%TYPO3_VERSION%" "typo3/cms-extensionmanager=%TYPO3_VERSION%" "typo3/cms-fluid=%TYPO3_VERSION%" "typo3/cms-install=%TYPO3_VERSION%" "typo3/cms-scheduler=%TYPO3_VERSION%" --prefer-dist --no-progress --ansi
+  - composer require "typo3/cms-backend=%TYPO3_VERSION%" "typo3/cms-core=%TYPO3_VERSION%" "typo3/cms-extbase=%TYPO3_VERSION%" "typo3/cms-extensionmanager=%TYPO3_VERSION%" "typo3/cms-fluid=%TYPO3_VERSION%" "typo3/cms-frontend=%TYPO3_VERSION%" "typo3/cms-install=%TYPO3_VERSION%" "typo3/cms-saltedpasswords=%TYPO3_VERSION%" "typo3/cms-scheduler=%TYPO3_VERSION%" --prefer-dist --no-progress --ansi
   - git checkout .
 
 test_script:

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "typo3/cms-extbase": "^8.7.10 || ~9.1.0",
         "typo3/cms-extensionmanager": "^8.7.10 || ~9.1.0",
         "typo3/cms-fluid": "^8.7.10 || ~9.1.0",
+        "typo3/cms-frontend": "^8.7.10 || ~9.1.0",
         "typo3/cms-install": "^8.7.10 || ~9.1.0",
         "typo3/cms-scheduler": "^8.7.10 || ~9.1.0",
         "typo3/cms-saltedpasswords": "^8.7.10 || ~9.1.0",


### PR DESCRIPTION
Mostly tests adjustments.
Remove call to Bootstrap::shutdown, which was there
for compatibility anyway and does nothing TYPO3 Console needs