### PR TITLE
[FEATURE] Add argument to select database connection

### DIFF
--- a/Classes/Console/Database/Process/MysqlCommand.php
+++ b/Classes/Console/Database/Process/MysqlCommand.php
@@ -86,7 +86,7 @@ class MysqlCommand
         $process = new Process($commandLine, null, null, null, 0.0);
         $process->inheritEnvironmentVariables();
 
-        echo sprintf('-- Dump of TYPO3 Connection "%s"', $connectionName) . chr(10);
+        echo  chr(10) . sprintf('-- Dump of TYPO3 Connection "%s"', $connectionName) . chr(10);
 
         return $process->run($this->buildDefaultOutputCallback($outputCallback));
     }

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -632,6 +632,14 @@ Options
 - Is multiple: no
 - Default: array ()
 
+``--connection``
+  TYPO3 database connection name (defaults to all configured MySQL connections)
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+
+
 
 
 
@@ -665,6 +673,14 @@ Options
 - Is value required: no
 - Is multiple: no
 - Default: false
+
+``--connection``
+  TYPO3 database connection name
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: 'Default'
 
 
 

--- a/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
@@ -137,6 +137,52 @@ class DatabaseCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
+    public function sqlCanBeImportedWithSpecifiedConnection()
+    {
+        $sql = 'SELECT username from be_users where username="_cli_";';
+        $output = $this->executeConsoleCommand('database:import', ['--connection', 'Default'], [], $sql);
+        $this->assertSame('_cli_', trim($output));
+    }
+
+    /**
+     * @test
+     */
+    public function databaseImportFailsWithNotExistingConnection()
+    {
+        $sql = 'SELECT username from be_users where username="_cli_";';
+        try {
+            $output = $this->commandDispatcher->executeCommand('database:import', ['--connection', 'foo'], [], $sql);
+        } catch (FailedSubProcessCommandException $e) {
+            $output = $e->getOutputMessage();
+        }
+        $this->assertContains('No suitable MySQL connection found for import', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function databaseExportFailsWithNotExistingConnection()
+    {
+        try {
+            $output = $this->commandDispatcher->executeCommand('database:export', ['--connection', 'foo']);
+        } catch (FailedSubProcessCommandException $e) {
+            $output = $e->getOutputMessage();
+        }
+        $this->assertContains('No MySQL connections found to export. Given connection "foo" is not configured as MySQL connection', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function databaseExportWorksWithGivenConnection()
+    {
+        $output = $this->executeConsoleCommand('database:export', ['--connection', 'Default']);
+        $this->assertContains('-- Dump of TYPO3 Connection "Default"', $output);
+    }
+
+    /**
+     * @test
+     */
     public function databaseExportCanExcludeTables()
     {
         $output = $this->executeConsoleCommand('database:export', ['--exclude-tables' => 'sys_log']);


### PR DESCRIPTION
Since TYPO3 v8 is it possible to use multiple databases in one TYPO3 installation. Every database became a connection (default: "Default"). With this new argument is it possible to export and import data from or to a defined connection.

**Example (import):** `ssh remote.server '/path/to/typo3cms database:export' | typo3cms database:import --connection="OtherDatabase"`
**Example (export):** `typo3cms database:export --connection="OtherDatabase"`