### PR TITLE
Avoid deprecation messages with TYPO3 master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ script:
 jobs:
   fast_finish: true
   allow_failures:
-    - env: TYPO3_VERSION="dev-master as 9.1.0"
+    - env: TYPO3_VERSION="9.2.*@dev"
   include:
     - &lint
       stage: test
@@ -90,7 +90,7 @@ jobs:
       env: TYPO3_VERSION="~9.1.0"
     - stage: test
       php: 7.2
-      env: TYPO3_VERSION="dev-master as 9.1.0"
+      env: TYPO3_VERSION="9.2.*@dev"
 
     - stage: test
       php: 7.1

--- a/Classes/Compatibility/TYPO3v87/Core/Booting/CompatibilityScripts.php
+++ b/Classes/Compatibility/TYPO3v87/Core/Booting/CompatibilityScripts.php
@@ -14,13 +14,26 @@ namespace Helhum\Typo3Console\TYPO3v87\Core\Booting;
  */
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Helhum\Typo3Console\Package\UncachedPackageManager;
 use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Package\DependencyResolver;
+use TYPO3\CMS\Core\Service\DependencyOrderingService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class CompatibilityScripts
 {
-    /**
-     * @param Bootstrap $bootstrap
-     */
+    public static function createPackageManager(): UncachedPackageManager
+    {
+        $packageManager = new UncachedPackageManager();
+        $dependencyResolver = GeneralUtility::makeInstance(DependencyResolver::class);
+        $dependencyResolver->injectDependencyOrderingService(
+            GeneralUtility::makeInstance(DependencyOrderingService::class)
+        );
+        $packageManager->injectDependencyResolver($dependencyResolver);
+
+        return $packageManager;
+    }
+
     public static function initializeConfigurationManagement(Bootstrap $bootstrap)
     {
         self::initializeAnnotationReader();

--- a/Classes/Compatibility/TYPO3v91/Core/Booting/CompatibilityScripts.php
+++ b/Classes/Compatibility/TYPO3v91/Core/Booting/CompatibilityScripts.php
@@ -1,5 +1,5 @@
 <?php
-namespace Helhum\Typo3Console\Core\Booting;
+namespace Helhum\Typo3Console\TYPO3v91\Core\Booting;
 
 /*
  * This file is part of the TYPO3 Console project.
@@ -14,6 +14,7 @@ namespace Helhum\Typo3Console\Core\Booting;
  */
 
 use Helhum\Typo3Console\Package\UncachedPackageManager;
+use TYPO3\CMS\Core\Package\DependencyResolver;
 use TYPO3\CMS\Core\Service\DependencyOrderingService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -21,7 +22,12 @@ class CompatibilityScripts
 {
     public static function createPackageManager(): UncachedPackageManager
     {
-        $packageManager = new UncachedPackageManager(GeneralUtility::makeInstance(DependencyOrderingService::class));
+        $packageManager = new UncachedPackageManager();
+        $dependencyResolver = GeneralUtility::makeInstance(DependencyResolver::class);
+        $dependencyResolver->injectDependencyOrderingService(
+            GeneralUtility::makeInstance(DependencyOrderingService::class)
+        );
+        $packageManager->injectDependencyResolver($dependencyResolver);
 
         return $packageManager;
     }

--- a/Classes/Console/Core/Booting/Scripts.php
+++ b/Classes/Console/Core/Booting/Scripts.php
@@ -16,7 +16,6 @@ namespace Helhum\Typo3Console\Core\Booting;
 use Helhum\Typo3Console\Core\Cache\FakeDatabaseBackend;
 use Helhum\Typo3Console\Error\ErrorHandler;
 use Helhum\Typo3Console\Error\ExceptionHandler;
-use Helhum\Typo3Console\Package\UncachedPackageManager;
 use Symfony\Component\Console\Exception\RuntimeException;
 use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
@@ -76,16 +75,11 @@ class Scripts
      */
     private static function initializePackageManagement(Bootstrap $bootstrap)
     {
-        $packageManager = new UncachedPackageManager();
+        $packageManager = CompatibilityScripts::createPackageManager();
         $bootstrap->setEarlyInstance(PackageManager::class, $packageManager);
-        ExtensionManagementUtility::setPackageManager($packageManager);
-        $dependencyResolver = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Package\DependencyResolver::class);
-        $dependencyResolver->injectDependencyOrderingService(
-            GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\DependencyOrderingService::class)
-        );
-        $packageManager->injectDependencyResolver($dependencyResolver);
-        $packageManager->init();
         GeneralUtility::setSingletonInstance(PackageManager::class, $packageManager);
+        ExtensionManagementUtility::setPackageManager($packageManager);
+        $packageManager->init();
     }
 
     public static function disableCachesForObjectManagement()

--- a/Classes/Console/Core/Kernel.php
+++ b/Classes/Console/Core/Kernel.php
@@ -24,6 +24,7 @@ use Helhum\Typo3Console\Mvc\Cli\Symfony\Application;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
 use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Package\PackageManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -87,11 +88,13 @@ class Kernel
      */
     private function initializeCompatibilityLayer()
     {
-        $typo3Branch = '90';
+        $typo3Branch = '92';
         if (method_exists($this->bootstrap, 'setCacheHashOptions')) {
             $typo3Branch = '87';
+        } elseif (!class_exists(Environment::class)) {
+            $typo3Branch = '91';
         }
-        if ($typo3Branch === '90') {
+        if ($typo3Branch === '92') {
             return;
         }
         $compatibilityNamespace = 'Helhum\\Typo3Console\\TYPO3v' . $typo3Branch . '\\';

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
         "typo3/cms-fluid": "^8.7.10 || ~9.1.0",
         "typo3/cms-frontend": "^8.7.10 || ~9.1.0",
         "typo3/cms-install": "^8.7.10 || ~9.1.0",
-        "typo3/cms-scheduler": "^8.7.10 || ~9.1.0",
         "typo3/cms-saltedpasswords": "^8.7.10 || ~9.1.0",
+        "typo3/cms-scheduler": "^8.7.10 || ~9.1.0",
 
         "doctrine/annotations": "^1.4",
         "symfony/console": "^3.4.4 || ^4.0",


### PR DESCRIPTION
To avoid deprecation messages early on, which might pollute
console output, we add different code for different
package manager creation in 8.7 and upcoming 9.2