### PR TITLE
[TASK] Add declare strict types everywhere

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -11,6 +11,7 @@ return PhpCsFixer\Config::create()
         'concat_space' => [
             'spacing' => 'one',
         ],
+        'declare_strict_types' => true,
         'function_typehint_space' => true,
         'hash_to_slash_comment' => true,
         'linebreak_after_opening_tag' => true,
@@ -84,5 +85,6 @@ return PhpCsFixer\Config::create()
             ->exclude('Documentation')
             ->exclude('Libraries')
             ->notName('ext_emconf.php')
+            ->notName('ext_localconf.php')
             ->notName('ComposerPackagesCommands.php')
     );

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -5,6 +5,7 @@ enabled:
   - binary_operator_spaces
   - blank_line_before_return
   - concat_with_spaces
+  - declare_strict_types
   - function_typehint_space
   - hash_to_slash_comment
   - linebreak_after_opening_tag
@@ -67,4 +68,5 @@ finder:
     - "Libraries"
   not-name:
     - "ext_emconf.php"
+    - "ext_localconf.php"
     - "ComposerPackagesCommands.php"

--- a/Classes/Compatibility/TYPO3v87/Core/Booting/CompatibilityScripts.php
+++ b/Classes/Compatibility/TYPO3v87/Core/Booting/CompatibilityScripts.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\TYPO3v87\Core\Booting;
 
 /*

--- a/Classes/Compatibility/TYPO3v87/Install/CliMessageRenderer.php
+++ b/Classes/Compatibility/TYPO3v87/Install/CliMessageRenderer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\TYPO3v87\Install;
 
 /*

--- a/Classes/Compatibility/TYPO3v87/Install/InstallStepActionExecutor.php
+++ b/Classes/Compatibility/TYPO3v87/Install/InstallStepActionExecutor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\TYPO3v87\Install;
 
 /*

--- a/Classes/Compatibility/TYPO3v87/Install/Upgrade/SilentConfigurationUpgrade.php
+++ b/Classes/Compatibility/TYPO3v87/Install/Upgrade/SilentConfigurationUpgrade.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\TYPO3v87\Install\Upgrade;
 
 /*

--- a/Classes/Compatibility/TYPO3v91/Core/Booting/CompatibilityScripts.php
+++ b/Classes/Compatibility/TYPO3v91/Core/Booting/CompatibilityScripts.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\TYPO3v91\Core\Booting;
 
 /*

--- a/Classes/Console/Command/CacheCommandController.php
+++ b/Classes/Console/Command/CacheCommandController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Command;
 
 /*

--- a/Classes/Console/Command/CleanupCommandController.php
+++ b/Classes/Console/Command/CleanupCommandController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Command;
 
 /*

--- a/Classes/Console/Command/ConfigurationCommandController.php
+++ b/Classes/Console/Command/ConfigurationCommandController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Command;
 
 /*

--- a/Classes/Console/Command/DatabaseCommandController.php
+++ b/Classes/Console/Command/DatabaseCommandController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Command;
 
 /*

--- a/Classes/Console/Command/Delegation/ReferenceIndexUpdateDelegate.php
+++ b/Classes/Console/Command/Delegation/ReferenceIndexUpdateDelegate.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Command\Delegation;
 
 /*

--- a/Classes/Console/Command/DocumentationCommandController.php
+++ b/Classes/Console/Command/DocumentationCommandController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Command;
 
 /*

--- a/Classes/Console/Command/ExtensionCommandController.php
+++ b/Classes/Console/Command/ExtensionCommandController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Command;
 
 /*

--- a/Classes/Console/Command/FrontendCommandController.php
+++ b/Classes/Console/Command/FrontendCommandController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Command;
 
 /*

--- a/Classes/Console/Command/HelpCommandController.php
+++ b/Classes/Console/Command/HelpCommandController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Command;
 
 /*

--- a/Classes/Console/Command/InstallCommandController.php
+++ b/Classes/Console/Command/InstallCommandController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Command;
 
 /*

--- a/Classes/Console/Command/SchedulerCommandController.php
+++ b/Classes/Console/Command/SchedulerCommandController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Command;
 
 /*

--- a/Classes/Console/Command/UpgradeCommandController.php
+++ b/Classes/Console/Command/UpgradeCommandController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Command;
 
 /*

--- a/Classes/Console/Core/Booting/CompatibilityScripts.php
+++ b/Classes/Console/Core/Booting/CompatibilityScripts.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Core\Booting;
 
 /*

--- a/Classes/Console/Core/Booting/Scripts.php
+++ b/Classes/Console/Core/Booting/Scripts.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Core\Booting;
 
 /*

--- a/Classes/Console/Core/Booting/Sequence.php
+++ b/Classes/Console/Core/Booting/Sequence.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Core\Booting;
 
 /*

--- a/Classes/Console/Core/Booting/Step.php
+++ b/Classes/Console/Core/Booting/Step.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Core\Booting;
 
 /*

--- a/Classes/Console/Core/Cache/FakeDatabaseBackend.php
+++ b/Classes/Console/Core/Cache/FakeDatabaseBackend.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Core\Cache;
 
 /*

--- a/Classes/Console/Core/Kernel.php
+++ b/Classes/Console/Core/Kernel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Core;
 
 /*

--- a/Classes/Console/Database/Configuration/ConnectionConfiguration.php
+++ b/Classes/Console/Database/Configuration/ConnectionConfiguration.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Database\Configuration;
 
 /*

--- a/Classes/Console/Database/Schema/SchemaUpdate.php
+++ b/Classes/Console/Database/Schema/SchemaUpdate.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Database\Schema;
 
 /*

--- a/Classes/Console/Database/Schema/SchemaUpdateInterface.php
+++ b/Classes/Console/Database/Schema/SchemaUpdateInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Database\Schema;
 
 /*

--- a/Classes/Console/Database/Schema/SchemaUpdateResult.php
+++ b/Classes/Console/Database/Schema/SchemaUpdateResult.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Database\Schema;
 
 /*

--- a/Classes/Console/Database/Schema/SchemaUpdateResultRenderer.php
+++ b/Classes/Console/Database/Schema/SchemaUpdateResultRenderer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Database\Schema;
 
 /*

--- a/Classes/Console/Database/Schema/SchemaUpdateResultRenderer.php
+++ b/Classes/Console/Database/Schema/SchemaUpdateResultRenderer.php
@@ -75,8 +75,8 @@ class SchemaUpdateResultRenderer
     public function renderErrors(SchemaUpdateResult $result, ConsoleOutput $output, $includeStatements = false, $maxStatementLength = 90)
     {
         $tableRows = [];
-        $messageLength = $includeStatements ? $maxStatementLength * .3 : $maxStatementLength;
-        $statementLength = $maxStatementLength * 0.6;
+        $messageLength = $includeStatements ? (int)($maxStatementLength * .3) : $maxStatementLength;
+        $statementLength = (int)($maxStatementLength * 0.6);
         foreach ($result->getErrors() as $type => $errors) {
             $typeLabel = self::$schemaUpdateTypeLabels[(string)$type];
             foreach ($errors as $error) {
@@ -103,7 +103,7 @@ class SchemaUpdateResultRenderer
      * @param int $truncateAt
      * @return array
      */
-    protected function getTruncatedQueries(array $queries, $truncateAt)
+    protected function getTruncatedQueries(array $queries, int $truncateAt): array
     {
         foreach ($queries as &$query) {
             $truncatedLines = [];

--- a/Classes/Console/Database/Schema/SchemaUpdateType.php
+++ b/Classes/Console/Database/Schema/SchemaUpdateType.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Database\Schema;
 
 /*

--- a/Classes/Console/Error/ErrorHandler.php
+++ b/Classes/Console/Error/ErrorHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Error;
 
 /*

--- a/Classes/Console/Error/ExceptionHandler.php
+++ b/Classes/Console/Error/ExceptionHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Error;
 
 /*

--- a/Classes/Console/Error/ExceptionRenderer.php
+++ b/Classes/Console/Error/ExceptionRenderer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Error;
 
 /*

--- a/Classes/Console/Exception.php
+++ b/Classes/Console/Exception.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console;
 
 /*

--- a/Classes/Console/Extension/ExtensionCompatibilityCheck.php
+++ b/Classes/Console/Extension/ExtensionCompatibilityCheck.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Extension;
 
 /*

--- a/Classes/Console/Extension/ExtensionConstraintCheck.php
+++ b/Classes/Console/Extension/ExtensionConstraintCheck.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Extension;
 
 /*

--- a/Classes/Console/Extension/ExtensionSetup.php
+++ b/Classes/Console/Extension/ExtensionSetup.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Extension;
 
 /*

--- a/Classes/Console/Extension/ExtensionSetupResultRenderer.php
+++ b/Classes/Console/Extension/ExtensionSetupResultRenderer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Extension;
 
 /*

--- a/Classes/Console/Install/CliMessageRenderer.php
+++ b/Classes/Console/Install/CliMessageRenderer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Install;
 
 /*

--- a/Classes/Console/Install/CliSetupRequestHandler.php
+++ b/Classes/Console/Install/CliSetupRequestHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Install;
 
 /*

--- a/Classes/Console/Install/FolderStructure/ExtensionFactory.php
+++ b/Classes/Console/Install/FolderStructure/ExtensionFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Install\FolderStructure;
 
 /*

--- a/Classes/Console/Install/InstallStepActionExecutor.php
+++ b/Classes/Console/Install/InstallStepActionExecutor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Install;
 
 /*

--- a/Classes/Console/Install/InstallStepActionExecutor.php
+++ b/Classes/Console/Install/InstallStepActionExecutor.php
@@ -72,12 +72,12 @@ class InstallStepActionExecutor
         $messages = [];
         $needsExecution = file_exists(PATH_site . 'FIRST_INSTALL');
         if (is_callable([$this->installerController, $checkMethod])) {
-            $needsExecution = !\json_decode($this->installerController->$checkMethod()->getBody(), true)['success'];
+            $needsExecution = !\json_decode((string)$this->installerController->$checkMethod()->getBody(), true)['success'];
         }
         if ($needsExecution && !$dryRun) {
             $request = ($this->requestFactory)($arguments);
             try {
-                $response = \json_decode($this->installerController->$actionMethod($request)->getBody(), true);
+                $response = \json_decode((string)$this->installerController->$actionMethod($request)->getBody(), true);
                 if (!$response['success']) {
                     $messages = $response['status'];
                 }

--- a/Classes/Console/Install/InstallStepResponse.php
+++ b/Classes/Console/Install/InstallStepResponse.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Install;
 
 /*

--- a/Classes/Console/Install/PackageStatesGenerator.php
+++ b/Classes/Console/Install/PackageStatesGenerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Install;
 
 /*

--- a/Classes/Console/Install/Upgrade/SilentConfigurationUpgrade.php
+++ b/Classes/Console/Install/Upgrade/SilentConfigurationUpgrade.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Install\Upgrade;
 
 /*

--- a/Classes/Console/Install/Upgrade/UpgradeWizardList.php
+++ b/Classes/Console/Install/Upgrade/UpgradeWizardList.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Install\Upgrade;
 
 /*

--- a/Classes/Console/Install/Upgrade/UpgradeWizardListRenderer.php
+++ b/Classes/Console/Install/Upgrade/UpgradeWizardListRenderer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Install\Upgrade;
 
 /*

--- a/Classes/Console/Install/Upgrade/UpgradeWizardResult.php
+++ b/Classes/Console/Install/Upgrade/UpgradeWizardResult.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Install\Upgrade;
 
 /*

--- a/Classes/Console/Install/Upgrade/UpgradeWizardResultRenderer.php
+++ b/Classes/Console/Install/Upgrade/UpgradeWizardResultRenderer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Install\Upgrade;
 
 /*

--- a/Classes/Console/Log/Writer/ConsoleWriter.php
+++ b/Classes/Console/Log/Writer/ConsoleWriter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Log\Writer;
 
 /*

--- a/Classes/Console/Mvc/Cli/FailedSubProcessCommandException.php
+++ b/Classes/Console/Mvc/Cli/FailedSubProcessCommandException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Mvc\Cli;
 
 /*

--- a/Classes/Console/Mvc/Cli/InteractiveProcess.php
+++ b/Classes/Console/Mvc/Cli/InteractiveProcess.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Mvc\Cli;
 
 /*

--- a/Classes/Console/Mvc/Cli/RequestHandler.php
+++ b/Classes/Console/Mvc/Cli/RequestHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Mvc\Cli;
 
 /*

--- a/Classes/Console/Mvc/Cli/SubProcessException.php
+++ b/Classes/Console/Mvc/Cli/SubProcessException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Mvc\Cli;
 
 /*

--- a/Classes/Console/Mvc/Cli/Symfony/Command/HelpCommand.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Command/HelpCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Mvc\Cli\Symfony\Command;
 
 /*

--- a/Classes/Console/Mvc/Cli/Symfony/Descriptor/TextDescriptor.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Descriptor/TextDescriptor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Mvc\Cli\Symfony\Descriptor;
 
 /*

--- a/Classes/Console/Mvc/Controller/CommandController.php
+++ b/Classes/Console/Mvc/Controller/CommandController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Mvc\Controller;
 
 /*

--- a/Classes/Console/Package/UncachedPackageManager.php
+++ b/Classes/Console/Package/UncachedPackageManager.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Package;
 
 /*

--- a/Classes/Console/Parser/ParsedClass.php
+++ b/Classes/Console/Parser/ParsedClass.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Parser;
 
 /*

--- a/Classes/Console/Parser/ParsingException.php
+++ b/Classes/Console/Parser/ParsingException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Parser;
 
 /*

--- a/Classes/Console/Parser/PhpParser.php
+++ b/Classes/Console/Parser/PhpParser.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Parser;
 
 /*

--- a/Classes/Console/Parser/PhpParserInterface.php
+++ b/Classes/Console/Parser/PhpParserInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Parser;
 
 /*

--- a/Classes/Console/Property/TypeConverter/ArrayConverter.php
+++ b/Classes/Console/Property/TypeConverter/ArrayConverter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Property\TypeConverter;
 
 /*

--- a/Classes/Console/Service/CacheLowLevelCleaner.php
+++ b/Classes/Console/Service/CacheLowLevelCleaner.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service;
 
 /*

--- a/Classes/Console/Service/CacheService.php
+++ b/Classes/Console/Service/CacheService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service;
 
 /*

--- a/Classes/Console/Service/Configuration/ConfigurationService.php
+++ b/Classes/Console/Service/Configuration/ConfigurationService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service\Configuration;
 
 /*

--- a/Classes/Console/Service/Configuration/ConfigurationValueNotFoundException.php
+++ b/Classes/Console/Service/Configuration/ConfigurationValueNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service\Configuration;
 
 /*

--- a/Classes/Console/Service/Configuration/ConsoleRenderer/ConsoleRenderer.php
+++ b/Classes/Console/Service/Configuration/ConsoleRenderer/ConsoleRenderer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service\Configuration\ConsoleRenderer;
 
 /*

--- a/Classes/Console/Service/Configuration/ConsoleRenderer/DiffConsoleRenderer.php
+++ b/Classes/Console/Service/Configuration/ConsoleRenderer/DiffConsoleRenderer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service\Configuration\ConsoleRenderer;
 
 /*

--- a/Classes/Console/Service/Configuration/TypesAreNotConvertibleException.php
+++ b/Classes/Console/Service/Configuration/TypesAreNotConvertibleException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service\Configuration;
 
 /*

--- a/Classes/Console/Service/Database/Exception.php
+++ b/Classes/Console/Service/Database/Exception.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service\Database;
 
 /*

--- a/Classes/Console/Service/Database/SchemaService.php
+++ b/Classes/Console/Service/Database/SchemaService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service\Database;
 
 /*

--- a/Classes/Console/Service/Delegation/ReferenceIndexIntegrityDelegateInterface.php
+++ b/Classes/Console/Service/Delegation/ReferenceIndexIntegrityDelegateInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service\Delegation;
 
 /*

--- a/Classes/Console/Service/Exception.php
+++ b/Classes/Console/Service/Exception.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service;
 
 /*

--- a/Classes/Console/Service/Persistence/PersistenceContext.php
+++ b/Classes/Console/Service/Persistence/PersistenceContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service\Persistence;
 
 /*

--- a/Classes/Console/Service/Persistence/PersistenceContextInterface.php
+++ b/Classes/Console/Service/Persistence/PersistenceContextInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service\Persistence;
 
 /*

--- a/Classes/Console/Service/Persistence/PersistenceIntegrityService.php
+++ b/Classes/Console/Service/Persistence/PersistenceIntegrityService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service\Persistence;
 
 /*

--- a/Classes/Console/Service/Persistence/TableDoesNotExistException.php
+++ b/Classes/Console/Service/Persistence/TableDoesNotExistException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service\Persistence;
 
 /*

--- a/Classes/Console/Service/XsdGenerator.php
+++ b/Classes/Console/Service/XsdGenerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Service;
 
 /*

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 return [
     'commands' => [
         '_dummy' => [

--- a/Packages/CreateReferenceCommand/Configuration/Console/Commands.php
+++ b/Packages/CreateReferenceCommand/Configuration/Console/Commands.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 return [
     'commands' => [
         'commandreference:render' => [

--- a/Packages/CreateReferenceCommand/src/Command/CommandReferenceRenderCommand.php
+++ b/Packages/CreateReferenceCommand/src/Command/CommandReferenceRenderCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Typo3Console\CreateReferenceCommand\Command;
 
 /*

--- a/Packages/CreateReferenceCommand/src/ViewHelpers/Format/IndentViewHelper.php
+++ b/Packages/CreateReferenceCommand/src/ViewHelpers/Format/IndentViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Typo3Console\CreateReferenceCommand\ViewHelpers\Format;
 
 /*

--- a/Packages/CreateReferenceCommand/src/ViewHelpers/Format/UnderlineViewHelper.php
+++ b/Packages/CreateReferenceCommand/src/ViewHelpers/Format/UnderlineViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Typo3Console\CreateReferenceCommand\ViewHelpers\Format;
 
 /*

--- a/Resources/Private/ExtensionArtifacts/autoload.php
+++ b/Resources/Private/ExtensionArtifacts/autoload.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 return (function () {
     static $classLoader;
     if ($classLoader) {

--- a/Resources/Private/ExtensionArtifacts/src/Hook/ExtensionInstallation.php
+++ b/Resources/Private/ExtensionArtifacts/src/Hook/ExtensionInstallation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Hook;
 
 /*

--- a/Scripts/typo3-console.php
+++ b/Scripts/typo3-console.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 (function () {
     if (file_exists($rootAutoLoadFile = dirname(__DIR__) . '/.Build/vendor/autoload.php')) {
         // Console is root package, thus vendor folder is .Build/vendor

--- a/Tests/Console/Functional/Command/AbstractCommandTest.php
+++ b/Tests/Console/Functional/Command/AbstractCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Functional\Command;
 
 /*

--- a/Tests/Console/Functional/Command/BackendCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/BackendCommandControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Functional\Command;
 
 /*

--- a/Tests/Console/Functional/Command/CacheCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/CacheCommandControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Functional\Command;
 
 /*

--- a/Tests/Console/Functional/Command/CleanupCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/CleanupCommandControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Functional\Command;
 
 /*

--- a/Tests/Console/Functional/Command/ConfigurationCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/ConfigurationCommandControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Functional\Command;
 
 /*

--- a/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Functional\Command;
 
 /*

--- a/Tests/Console/Functional/Command/DocumentationCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/DocumentationCommandControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Functional\Command;
 
 /*

--- a/Tests/Console/Functional/Command/ExtensionCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/ExtensionCommandControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Functional\Command;
 
 /*

--- a/Tests/Console/Functional/Command/FrontendCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/FrontendCommandControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Functional\Command;
 
 /*

--- a/Tests/Console/Functional/Command/HelpCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/HelpCommandControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Functional\Command;
 
 /*

--- a/Tests/Console/Functional/Command/Install/InstallCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/Install/InstallCommandControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Functional\Command\Install;
 
 /*

--- a/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Functional\Command;
 
 /*

--- a/Tests/Console/Unit/Command/FrontendCommandControllerTest.php
+++ b/Tests/Console/Unit/Command/FrontendCommandControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace  Helhum\Typo3Console\Tests\Unit\Command;
 
 use Helhum\Typo3Console\Command\FrontendCommandController;

--- a/Tests/Console/Unit/Database/Schema/SchemaUpdateTypeTest.php
+++ b/Tests/Console/Unit/Database/Schema/SchemaUpdateTypeTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Unit\Database\Schema;
 
 /*

--- a/Tests/Console/Unit/Extension/ExtensionConstraintCheckTest.php
+++ b/Tests/Console/Unit/Extension/ExtensionConstraintCheckTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Unit\Extension;
 
 /*

--- a/Tests/Console/Unit/Install/InstallStepExecutorTest.php
+++ b/Tests/Console/Unit/Install/InstallStepExecutorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Unit\Install;
 
 /*

--- a/Tests/Console/Unit/Install/PackageStatesGeneratorTest.php
+++ b/Tests/Console/Unit/Install/PackageStatesGeneratorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Unit\Install;
 
 /*

--- a/Tests/Console/Unit/Install/Upgrade/Fixture/DummyUpgradeWizard.php
+++ b/Tests/Console/Unit/Install/Upgrade/Fixture/DummyUpgradeWizard.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture;
 
 /*

--- a/Tests/Console/Unit/Install/Upgrade/UpgradeWizardExecutorTest.php
+++ b/Tests/Console/Unit/Install/Upgrade/UpgradeWizardExecutorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Unit\Install\Upgrade;
 
 /*

--- a/Tests/Console/Unit/Install/Upgrade/UpgradeWizardFactoryTest.php
+++ b/Tests/Console/Unit/Install/Upgrade/UpgradeWizardFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Unit\Install\Upgrade;
 
 /*

--- a/Tests/Console/Unit/Mvc/Cli/CommandConfigurationTest.php
+++ b/Tests/Console/Unit/Mvc/Cli/CommandConfigurationTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Unit\Mvc\Cli;
 
 /*

--- a/Tests/Console/Unit/Parser/Fixtures/NamespacedClassFixture.php
+++ b/Tests/Console/Unit/Parser/Fixtures/NamespacedClassFixture.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Unit\Parser\Fixtures;
 
 /*

--- a/Tests/Console/Unit/Parser/Fixtures/NamespacedInterfaceFixture.php
+++ b/Tests/Console/Unit/Parser/Fixtures/NamespacedInterfaceFixture.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Unit\Parser\Fixtures;
 
 /*

--- a/Tests/Console/Unit/Parser/PhpParserTest.php
+++ b/Tests/Console/Unit/Parser/PhpParserTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Unit\Parser;
 
 /*

--- a/Tests/Console/Unit/Service/CacheServiceTest.php
+++ b/Tests/Console/Unit/Service/CacheServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Unit\Service;
 
 /*

--- a/Tests/Console/Unit/Service/Configuration/ConfigurationServiceTest.php
+++ b/Tests/Console/Unit/Service/Configuration/ConfigurationServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Helhum\Typo3Console\Tests\Unit\Service\Configuration;
 
 /*


### PR DESCRIPTION
Add fixer rule for that and apply it.
ext_localconf.php is excluded in .php_cs.dist, because
it would break TYPO3 after concatenation.

We therefore accept style violations in these files
from now on.