### PR TITLE
Improve fetching testing framework fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
   - if php -i | grep -q xdebug; then phpenv config-rm xdebug.ini; fi
   - mkdir -p .Build/external
   - git clone https://github.com/helhum/TYPO3-testing-framework.git .Build/external/nimut-testing-framework -b typo3-93-compat
+  - composer config repositories.testing-framework vcs .Build/external/nimut-testing-framework
 
 install:
   - export COMPOSER_ROOT_VERSION=5.3.2
@@ -129,7 +130,7 @@ jobs:
             sonar-scanner
           fi
 
-    - stage: publish in ter
+    - stage: 🚢 to TER
       if: tag IS present
       php: 7.0
       install: skip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,9 +29,6 @@ init:
   - SET PATH=c:\php\%PHP_VERSION%;"C:\Program Files\MySQL\MySQL Server 5.7\bin\";%PATH%
 
 install:
-  - md .Build
-  - md .Build\external
-  - git clone https://github.com/helhum/TYPO3-testing-framework.git .Build/external/nimut-testing-framework -b typo3-93-compat
   - mysql --version
   - IF NOT EXIST c:\php mkdir c:\php
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
@@ -53,6 +50,10 @@ install:
   - IF NOT EXIST php-installed.txt type nul >> php-installed.txt
 
   - cd c:\t3c
+  - md .Build
+  - md .Build\external
+  - git clone https://github.com/helhum/TYPO3-testing-framework.git .Build/external/nimut-testing-framework -b typo3-93-compat
+  - composer config repositories.testing-framework vcs .Build/external/nimut-testing-framework
   - composer require "typo3/cms-backend=%TYPO3_VERSION%" "typo3/cms-core=%TYPO3_VERSION%" "typo3/cms-extbase=%TYPO3_VERSION%" "typo3/cms-extensionmanager=%TYPO3_VERSION%" "typo3/cms-fluid=%TYPO3_VERSION%" "typo3/cms-frontend=%TYPO3_VERSION%" "typo3/cms-install=%TYPO3_VERSION%" "typo3/cms-saltedpasswords=%TYPO3_VERSION%" "typo3/cms-scheduler=%TYPO3_VERSION%" --prefer-dist --no-progress --ansi
   - git checkout .
 

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,14 @@
 {
-    "repositories": [
-        {
+    "repositories": {
+        "local": {
             "type": "path",
             "url": "Packages/*"
         },
-        {
+        "testing-framework": {
             "type": "vcs",
-            "url": ".Build/external/nimut-testing-framework/"
+            "url": "https://github.com/helhum/TYPO3-testing-framework.git"
         }
-    ],
+    },
     "name": "helhum/typo3-console",
     "description": "A reliable and powerful command line interface for TYPO3 CMS",
     "keywords": [


### PR DESCRIPTION
To not require a clone of the testing framework to be present
on local installs, we now change the repository url back
to the remote repository and change it back to the local
clone on travis and appveyor