### PR TITLE
[BUGFIX] Harden class loading in non composer mode

### DIFF
--- a/Classes/Console/Core/Kernel.php
+++ b/Classes/Console/Core/Kernel.php
@@ -60,9 +60,6 @@ class Kernel
         $this->bootstrap->initializeClassLoader($classLoader);
         // Initialize basic annotation loader until TYPO3 does so as well
         AnnotationRegistry::registerLoader('class_exists');
-
-        // We need to be sure all classes can be loaded in non composer mode as early as possible
-        $this->initializeNonComposerClassLoading();
         $this->runLevel = new RunLevel($this->bootstrap);
     }
 
@@ -81,29 +78,6 @@ class Kernel
         if (ini_get('max_execution_time') !== '0') {
             @ini_set('max_execution_time', '0');
         }
-    }
-
-    /**
-     * Register auto loading for our own classes in case we cannot rely on composer class loading.
-     */
-    private function initializeNonComposerClassLoading()
-    {
-        if (Bootstrap::usesComposerClassLoading()) {
-            return;
-        }
-        $extensionBaseDir = dirname(__DIR__, 3) . '/';
-        $autoloadDefinition = json_decode(file_get_contents($extensionBaseDir . 'composer.json'), true)['autoload']['psr-4'];
-        foreach ($autoloadDefinition as $prefix => $paths) {
-            $paths = array_map(
-                function ($path) use ($extensionBaseDir) {
-                    return $extensionBaseDir . $path;
-                },
-                (array)$paths
-            );
-            $this->classLoader->addPsr4($prefix, $paths);
-        }
-        $pharFile = __DIR__ . '/../../../Libraries/symfony-process.phar';
-        require 'phar://' . $pharFile . '/vendor/autoload.php';
     }
 
     /**

--- a/Resources/Private/ExtensionArtifacts/autoload.php
+++ b/Resources/Private/ExtensionArtifacts/autoload.php
@@ -1,0 +1,26 @@
+<?php
+return (function () {
+    static $classLoader;
+    if ($classLoader) {
+        return $classLoader;
+    }
+
+    $typo3AutoLoadFile = realpath(($rootPath = dirname(__DIR__, 6)) . '/typo3') . '/../vendor/autoload.php';
+    putenv('TYPO3_PATH_ROOT=' . $rootPath);
+    $classLoader = require $typo3AutoLoadFile;
+
+    $extensionBaseDir = dirname(__DIR__, 3) . '/';
+    $autoloadDefinition = json_decode(file_get_contents($extensionBaseDir . 'composer.json'), true)['autoload']['psr-4'];
+    foreach ($autoloadDefinition as $prefix => $paths) {
+        $paths = array_map(
+            function ($path) use ($extensionBaseDir) {
+                return $extensionBaseDir . $path;
+            },
+            (array)$paths
+        );
+        $classLoader->addPsr4($prefix, $paths);
+    }
+    $pharFile = __DIR__ . '/../../../Libraries/symfony-process.phar';
+    require 'phar://' . $pharFile . '/vendor/autoload.php';
+    return $classLoader;
+})();

--- a/Resources/Private/ExtensionArtifacts/ext_emconf.php
+++ b/Resources/Private/ExtensionArtifacts/ext_emconf.php
@@ -29,4 +29,6 @@ $EM_CONF[$_EXTKEY] = [
     'suggests' => [
     ],
   ],
+  'autoload' => [
+  ],
 ];

--- a/Resources/Private/ExtensionArtifacts/ext_localconf.php
+++ b/Resources/Private/ExtensionArtifacts/ext_localconf.php
@@ -3,6 +3,7 @@ defined('TYPO3_MODE') or die('Access denied.');
 
 (function () {
     if ((TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_CLI) || (TYPO3_MODE === 'BE' && isset($_GET['M']) && 'tools_ExtensionmanagerExtensionmanager' === $_GET['M'])) {
+        require \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('typo3_console') . 'Resources/Private/ExtensionArtifacts/autoload.php';
         $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
         $signalSlotDispatcher->connect(
             \TYPO3\CMS\Extensionmanager\Utility\InstallUtility::class,

--- a/Scripts/typo3-console.php
+++ b/Scripts/typo3-console.php
@@ -6,20 +6,14 @@
     } elseif (file_exists($vendorAutoLoadFile = dirname(dirname(dirname(__DIR__))) . '/autoload.php')) {
         // Console is a dependency, thus located in vendor/helhum/typo3-console
         $classLoader = require $vendorAutoLoadFile;
-    } elseif (file_exists($typo3AutoLoadFile = realpath(($rootPath = dirname(dirname(dirname(dirname(__DIR__))))) . '/typo3') . '/../vendor/autoload.php')) {
+    } elseif (file_exists($typo3AutoLoadFile = __DIR__ . '/../Resources/Private/ExtensionArtifacts/autoload.php')) {
         // Console is extension
-        putenv('TYPO3_PATH_ROOT=' . $rootPath);
         $classLoader = require $typo3AutoLoadFile;
     } else {
-        echo 'Could not find autoload.php file. Is TYPO3_PATH_ROOT specified correctly?' . PHP_EOL;
+        echo 'Could not find autoload.php file. TYPO3 Console needs to be installed with composer' . PHP_EOL;
         exit(1);
     }
 
-    if (!class_exists(\Helhum\Typo3Console\Core\Kernel::class)) {
-        // This require is needed so that the console works in non Composer mode,
-        // where requiring the main autoload.php is not enough to load extension classes
-        require __DIR__ . '/../Classes/Core/Kernel.php';
-    }
     $kernel = new \Helhum\Typo3Console\Core\Kernel($classLoader);
     $exitCode = $kernel->handle(new \Helhum\Typo3Console\Mvc\Cli\Symfony\Input\ArgvInput());
     $kernel->terminate($exitCode);


### PR DESCRIPTION
We now always add our class prefixes to the main
class loader and disable other registration for
console classes.

This helps to fix an edge case where old class loading
info has overwritten what was added before.

While doing so, all non composer class loading code
is extracted to a autoload.php file, which is only
loaded when console is not installed with composer.

With that, we can remove remaining class_exists and
one composer mode check from bootstrap.

Fixes: #667