### PR TITLE
[FEATURE] Unify command registration

### DIFF
--- a/Classes/Composer/InstallerScript/PopulateCommandConfiguration.php
+++ b/Classes/Composer/InstallerScript/PopulateCommandConfiguration.php
@@ -15,6 +15,7 @@ namespace Helhum\Typo3Console\Composer\InstallerScript;
  */
 
 use Composer\Script\Event as ScriptEvent;
+use Helhum\Typo3Console\Mvc\Cli\CommandConfiguration;
 use TYPO3\CMS\Composer\Plugin\Core\InstallerScript;
 
 /**
@@ -50,6 +51,7 @@ class PopulateCommandConfiguration implements InstallerScript
             }
             $commandConfiguration = array_merge($commandConfiguration, $this->getConfigFromPackage($installPath, $packageName));
         }
+
         $success = file_put_contents(
             __DIR__ . '/../../../Configuration/Console/ComposerPackagesCommands.php',
             '<?php' . chr(10)
@@ -65,7 +67,7 @@ class PopulateCommandConfiguration implements InstallerScript
      * @param \Composer\Composer $composer
      * @return array
      */
-    private function extractPackageMapFromComposer(\Composer\Composer $composer)
+    private function extractPackageMapFromComposer(\Composer\Composer $composer): array
     {
         $mainPackage = $composer->getPackage();
         $autoLoadGenerator = $composer->getAutoloadGenerator();
@@ -74,10 +76,12 @@ class PopulateCommandConfiguration implements InstallerScript
     }
 
     /**
-     * @param $installPath
-     * @return mixed
+     * @param string $installPath
+     * @param string $packageName
+     * @throws \Symfony\Component\Console\Exception\RuntimeException
+     * @return array
      */
-    private function getConfigFromPackage(string $installPath, string $packageName)
+    private function getConfigFromPackage(string $installPath, string $packageName): array
     {
         $commandConfiguration = [];
         if (file_exists($commandConfigurationFile = $installPath . '/Configuration/Console/Commands.php')) {
@@ -89,6 +93,7 @@ class PopulateCommandConfiguration implements InstallerScript
         if (empty($commandConfiguration)) {
             return [];
         }
-        return [$packageName => $commandConfiguration];
+        CommandConfiguration::ensureValidCommandRegistration($commandConfiguration, $packageName);
+        return [$packageName => CommandConfiguration::unifyCommandConfiguration($commandConfiguration, $packageName)];
     }
 }

--- a/Classes/Core/Booting/RunLevel.php
+++ b/Classes/Core/Booting/RunLevel.php
@@ -294,7 +294,7 @@ class RunLevel
      */
     public function getRunLevelForCommand(string $commandIdentifier): string
     {
-        if (in_array($commandIdentifier, ['', 'help', 'list'], true)) {
+        if (in_array($commandIdentifier, ['help', 'list'], true)) {
             return $this->getMaximumAvailableRunLevel();
         }
         $options = $this->getOptionsForCommand($commandIdentifier);

--- a/Classes/Core/Booting/RunLevel.php
+++ b/Classes/Core/Booting/RunLevel.php
@@ -292,13 +292,13 @@ class RunLevel
      * @return string
      * @internal
      */
-    private function getRunLevelForCommand(string $commandIdentifier): string
+    public function getRunLevelForCommand(string $commandIdentifier): string
     {
         if (in_array($commandIdentifier, ['', 'help', 'list'], true)) {
             return $this->getMaximumAvailableRunLevel();
         }
         $options = $this->getOptionsForCommand($commandIdentifier);
-        return isset($options['runLevel']) ? $options['runLevel'] : self::LEVEL_FULL;
+        return $options['runLevel'] ?? self::LEVEL_FULL;
     }
 
     /**
@@ -337,30 +337,19 @@ class RunLevel
      */
     private function getOptionsForCommand(string $commandIdentifier)
     {
-        $commandIdentifierParts = explode(':', $commandIdentifier);
-        if (count($commandIdentifierParts) < 2 || count($commandIdentifierParts) > 3) {
-            return null;
+        $commandIdentifierPrefix = $commandIdentifier;
+        $position = strrpos($commandIdentifier, ':');
+        if ($position !== false) {
+            $commandIdentifierPrefix = substr($commandIdentifier, 0, $position);
         }
+
         if (isset($this->commandOptions[$commandIdentifier])) {
             return $this->commandOptions[$commandIdentifier];
         }
 
-        if (count($commandIdentifierParts) === 3) {
-            $currentCommandControllerName = $commandIdentifierParts[1];
-            $currentCommandName = $commandIdentifierParts[2];
-        } else {
-            $currentCommandControllerName = $commandIdentifierParts[0];
-            $currentCommandName = $commandIdentifierParts[1];
-        }
-
-        foreach ($this->commandOptions as $fullControllerIdentifier => $commandRegistry) {
-            list(, $controllerName, $commandName) = explode(':', $fullControllerIdentifier);
-            if ($controllerName === $currentCommandControllerName && $commandName === $currentCommandName) {
-                return $this->commandOptions[$fullControllerIdentifier];
-            }
-            if ($controllerName === $currentCommandControllerName && $commandName === '*') {
-                return $this->commandOptions[$fullControllerIdentifier];
-            }
+        $lookupKey = $commandIdentifierPrefix . ':*';
+        if (isset($this->commandOptions[$lookupKey])) {
+            return $this->commandOptions[$lookupKey];
         }
 
         return null;

--- a/Classes/Mvc/Cli/CommandConfiguration.php
+++ b/Classes/Mvc/Cli/CommandConfiguration.php
@@ -1,0 +1,207 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Mvc\Cli;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Symfony\Component\Console\Exception\RuntimeException;
+use TYPO3\CMS\Core\Console\CommandNameAlreadyInUseException;
+use TYPO3\CMS\Core\Package\PackageInterface;
+use TYPO3\CMS\Core\Package\PackageManager;
+
+/**
+ * Represents command configuration provided by packages
+ */
+class CommandConfiguration
+{
+    /**
+     * @var PackageManager
+     */
+    private $packageManager;
+
+    private $replaces = [];
+
+    private $commandDefinitions = [];
+
+    public function __construct(PackageManager $packageManager)
+    {
+        $this->packageManager = $packageManager;
+        $this->initialize();
+    }
+
+    /**
+     * @param mixed $commandConfiguration
+     * @param string $packageName
+     * @throws RuntimeException
+     */
+    public static function ensureValidCommandRegistration($commandConfiguration, $packageName)
+    {
+        if (
+            !is_array($commandConfiguration)
+            || (isset($commandConfiguration['controllers']) && !is_array($commandConfiguration['controllers']))
+            || (isset($commandConfiguration['runLevels']) && !is_array($commandConfiguration['runLevels']))
+            || (isset($commandConfiguration['bootingSteps']) && !is_array($commandConfiguration['bootingSteps']))
+            || (isset($commandConfiguration['commands']) && !is_array($commandConfiguration['commands']))
+            || (isset($commandConfiguration['replace']) && !is_array($commandConfiguration['replace']))
+        ) {
+            throw new RuntimeException($packageName . ' defines invalid commands in Configuration/Console/Commands.php', 1461186959);
+        }
+    }
+
+    public static function unifyCommandConfiguration(array $commandConfiguration, string $packageName): array
+    {
+        $commandDefinitions = array_replace($commandConfiguration['commands'] ?? [], self::extractCommandDefinitionsFromControllers($commandConfiguration['controllers'] ?? []));
+
+        foreach ($commandDefinitions as $commandName => $commandConfig) {
+            $commandDefinitions[$commandName]['vendor'] = $vendor = $commandConfig['vendor'] ?? $packageName;
+            $nameSpacedCommandName = $vendor . ':' . $commandName;
+            $nameSpacedCommandCollection = $nameSpacedCommandName;
+            if (strrpos($commandName, ':') !== false) {
+                $nameSpacedCommandCollection = $vendor . ':' . substr($commandName, 0, strrpos($commandName, ':')) . ':*';
+            }
+            if (isset($commandConfiguration['runLevels'][$nameSpacedCommandCollection])) {
+                $commandDefinitions[$commandName]['runLevel'] = $commandConfiguration['runLevels'][$nameSpacedCommandCollection];
+            }
+            if (isset($commandConfiguration['runLevels'][$commandName])) {
+                $commandDefinitions[$commandName]['runLevel'] = $commandConfiguration['runLevels'][$commandName];
+            }
+            if (isset($commandConfiguration['runLevels'][$nameSpacedCommandName])) {
+                $commandDefinitions[$commandName]['runLevel'] = $commandConfiguration['runLevels'][$nameSpacedCommandName];
+            }
+            if (isset($commandConfiguration['bootingSteps'][$commandName])) {
+                $commandDefinitions[$commandName]['bootingSteps'] = $commandConfiguration['bootingSteps'][$commandName];
+            }
+            if (isset($commandConfiguration['bootingSteps'][$nameSpacedCommandName])) {
+                $commandDefinitions[$commandName]['bootingSteps'] = $commandConfiguration['bootingSteps'][$nameSpacedCommandName];
+            }
+        }
+        if (isset($commandConfiguration['replace'])) {
+            $anyCommandName = key($commandDefinitions);
+            $commandDefinitions[$anyCommandName]['replace'] = array_merge($commandDefinitions[$anyCommandName]['replace'] ?? [], $commandConfiguration['replace']);
+        }
+
+        return $commandDefinitions;
+    }
+
+    private static function extractCommandDefinitionsFromControllers(array $controllers): array
+    {
+        $commandDefinitions = [];
+        foreach ($controllers as $controllerClassName) {
+            if (!class_exists($controllerClassName)) {
+                throw new RuntimeException(sprintf('Command controller class "%s" does not exist.', $controllerClassName), 1520200175);
+            }
+            foreach (get_class_methods($controllerClassName) as $methodName) {
+                if (substr($methodName, -7, 7) === 'Command') {
+                    $controllerCommandName = substr($methodName, 0, -7);
+                    $classNameParts = explode('\\', $controllerClassName);
+                    if (isset($classNameParts[0], $classNameParts[1]) && $classNameParts[0] === 'TYPO3' && $classNameParts[1] === 'CMS') {
+                        $classNameParts[0] .= '\\' . $classNameParts[1];
+                        unset($classNameParts[1]);
+                        $classNameParts = array_values($classNameParts);
+                    }
+                    $numberOfClassNameParts = count($classNameParts);
+                    $vendor = \TYPO3\CMS\Core\Utility\GeneralUtility::camelCaseToLowerCaseUnderscored($classNameParts[1]);
+                    $controllerCommandNameSpace = strtolower(substr($classNameParts[$numberOfClassNameParts - 1], 0, -17));
+                    $commandName = $controllerCommandNameSpace . ':' . strtolower($controllerCommandName);
+                    $commandDefinitions[$commandName]['vendor'] = $vendor;
+                    $commandDefinitions[$commandName]['controller'] = $controllerClassName;
+                    $commandDefinitions[$commandName]['controllerCommandName'] = $controllerCommandName;
+                }
+            }
+        }
+
+        return $commandDefinitions;
+    }
+
+    /**
+     * @return array
+     */
+    public function getReplaces(): array
+    {
+        return $this->replaces;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCommandDefinitions(): array
+    {
+        return $this->commandDefinitions;
+    }
+
+    public function addCommandControllerCommands(array $commandControllers): array
+    {
+        $addedCommandDefinitions = $this->getCommandDefinitionsForCommands(self::unifyCommandConfiguration(['controllers' => $commandControllers], ''));
+        $this->commandDefinitions = array_replace($this->commandDefinitions, $addedCommandDefinitions);
+        return $addedCommandDefinitions;
+    }
+
+    private function initialize()
+    {
+        foreach ($this->gatherRawConfig() as $packageName => $commandConfiguration) {
+            $this->commandDefinitions = array_replace($this->commandDefinitions, $this->getCommandDefinitionsForCommands($commandConfiguration));
+        }
+    }
+
+    private function getCommandDefinitionsForCommands(array $commands): array
+    {
+        $commandDefinitions = [];
+        foreach ($commands as $name => $singleCommandConfiguration) {
+            $vendor = $singleCommandConfiguration['vendor'];
+            if (isset($singleCommandConfiguration['replace'])) {
+                $this->replaces = array_merge($this->replaces, $singleCommandConfiguration['replace']);
+            }
+            $singleCommandConfiguration['name'] = $name;
+            $nameSpacedCommandName = $vendor . ':' . $name;
+            if (isset($this->commandDefinitions[$nameSpacedCommandName])) {
+                throw new CommandNameAlreadyInUseException('Command "' . $nameSpacedCommandName . '" registered by "' . $vendor . '" is already in use', 1520181870);
+            }
+            $commandDefinitions[$nameSpacedCommandName] = $singleCommandConfiguration;
+        }
+        return $commandDefinitions;
+    }
+
+    /**
+     * @return array
+     */
+    private function gatherRawConfig(): array
+    {
+        if (file_exists($commandConfigurationFile = __DIR__ . '/../../../Configuration/Console/ComposerPackagesCommands.php')) {
+            $configuration = require $commandConfigurationFile;
+        } else {
+            // We only reach this point in non composer mode
+            // We ensure that our commands are present, even if we are not an active extension or even not being an extension at all
+            $configuration['typo3_console'] = self::unifyCommandConfiguration(require __DIR__ . '/../../../Configuration/Console/Commands.php', 'typo3_console');
+        }
+        foreach ($this->packageManager->getActivePackages() as $package) {
+            $packageConfig = $this->getConfigFromExtension($package);
+            if (!empty($packageConfig)) {
+                self::ensureValidCommandRegistration($packageConfig, $package->getPackageKey());
+                $configuration[$package->getPackageKey()] = self::unifyCommandConfiguration($packageConfig, $package->getPackageKey());
+            }
+        }
+        return $configuration;
+    }
+
+    private function getConfigFromExtension(PackageInterface $package): array
+    {
+        $commandConfiguration = [];
+        if (file_exists($commandConfigurationFile = $package->getPackagePath() . 'Configuration/Console/Commands.php')) {
+            $commandConfiguration = require $commandConfigurationFile;
+        }
+        if (file_exists($commandConfigurationFile = $package->getPackagePath() . 'Configuration/Commands.php')) {
+            $commandConfiguration['commands'] = require $commandConfigurationFile;
+        }
+        return $commandConfiguration;
+    }
+}

--- a/Commands/CreateReferenceCommand/Configuration/Console/Commands.php
+++ b/Commands/CreateReferenceCommand/Configuration/Console/Commands.php
@@ -3,11 +3,8 @@ return [
     'commands' => [
         'commandreference:render' => [
             'class' => \Typo3Console\CreateReferenceCommand\Command\CommandReferenceRenderCommand::class,
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+            'vendor' => 'typo3_console',
         ],
-    ],
-    'runLevels' => [
-        'typo3-console/create-reference-command:commandreference:render' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
-    ],
-    'bootingSteps' => [
     ],
 ];

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -1,50 +1,311 @@
 <?php
 return [
-    'controllers' => [
-        \Helhum\Typo3Console\Command\HelpCommandController::class,
-        \Helhum\Typo3Console\Command\CacheCommandController::class,
-        \Helhum\Typo3Console\Command\BackendCommandController::class,
-        \Helhum\Typo3Console\Command\SchedulerCommandController::class,
-        \Helhum\Typo3Console\Command\CleanupCommandController::class,
-        \Helhum\Typo3Console\Command\DocumentationCommandController::class,
-        \Helhum\Typo3Console\Command\InstallCommandController::class,
-        \Helhum\Typo3Console\Command\DatabaseCommandController::class,
-        \Helhum\Typo3Console\Command\ConfigurationCommandController::class,
-        \Helhum\Typo3Console\Command\FrontendCommandController::class,
-        \Helhum\Typo3Console\Command\ExtensionCommandController::class,
-        \Helhum\Typo3Console\Command\UpgradeCommandController::class,
-    ],
-    'runLevels' => [
-        'typo3_console:install:databasedata' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
-        'typo3_console:install:defaultconfiguration' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
-        'typo3_console:install:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
-        'typo3_console:cache:flush' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
-        'typo3_console:cache:flushcomplete' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
-        'typo3_console:configuration:show' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
-        'typo3_console:configuration:showactive' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
-        'typo3_console:configuration:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
-        'typo3_console:database:import' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
-        'typo3_console:database:updateschema' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
-        'typo3_console:extension:dumpautoload' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
-        'typo3_console:upgrade:subprocess' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
-        'typo3_console:upgrade:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
-    ],
-    'bootingSteps' => [
-        // @deprecated database step can be removed once TYPO3 8 support is removed
-        'typo3_console:install:databasedata' => ['helhum.typo3console:database', 'helhum.typo3console:persistence'],
-        'typo3_console:install:defaultconfiguration' => ['helhum.typo3console:database', 'helhum.typo3console:persistence'],
-        'typo3_console:database:updateschema' => ['helhum.typo3console:database', 'helhum.typo3console:persistence'],
-    ],
-    'replace' => [
-        'backend:backend:lock',
-        'backend:backend:unlock',
-        'backend:referenceindex:update',
-        'extbase:_core_command',
-        'extbase:_extbase_help',
-        'extensionmanager:extension:dumpclassloadinginformation',
-        'extensionmanager:extension:install',
-        'extensionmanager:extension:uninstall',
-        'help:error',
-        'scheduler:scheduler:run',
+    'commands' => [
+        '_dummy' => [
+            'vendor' => 'typo3_console',
+            'replace' => [
+                'extbase:_core_command',
+                'extbase:_extbase_help',
+                'extbase:help:error',
+                'typo3_console:_dummy',
+            ],
+        ],
+        'backend:createadmin' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\BackendCommandController::class,
+            'controllerCommandName' => 'createAdmin',
+        ],
+        'backend:lock' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\BackendCommandController::class,
+            'controllerCommandName' => 'lock',
+            'replace' => [
+                'backend:backend:lock',
+            ],
+        ],
+        'backend:lockforeditors' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\BackendCommandController::class,
+            'controllerCommandName' => 'lockForEditors',
+        ],
+        'backend:unlock' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\BackendCommandController::class,
+            'controllerCommandName' => 'unlock',
+            'replace' => [
+                'backend:backend:unlock',
+            ],
+        ],
+        'backend:unlockforeditors' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\BackendCommandController::class,
+            'controllerCommandName' => 'unlockForEditors',
+        ],
+        'cache:flush' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\CacheCommandController::class,
+            'controllerCommandName' => 'flush',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
+        'cache:flushcomplete' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\CacheCommandController::class,
+            'controllerCommandName' => 'flushComplete',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
+        ],
+        'cache:flushgroups' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\CacheCommandController::class,
+            'controllerCommandName' => 'flushGroups',
+        ],
+        'cache:flushtags' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\CacheCommandController::class,
+            'controllerCommandName' => 'flushTags',
+        ],
+        'cache:listgroups' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\CacheCommandController::class,
+            'controllerCommandName' => 'listGroups',
+        ],
+        'cleanup:updatereferenceindex' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\CleanupCommandController::class,
+            'controllerCommandName' => 'updateReferenceIndex',
+            'replace' => [
+                'backend:referenceindex:update',
+            ],
+            'aliases' => [
+                'backend:referenceindex:update',
+                'referenceindex:update',
+            ],
+        ],
+        'configuration:remove' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\ConfigurationCommandController::class,
+            'controllerCommandName' => 'remove',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
+        ],
+        'configuration:set' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\ConfigurationCommandController::class,
+            'controllerCommandName' => 'set',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
+        ],
+        'configuration:show' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\ConfigurationCommandController::class,
+            'controllerCommandName' => 'show',
+        ],
+        'configuration:showactive' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\ConfigurationCommandController::class,
+            'controllerCommandName' => 'showActive',
+        ],
+        'configuration:showlocal' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\ConfigurationCommandController::class,
+            'controllerCommandName' => 'showLocal',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
+        ],
+        'database:export' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\DatabaseCommandController::class,
+            'controllerCommandName' => 'export',
+        ],
+        'database:import' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\DatabaseCommandController::class,
+            'controllerCommandName' => 'import',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
+        ],
+        'database:updateschema' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\DatabaseCommandController::class,
+            'controllerCommandName' => 'updateSchema',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
+            'bootingSteps' => [
+                'helhum.typo3console:database',
+                'helhum.typo3console:persistence',
+            ],
+        ],
+        'documentation:generatexsd' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\DocumentationCommandController::class,
+            'controllerCommandName' => 'generateXsd',
+        ],
+        'extension:activate' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\ExtensionCommandController::class,
+            'controllerCommandName' => 'activate',
+            'replace' => [
+                'extensionmanager:extension:install',
+            ],
+            'aliases' => [
+                'extension:install',
+                'extensionmanager:extension:install',
+            ],
+        ],
+        'extension:deactivate' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\ExtensionCommandController::class,
+            'controllerCommandName' => 'deactivate',
+            'replace' => [
+                'extensionmanager:extension:uninstall',
+            ],
+            'aliases' => [
+                'extension:uninstall',
+                'extensionmanager:extension:uninstall',
+            ],
+        ],
+        'extension:dumpautoload' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\ExtensionCommandController::class,
+            'controllerCommandName' => 'dumpAutoload',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+            'replace' => [
+                'extensionmanager:extension:dumpclassloadinginformation',
+            ],
+            'aliases' => [
+                'extension:dumpclassloadinginformation',
+                'extensionmanager:extension:dumpclassloadinginformation',
+            ],
+        ],
+        'extension:list' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\ExtensionCommandController::class,
+            'controllerCommandName' => 'list',
+        ],
+        'extension:removeinactive' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\ExtensionCommandController::class,
+            'controllerCommandName' => 'removeInactive',
+        ],
+        'extension:setup' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\ExtensionCommandController::class,
+            'controllerCommandName' => 'setup',
+        ],
+        'extension:setupactive' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\ExtensionCommandController::class,
+            'controllerCommandName' => 'setupActive',
+        ],
+        'frontend:request' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\FrontendCommandController::class,
+            'controllerCommandName' => 'request',
+        ],
+        'install:setup' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\InstallCommandController::class,
+            'controllerCommandName' => 'setup',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
+        'install:generatepackagestates' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\InstallCommandController::class,
+            'controllerCommandName' => 'generatePackageStates',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
+        'install:fixfolderstructure' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\InstallCommandController::class,
+            'controllerCommandName' => 'fixFolderStructure',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
+        'install:extensionsetupifpossible' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\InstallCommandController::class,
+            'controllerCommandName' => 'extensionSetupIfPossible',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
+        'install:environmentandfolders' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\InstallCommandController::class,
+            'controllerCommandName' => 'environmentAndFolders',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
+        'install:databaseconnect' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\InstallCommandController::class,
+            'controllerCommandName' => 'databaseConnect',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
+        'install:databaseselect' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\InstallCommandController::class,
+            'controllerCommandName' => 'databaseSelect',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
+        'install:databasedata' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\InstallCommandController::class,
+            'controllerCommandName' => 'databaseData',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
+            'bootingSteps' => [
+                'helhum.typo3console:database',
+                'helhum.typo3console:persistence',
+            ],
+        ],
+        'install:defaultconfiguration' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\InstallCommandController::class,
+            'controllerCommandName' => 'defaultConfiguration',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
+            'bootingSteps' => [
+                'helhum.typo3console:database',
+                'helhum.typo3console:persistence',
+            ],
+        ],
+        'install:actionneedsexecution' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\InstallCommandController::class,
+            'controllerCommandName' => 'actionNeedsExecution',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
+        'scheduler:run' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\SchedulerCommandController::class,
+            'controllerCommandName' => 'run',
+            'replace' => [
+                'scheduler:scheduler:run',
+            ],
+        ],
+        'upgrade:all' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\UpgradeCommandController::class,
+            'controllerCommandName' => 'all',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
+        'upgrade:checkextensionconstraints' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\UpgradeCommandController::class,
+            'controllerCommandName' => 'checkExtensionConstraints',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
+        'upgrade:list' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\UpgradeCommandController::class,
+            'controllerCommandName' => 'list',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
+        'upgrade:wizard' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\UpgradeCommandController::class,
+            'controllerCommandName' => 'wizard',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
+        'upgrade:subprocess' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\UpgradeCommandController::class,
+            'controllerCommandName' => 'subProcess',
+        ],
+        'upgrade:checkextensioncompatibility' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\UpgradeCommandController::class,
+            'controllerCommandName' => 'checkExtensionCompatibility',
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        ],
     ],
 ];

--- a/Tests/Functional/Command/DatabaseCommandControllerTest.php
+++ b/Tests/Functional/Command/DatabaseCommandControllerTest.php
@@ -88,6 +88,19 @@ class DatabaseCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
+    public function schemaUpdateCanBePerformedWithoutAnyTablesAndShortName()
+    {
+        $this->backupDatabase();
+        $this->executeMysqlQuery('DROP DATABASE ' . getenv('TYPO3_INSTALL_DB_DBNAME'), false);
+        $this->executeMysqlQuery('CREATE DATABASE ' . getenv('TYPO3_INSTALL_DB_DBNAME'), false);
+        $output = $this->executeConsoleCommand('d:u', ['*']);
+        $this->assertContains('The following database schema updates were performed:', $output);
+        $this->restoreDatabase();
+    }
+
+    /**
+     * @test
+     */
     public function schemaUpdateShowsErrorMessageIfTheyOccur()
     {
         $this->installFixtureExtensionCode('ext_broken_sql');

--- a/Tests/Unit/Core/Booting/RunLevelTest.php
+++ b/Tests/Unit/Core/Booting/RunLevelTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Tests\Unit\Core\Booting;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Core\Booting\RunLevel;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Core\Bootstrap;
+
+class RunLevelTest extends TestCase
+{
+    public function runLevelIsCorrectlyDeterminedForCommandsDataProvider()
+    {
+        return [
+            'no namespace command' => [
+                [
+                    'foo' => RunLevel::LEVEL_COMPILE,
+                ],
+                'foo',
+                RunLevel::LEVEL_COMPILE,
+            ],
+            'Definition same as name' => [
+                [
+                    'foo:bar' => RunLevel::LEVEL_COMPILE,
+                ],
+                'foo:bar',
+                RunLevel::LEVEL_COMPILE,
+            ],
+            'Definition not present defaults to full' => [
+                [],
+                'foo:bar',
+                RunLevel::LEVEL_FULL,
+            ],
+            'Command with package name works' => [
+                [
+                    'package:foo:bar' => RunLevel::LEVEL_COMPILE,
+                ],
+                'package:foo:bar',
+                RunLevel::LEVEL_COMPILE,
+            ],
+            'Wildcard with package name works' => [
+                [
+                    'package:foo:*' => RunLevel::LEVEL_COMPILE,
+                ],
+                'package:foo:bar',
+                RunLevel::LEVEL_COMPILE,
+            ],
+            'Wildcard first works for wildcard command' => [
+                [
+                    'package:foo:*' => RunLevel::LEVEL_COMPILE,
+                    'package:foo:baz' => RunLevel::LEVEL_MINIMAL,
+                ],
+                'package:foo:bar',
+                RunLevel::LEVEL_COMPILE,
+            ],
+            'Wildcard first works for specific command' => [
+                [
+                    'package:foo:*' => RunLevel::LEVEL_COMPILE,
+                    'package:foo:baz' => RunLevel::LEVEL_MINIMAL,
+                ],
+                'package:foo:baz',
+                RunLevel::LEVEL_MINIMAL,
+            ],
+            'Wildcard last works for wildcard command' => [
+                [
+                    'package:foo:baz' => RunLevel::LEVEL_MINIMAL,
+                    'package:foo:*' => RunLevel::LEVEL_COMPILE,
+                ],
+                'package:foo:bar',
+                RunLevel::LEVEL_COMPILE,
+            ],
+            'Wildcard last works for specific command' => [
+                [
+                    'package:foo:baz' => RunLevel::LEVEL_MINIMAL,
+                    'package:foo:*' => RunLevel::LEVEL_COMPILE,
+                ],
+                'package:foo:baz',
+                RunLevel::LEVEL_MINIMAL,
+            ],
+            'Wildcard without package name works' => [
+                ['foo:*' => RunLevel::LEVEL_COMPILE],
+                'foo:bar',
+                RunLevel::LEVEL_COMPILE,
+            ],
+        ];
+    }
+
+    /**
+     * @param array $definitions
+     * @param string $requestedCommand
+     * @param string $expectedRunlevel
+     * @test
+     * @dataProvider runLevelIsCorrectlyDeterminedForCommandsDataProvider
+     */
+    public function runLevelIsCorrectlyDeterminedForCommands(array $definitions, string $requestedCommand, string $expectedRunlevel)
+    {
+        $bootstrapMock = $this->getMockBuilder(Bootstrap::class)->disableOriginalConstructor()->getMock();
+        $subject = new RunLevel($bootstrapMock);
+        foreach ($definitions as $definition => $runLevel) {
+            $subject->setRunLevelForCommand($definition, $runLevel);
+        }
+
+        $this->assertSame($expectedRunlevel, $subject->getRunLevelForCommand($requestedCommand));
+    }
+}

--- a/Tests/Unit/Fixtures/Command/TestCommandController.php
+++ b/Tests/Unit/Fixtures/Command/TestCommandController.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Tests\Unit\Fixtures\Command;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+class TestCommandController
+{
+    public function helloCommand()
+    {
+    }
+}

--- a/Tests/Unit/Mvc/Cli/CommandConfigurationTest.php
+++ b/Tests/Unit/Mvc/Cli/CommandConfigurationTest.php
@@ -1,0 +1,182 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Unit\Mvc\Cli;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Mvc\Cli\CommandConfiguration;
+use Helhum\Typo3Console\Tests\Unit\Fixtures\Command\TestCommandController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\RuntimeException;
+
+class CommandConfigurationTest extends TestCase
+{
+    public function validationThrowsExceptionOnInvalidRegistrationDataProvider()
+    {
+        return [
+            'commands not an array' => [
+                [
+                    'commands' => '',
+                ],
+            ],
+            'controllers not an array' => [
+                [
+                    'controllers' => '',
+                ],
+            ],
+            'runLevels not an array' => [
+                [
+                    'runLevels' => '',
+                ],
+            ],
+            'bootingSteps not an array' => [
+                [
+                    'bootingSteps' => '',
+                ],
+            ],
+            'replace not an array' => [
+                [
+                    'replace' => '',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array $configuration
+     * @test
+     * @dataProvider validationThrowsExceptionOnInvalidRegistrationDataProvider
+     */
+    public function validationThrowsExceptionOnInvalidRegistration(array $configuration)
+    {
+        $this->expectException(RuntimeException::class);
+        CommandConfiguration::ensureValidCommandRegistration($configuration, 'foo');
+    }
+
+    /**
+     * @test
+     */
+    public function unifyCommandConfigurationMovesGlobalOptionsToCommandConfiguration()
+    {
+        $expected = [
+            'bar:baz' => [
+                'class' => 'bla',
+                'vendor' => 'foobar',
+                'runLevel' => 'normal',
+                'bootingSteps' => ['one'],
+                'replace' => ['replaced:command'],
+            ],
+        ];
+        $actual = CommandConfiguration::unifyCommandConfiguration(
+            [
+                'commands' => [
+                    'bar:baz' => [
+                        'class' => 'bla',
+                        'vendor' => 'foobar',
+                    ],
+                ],
+                'runLevels' => [
+                    'bar:baz' => 'normal',
+                ],
+                'bootingSteps' => [
+                    'bar:baz' => ['one'],
+                ],
+                'replace' => [
+                    'replaced:command',
+                ],
+            ],
+            'foo'
+        );
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function unifyCommandConfigurationMovesGlobalRunLevelOptionsToCommandConfigurationDataProvider()
+    {
+        return [
+            'command matches' => [
+                'foo:bar',
+                ['foo:bar' => 'normal'],
+            ],
+            'name spaced name in run level' => [
+                'foo:bar',
+                ['baz:foo:bar' => 'normal'],
+            ],
+            'name spaced collection in run level, command name not matching' => [
+                'foo:bar',
+                ['baz:foo:bla' => 'wrong', 'baz:foo:*' => 'normal'],
+            ],
+            'name spaced collection first in run level, command name not matching' => [
+                'foo:bar',
+                ['baz:foo:*' => 'normal', 'baz:foo:bla' => 'wrong'],
+            ],
+            'name spaced collection in run level, command name matching' => [
+                'foo:bla',
+                ['baz:foo:bla' => 'normal', 'baz:foo:*' => 'wrong'],
+            ],
+            'name spaced collection first in run level, command name matching' => [
+                'foo:bla',
+                ['baz:foo:*' => 'wrong', 'baz:foo:bla' => 'normal'],
+            ],
+        ];
+    }
+
+    /**
+     * @param string $commandName
+     * @param array $runLevels
+     * @test
+     * @dataProvider unifyCommandConfigurationMovesGlobalRunLevelOptionsToCommandConfigurationDataProvider
+     */
+    public function unifyCommandConfigurationMovesGlobalRunLevelOptionsToCommandConfiguration(string $commandName, array $runLevels)
+    {
+        $expected = [
+            $commandName => [
+                'vendor' => 'baz',
+                'runLevel' => 'normal',
+            ],
+        ];
+        $actual = CommandConfiguration::unifyCommandConfiguration(
+            [
+                'commands' => [
+                    $commandName => [
+                    ],
+                ],
+                'runLevels' => $runLevels,
+            ],
+            'baz'
+        );
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function commandControllerCommandsAreResolved()
+    {
+        $expected = [
+            'test:hello' => [
+                'vendor' => 'typo3_console',
+                'controller' => TestCommandController::class,
+                'controllerCommandName' => 'hello',
+            ],
+        ];
+        $actual = CommandConfiguration::unifyCommandConfiguration(
+            [
+                'controllers' => [TestCommandController::class],
+            ],
+            ''
+        );
+
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
   - IF NOT EXIST c:\php mkdir c:\php
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
-  - IF NOT EXIST php-installed.txt curl -fsS -o php-%PHP_VERSION%-x86.zip http://windows.php.net/downloads/releases/archives/php-%PHP_VERSION%-x86.zip
+  - IF NOT EXIST php-installed.txt curl -fsS -o php-%PHP_VERSION%-x86.zip https://windows.php.net/downloads/releases/archives/php-%PHP_VERSION%-x86.zip
   - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%-x86.zip -y >nul
   - IF NOT EXIST php-installed.txt del /Q *.zip
   - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,7 @@
         <env name="TYPO3_INSTALL_DB_HOST" value="127.0.0.1" />
         <env name="TYPO3_INSTALL_DB_PASSWORD" value="" />
         <env name="TYPO3_INSTALL_DB_DBNAME" value="travis_console_test" />
-        <env name="TYPO3_VERSION" value="^8.7" />
+        <env name="TYPO3_VERSION" value="^9.1" />
     </php>
     <testsuites>
         <testsuite name="TYPO3 Console Unit Tests">


### PR DESCRIPTION
I order to be able get rid of Configuration/Console/Commands.php
in the future, we now unify command registration.

All commands can now be registered with

"command:name" => [
	// Command configuration
]

This includes also commands from command controllers.

Run level, booting steps, replaces, aliases and vendor name
are now part of this configuration. All these are optional
with proper defaults in case they are missing.

Defaults are:

runLevel: full
booting steps: none
replaces: none
aliases: none
vendor name: package name (or extension key for TYPO3 extensions)

This allows to specify arbitrary aliases also for
command controller commands. Even different command names would be possible.

Old registration and command controllers registered in
$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers']
still work, as their registration is migrated to the new format.

Because this migrated configuration is merged with existing new configuration,
it is possible to just supply some command controller commands with aliases,
while not having to register every single command.

However all commands within TYPO3 Console are converted to the
new format. This will make the transition to native Symfony commands
much easier, because now every single command is registered.

Fixes: #684