### PR TITLE
[BUGFIX] Fix extension:activate when extension defines caches

### DIFF
--- a/Classes/Console/Command/ExtensionCommandController.php
+++ b/Classes/Console/Command/ExtensionCommandController.php
@@ -96,8 +96,8 @@ class ExtensionCommandController extends CommandController
         }
 
         if (!empty($activatedExtensions)) {
-            $this->getExtensionInstaller()->reloadCaches();
             $this->cacheService->flush();
+            $this->getExtensionInstaller()->reloadCaches();
 
             $extensionKeysAsString = implode('", "', $activatedExtensions);
             if (count($activatedExtensions) === 1) {

--- a/Tests/Console/Functional/Fixtures/Extensions/ext_test/ext_localconf.php
+++ b/Tests/Console/Functional/Fixtures/Extensions/ext_test/ext_localconf.php
@@ -5,3 +5,7 @@ defined('TYPO3_MODE') or die();
     'ext_test',
     'tx_exttest_cattest'
 );
+
+if (empty($TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['test'])) {
+    $TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['test'] = [];
+}


### PR DESCRIPTION
Cache needs to be flushed before ext_localconf.php files
are loaded, because those can define new caches with
database backend, thus a cache:flush will try to flush those
without the tables being present.