### PR TITLE
[FEATURE] Rewrite TYPO3 setup process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,12 @@ notifications:
 
 # This is executed for all stages
 before_install:
-  - if php -i | grep -q xdebug; then phpenv config-rm xdebug.ini; fi
   - mkdir -p .Build/external
   - git clone https://github.com/helhum/TYPO3-testing-framework.git .Build/external/nimut-testing-framework -b typo3-93-compat
   - composer config repositories.testing-framework vcs .Build/external/nimut-testing-framework
 
 install:
+  - if php -i | grep -q xdebug; then phpenv config-rm xdebug.ini; fi
   - export COMPOSER_ROOT_VERSION=5.3.2
   - |
     composer require \
@@ -124,7 +124,7 @@ jobs:
         - git fetch --unshallow
         - export COMPOSER_ROOT_VERSION=5.3.2
         - composer install
-        - .Build/bin/phpunit --whitelist Classes --coverage-clover clover.xml --log-junit junit.xml
+        - .Build/bin/phpunit --whitelist Classes --coverage-clover .Build/clover.xml --log-junit .Build/junit.xml
         - >
           if [ -n "$SONAR_TOKEN" ]; then
             sonar-scanner

--- a/Classes/Compatibility/TYPO3v87/Install/CliMessageRenderer.php
+++ b/Classes/Compatibility/TYPO3v87/Install/CliMessageRenderer.php
@@ -31,6 +31,10 @@ class CliMessageRenderer
 
     public function render(array $messages)
     {
+        if (empty($messages)) {
+            return;
+        }
+
         $this->output->outputLine();
         foreach ($messages as $statusMessage) {
             $this->renderSingle($statusMessage);

--- a/Classes/Console/Annotation/Command/Definition/Option.php
+++ b/Classes/Console/Annotation/Command/Definition/Option.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Annotation\Command\Definition;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+/**
+ * @Annotation
+ * @Target({"METHOD"})
+ */
+class Option
+{
+    /**
+     * @var string
+     * @Required
+     */
+    public $name;
+}

--- a/Classes/Console/Install/Action/CommandsAction.php
+++ b/Classes/Console/Install/Action/CommandsAction.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Install\Action;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
+use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
+
+class CommandsAction implements InstallActionInterface
+{
+    /**
+     * @var CommandDispatcher
+     */
+    private $commandDispatcher;
+
+    /**
+     * @var ConsoleOutput
+     */
+    private $output;
+
+    public function setOutput(ConsoleOutput $output)
+    {
+        $this->output = $output;
+    }
+
+    public function setCommandDispatcher(CommandDispatcher $commandDispatcher)
+    {
+        $this->commandDispatcher = $commandDispatcher;
+    }
+
+    public function shouldExecute(array $actionDefinition, array $options = []): bool
+    {
+        return true;
+    }
+
+    public function execute(array $actionDefinition, array $options = []): bool
+    {
+        foreach ($actionDefinition['commands'] ?? [] as $commandDefinition) {
+            $this->commandDispatcher->executeCommand($commandDefinition['command'], $commandDefinition['arguments'] ?? []);
+        }
+
+        return true;
+    }
+}

--- a/Classes/Console/Install/Action/ExtensionSetupAction.php
+++ b/Classes/Console/Install/Action/ExtensionSetupAction.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Install\Action;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+class ExtensionSetupAction extends CommandsAction
+{
+    public function shouldExecute(array $actionDefinition, array $options = []): bool
+    {
+        return !isset($options['extensionSetup']) || $options['extensionSetup'];
+    }
+}

--- a/Classes/Console/Install/Action/InstallActionDispatcher.php
+++ b/Classes/Console/Install/Action/InstallActionDispatcher.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Install\Action;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Install\StepsConfig;
+use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
+use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
+use Helhum\Typo3Console\Mvc\Cli\Symfony\Output\TrackableOutput;
+use Symfony\Component\Console\Exception\RuntimeException;
+
+/**
+ * This class acts as facade for the install tool step actions.
+ * It glues together the execution of these actions with the user interaction on the command line
+ */
+class InstallActionDispatcher
+{
+    /**
+     * @var ConsoleOutput
+     */
+    private $output;
+
+    /**
+     * @var StepsConfig
+     */
+    private $stepsConfig;
+
+    /**
+     * @var InstallActionFactory
+     */
+    private $installActionFactory;
+
+    public function __construct(
+        ConsoleOutput $output = null,
+        CommandDispatcher $commandDispatcher = null,
+        StepsConfig $stepsConfig = null,
+        InstallActionFactory $installActionFactory = null
+    ) {
+        $this->output = $output ?: new ConsoleOutput();
+        $commandDispatcher = $commandDispatcher ?: CommandDispatcher::createFromCommandRun();
+        $this->stepsConfig = $stepsConfig ?: new StepsConfig();
+        $this->installActionFactory = $installActionFactory ?: new InstallActionFactory($this->output, $commandDispatcher);
+    }
+
+    public function dispatch(array $givenArguments, array $options = [], string $stepsConfigFile = null)
+    {
+        $installSteps = $this->stepsConfig->getInstallSteps($stepsConfigFile);
+        $interactiveSetup = $options['interactive'] ?? $this->output->getSymfonyConsoleInput()->isInteractive();
+        $consoleOutput = $this->output->getSymfonyConsoleOutput();
+
+        foreach ($installSteps as $actionName => $actionDefinition) {
+            $skipAction = $actionDefinition['skip'] ?? false;
+            if ($skipAction) {
+                continue;
+            }
+
+            $action = $this->installActionFactory->create($actionDefinition['type']);
+            $success = true;
+            $errorCount = 0;
+            $options['actionName'] = $actionName;
+            $options['givenArguments'] = $givenArguments;
+
+            do {
+                $this->output->outputLine(sprintf('➤ <info>%s</info>', $actionDefinition['description'] ?? $actionName));
+                $consoleOutput->startTracking();
+
+                $shouldExecute = $action->shouldExecute($actionDefinition, $options);
+                if ($shouldExecute) {
+                    $success = $action->execute($actionDefinition, $options);
+                }
+
+                if (!$interactiveSetup && !$success && $errorCount++ > 10) {
+                    throw new RuntimeException(sprintf('Tried to dispatch "%s" %d times.', $actionName, $errorCount), 1405269518);
+                }
+            } while (!$success);
+
+            $this->outputSuccessMessage($consoleOutput, $shouldExecute, $actionDefinition['description'] ?? $actionName);
+        }
+    }
+
+    private function outputSuccessMessage(TrackableOutput $consoleOutput, bool $shouldExecute, string $description)
+    {
+        $canReplaceActionMark = $consoleOutput->isDecorated() && !$consoleOutput->wasOutputTracked();
+        $replaceSequence = "\r\033[K\033[1A\r";
+        $type = 'success';
+        $okLabel = '';
+
+        if (!$canReplaceActionMark) {
+            $replaceSequence = '';
+            $okLabel = ' Ok';
+        }
+        if (!$shouldExecute) {
+            $type = 'comment';
+            $okLabel = ' <comment>Skipped</comment> ' . $description;
+        }
+
+        $this->output->outputLine('%1$s<%2$s>✔</%2$s>%3$s', [$replaceSequence, $type, $okLabel]);
+    }
+}

--- a/Classes/Console/Install/Action/InstallActionFactory.php
+++ b/Classes/Console/Install/Action/InstallActionFactory.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Install\Action;
+
+use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
+use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
+use Symfony\Component\Console\Exception\RuntimeException;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2018 Helmut Hummel <info@helhum.io>
+ *  All rights reserved
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the text file GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+class InstallActionFactory
+{
+    private static $typeClassMapping = [
+        'prepareInstall' => PrepareInstallAction::class,
+        'install' => Typo3InstallAction::class,
+        'extensionSetup' => ExtensionSetupAction::class,
+        'commands' => CommandsAction::class,
+    ];
+
+    /**
+     * @var ConsoleOutput
+     */
+    private $output;
+
+    /**
+     * @var CommandDispatcher
+     */
+    private $commandDispatcher;
+
+    public function __construct(ConsoleOutput $output, CommandDispatcher $commandDispatcher)
+    {
+        $this->output = $output;
+        $this->commandDispatcher = $commandDispatcher;
+    }
+
+    public function create(string $type): InstallActionInterface
+    {
+        $action = null;
+
+        if (isset(self::$typeClassMapping[$type]) && $this->isInstallAction(self::$typeClassMapping[$type])) {
+            $action = new self::$typeClassMapping[$type]();
+        }
+        if ($action === null && $this->isInstallAction($type)) {
+            $action = new $type();
+        }
+
+        if (!$action instanceof InstallActionInterface) {
+            throw new RuntimeException(sprintf('Install actions must implement InstallActionInterface. Given type "%s" does not.', $type), 1529158153);
+        }
+
+        $action->setOutput($this->output);
+        $action->setCommandDispatcher($this->commandDispatcher);
+
+        return $action;
+    }
+
+    private function isInstallAction(string $className): bool
+    {
+        if (!class_exists($className)) {
+            return false;
+        }
+
+        return in_array(InstallActionInterface::class, class_implements($className), true);
+    }
+}

--- a/Classes/Console/Install/Action/InstallActionInterface.php
+++ b/Classes/Console/Install/Action/InstallActionInterface.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Install\Action;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
+use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
+
+interface InstallActionInterface
+{
+    public function setOutput(ConsoleOutput $output);
+
+    public function setCommandDispatcher(CommandDispatcher $commandDispatcher);
+
+    public function shouldExecute(array $actionDefinition, array $options = []): bool;
+
+    public function execute(array $actionDefinition, array $options = []): bool;
+}

--- a/Classes/Console/Install/Action/InteractiveActionArguments.php
+++ b/Classes/Console/Install/Action/InteractiveActionArguments.php
@@ -1,0 +1,150 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Install\Action;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
+use Symfony\Component\Console\Exception\RuntimeException;
+
+class InteractiveActionArguments
+{
+    /**
+     * @var ConsoleOutput
+     */
+    private $output;
+
+    /**
+     * @var bool
+     */
+    private $isInteractive;
+
+    /**
+     * @var array
+     */
+    private $givenArguments;
+
+    public function __construct(ConsoleOutput $output)
+    {
+        $this->output = $output;
+    }
+
+    public function populate(array $argumentDefinitions, array $options = []): array
+    {
+        $this->isInteractive = $options['interactive'] ?? $this->output->getSymfonyConsoleInput()->isInteractive();
+        $this->givenArguments = $options['givenArguments'];
+
+        $actionArguments = [];
+        foreach ($argumentDefinitions as $argumentName => $argumentDefinition) {
+            $argumentValue = $this->extractArgumentValueFromDefinitionOrGivenArguments($argumentName, $argumentDefinition);
+            while ($argumentValue === null) {
+                $argumentValue = $this->fetchArgumentValue($argumentDefinition);
+            }
+            $actionArguments[$argumentName] = $argumentValue;
+        }
+
+        return $actionArguments;
+    }
+
+    private function extractArgumentValueFromDefinitionOrGivenArguments(string $argumentName, array $argumentDefinition)
+    {
+        $argumentValue = null;
+        $isRequired = !isset($argumentDefinition['default']);
+        if (!$this->isInteractive && !$isRequired) {
+            $argumentValue = $argumentDefinition['default'];
+        }
+
+        if (isset($argumentDefinition['value'])) {
+            $argumentValue = $argumentDefinition['value'];
+        }
+
+        if (isset($this->givenArguments[$argumentName])) {
+            $argumentValue = $this->givenArguments[$argumentName];
+        }
+
+        if ($argumentValue === null && !$this->isInteractive) {
+            throw new RuntimeException(
+                sprintf(
+                    'Option "%s" is not set, but is required and user interaction is disabled',
+                    $argumentDefinition['option']
+                ),
+                1405273316
+            );
+        }
+
+        return $argumentValue;
+    }
+
+    /**
+     * @param $argumentDefinition
+     * @return mixed
+     */
+    private function fetchArgumentValue(array $argumentDefinition)
+    {
+        $isRequired = !isset($argumentDefinition['default']);
+        $argumentValue = null;
+
+        switch ($argumentDefinition['type']) {
+            case 'select':
+                $argumentValue = $this->output->select(
+                    sprintf(
+                        '<comment>%s (%s):</comment> ',
+                        $argumentDefinition['description'],
+                        $isRequired ? 'required' : sprintf('default: "%s"', $argumentDefinition['default'])
+                    ),
+                    $argumentDefinition['values'],
+                    $argumentDefinition['default'] ?? null,
+                    false,
+                    1
+                );
+                break;
+            case 'string':
+            case 'int':
+                $argumentValue = $this->output->ask(
+                    sprintf(
+                        '<comment>%s (%s):</comment> ',
+                        $argumentDefinition['description'],
+                        $isRequired ? 'required' : sprintf('default: "%s"', $argumentDefinition['default'])
+                    ),
+                    $argumentDefinition['default'] ?? null
+                );
+                break;
+            case 'bool':
+                $argumentValue = (int)$this->output->askConfirmation(
+                    sprintf(
+                        '<comment>%s (%s):</comment> ',
+                        $argumentDefinition['description'],
+                        $argumentDefinition['default'] ? 'Y/n' : 'y/N'
+                    ),
+                    $argumentDefinition['default']
+                );
+                break;
+            case 'hidden':
+                $argumentValue = $this->output->askHiddenResponse(
+                    sprintf(
+                        '<comment>%s (%s):</comment> ',
+                            $argumentDefinition['description'],
+                            $isRequired ? 'required' : sprintf('default: "%s"', $argumentDefinition['default'])
+                    )
+                );
+                if ($argumentValue === null) {
+                    $argumentValue = $argumentDefinition['default'] ?? null;
+                }
+                break;
+            default:
+                throw new RuntimeException(sprintf('Unknown argument type "%s"', $argumentDefinition['type']), 1529154809);
+        }
+
+        return $argumentValue;
+    }
+}

--- a/Classes/Console/Install/Action/PrepareInstallAction.php
+++ b/Classes/Console/Install/Action/PrepareInstallAction.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Install\Action;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
+use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
+
+class PrepareInstallAction implements InstallActionInterface
+{
+    /**
+     * @var CommandDispatcher
+     */
+    private $commandDispatcher;
+
+    /**
+     * @var ConsoleOutput
+     */
+    private $output;
+
+    public function setOutput(ConsoleOutput $output)
+    {
+        $this->output = $output;
+    }
+
+    public function setCommandDispatcher(CommandDispatcher $commandDispatcher)
+    {
+        $this->commandDispatcher = $commandDispatcher;
+    }
+
+    public function shouldExecute(array $actionDefinition, array $options = []): bool
+    {
+        return true;
+    }
+
+    public function execute(array $actionDefinition, array $options = []): bool
+    {
+        $typo3RootPath = rtrim(defined('PATH_site') ? PATH_site : getenv('TYPO3_PATH_ROOT'), '/');
+        $firstInstallPath = $typo3RootPath . '/FIRST_INSTALL';
+        if (!file_exists($firstInstallPath)) {
+            touch($firstInstallPath);
+        }
+
+        if (isset($options['extensionSetup']) && !$options['extensionSetup']) {
+            return true;
+        }
+
+        $packageStatesArguments = [];
+        // Exclude all local extensions in case any are present, to avoid interference with the setup
+        foreach (glob($typo3RootPath . '/typo3conf/ext/*') as $item) {
+            $packageStatesArguments['--excluded-extensions'][] = basename($item);
+        }
+        $this->commandDispatcher->executeCommand('install:generatepackagestates', $packageStatesArguments);
+
+        return true;
+    }
+}

--- a/Classes/Console/Install/Action/Typo3InstallAction.php
+++ b/Classes/Console/Install/Action/Typo3InstallAction.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Install\Action;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Install\CliMessageRenderer;
+use Helhum\Typo3Console\Install\InstallStepResponse;
+use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
+use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
+
+class Typo3InstallAction implements InstallActionInterface
+{
+    /**
+     * @var CommandDispatcher
+     */
+    private $commandDispatcher;
+
+    /**
+     * @var ConsoleOutput
+     */
+    private $output;
+
+    public function setOutput(ConsoleOutput $output)
+    {
+        $this->output = $output;
+    }
+
+    public function setCommandDispatcher(CommandDispatcher $commandDispatcher)
+    {
+        $this->commandDispatcher = $commandDispatcher;
+    }
+
+    public function shouldExecute(array $actionDefinition, array $options = []): bool
+    {
+        $actionName = $options['actionName'];
+        if (!$this->executeActionWithArguments('actionNeedsExecution', [$actionName])->actionNeedsExecution()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function execute(array $actionDefinition, array $options = []): bool
+    {
+        $actionName = $options['actionName'];
+        $argumentDefinitions = $actionDefinition['arguments'] ?? [];
+        $interactiveArguments = new InteractiveActionArguments($this->output);
+        $arguments = $this->translateActionArgumentsToCommandArguments(
+            $interactiveArguments->populate($argumentDefinitions, $options),
+            $argumentDefinitions
+        );
+        $response = $this->executeActionWithArguments($actionName, $arguments);
+
+        if ($this->executeActionWithArguments('actionNeedsExecution', [$actionName])->actionNeedsExecution()) {
+            // @deprecated Can be removed once TYPO3 8.7 support is removed. Then it will be safe to call the action only once
+            // and just assume it completed
+            $response = $this->executeActionWithArguments($actionName, $arguments);
+        }
+
+        $messages = $response->getMessages();
+        $messageRenderer = new CliMessageRenderer($this->output);
+        $messageRenderer->render($messages);
+
+        return empty($messages);
+    }
+
+    private function translateActionArgumentsToCommandArguments(array $actionArguments, $argumentDefinitions): array
+    {
+        $commandArguments = [];
+        foreach ($actionArguments as $name => $value) {
+            $argumentDefinition = $argumentDefinitions[$name];
+            if ($argumentDefinition['type'] === 'bool') {
+                if ((bool)$value) {
+                    $commandArguments[] = $argumentDefinition['option'];
+                }
+            } else {
+                $commandArguments[] = $argumentDefinition['option'];
+                $commandArguments[] = $value;
+            }
+        }
+
+        return $commandArguments;
+    }
+
+    /**
+     * Executes the given action and returns their response messages
+     *
+     * @param string $actionName Name of the install step
+     * @param array $arguments Arguments for the install step
+     * @param array $options Options for the install step
+     * @return InstallStepResponse
+     */
+    private function executeActionWithArguments($actionName, array $arguments = [], array $options = [])
+    {
+        $actionName = strtolower($actionName);
+        // Arguments must come first then options, to avoid argument values to be passed to boolean flags
+        $arguments = array_merge($arguments, $options);
+        $actionResult = $this->commandDispatcher->executeCommand('install:' . $actionName, $arguments);
+        $response = @unserialize($actionResult);
+        if ($response === false && $actionName === 'defaultconfiguration') {
+            // This action terminates with exit, (trying to initiate a HTTP redirect)
+            // Therefore we gracefully create a valid response here
+            $response = new InstallStepResponse(false, []);
+        }
+
+        return $response;
+    }
+}

--- a/Classes/Console/Install/CliMessageRenderer.php
+++ b/Classes/Console/Install/CliMessageRenderer.php
@@ -36,6 +36,10 @@ class CliMessageRenderer
 
     public function render(array $messages)
     {
+        if (empty($messages)) {
+            return;
+        }
+
         $this->output->outputLine();
         foreach ($messages as $statusMessage) {
             $this->renderSingle($statusMessage);

--- a/Classes/Console/Install/CliSetupRequestHandler.php
+++ b/Classes/Console/Install/CliSetupRequestHandler.php
@@ -27,6 +27,7 @@ use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 /**
  * This class acts as facade for the install tool step actions.
  * It glues together the execution of these actions with the user interaction on the command line
+ * @deprecated With 5.4 will be removed with 6.0. Use \Helhum\Typo3Console\Install\Action\InstallActionDispatcher instead.
  */
 class CliSetupRequestHandler
 {

--- a/Classes/Console/Install/StepsConfig.php
+++ b/Classes/Console/Install/StepsConfig.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Install;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\ConfigLoader\ConfigurationReaderFactory;
+use Helhum\ConfigLoader\Processor\PlaceholderValue;
+
+class StepsConfig
+{
+    /**
+     * @var string
+     */
+    private $baseConfigFile;
+
+    public function __construct(string $baseConfigFile = null)
+    {
+        $this->baseConfigFile = $baseConfigFile ?: __DIR__ . '/../../../Configuration/Install/InstallSteps.yaml';
+    }
+
+    public function getInstallSteps(string $stepsConfigFile = null): array
+    {
+        $stepsConfigFile = $stepsConfigFile ?? $this->baseConfigFile;
+
+        return (new PlaceholderValue(false))->processConfig(
+            $this->createConfigFactory($stepsConfigFile)
+                 ->createRootReader($stepsConfigFile)
+                 ->readConfig()
+        );
+    }
+
+    private function createConfigFactory(string $stepsConfigFile): ConfigurationReaderFactory
+    {
+        $factory = new ConfigurationReaderFactory(dirname($stepsConfigFile));
+        $factory->setReaderFactoryForType(
+            'console',
+            function () use ($factory) {
+                return $factory->createRootReader($this->baseConfigFile);
+            },
+            false
+        );
+
+        return $factory;
+    }
+}

--- a/Classes/Console/Mvc/Cli/ConsoleOutput.php
+++ b/Classes/Console/Mvc/Cli/ConsoleOutput.php
@@ -14,6 +14,7 @@ namespace Helhum\Typo3Console\Mvc\Cli;
  *
  */
 
+use Helhum\Typo3Console\Mvc\Cli\Symfony\Output\TrackableOutput;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Helper\FormatterHelper;
@@ -42,7 +43,7 @@ class ConsoleOutput
     protected $input;
 
     /**
-     * @var SymfonyConsoleOutput
+     * @var TrackableOutput
      */
     protected $output;
 
@@ -74,7 +75,7 @@ class ConsoleOutput
      */
     public function __construct(Output $output = null, Input $input = null)
     {
-        $this->output = $output ?: new SymfonyConsoleOutput();
+        $this->output = new TrackableOutput($output ?: new SymfonyConsoleOutput());
         $this->output->getFormatter()->setStyle('b', new OutputFormatterStyle(null, null, ['bold']));
         $this->output->getFormatter()->setStyle('i', new OutputFormatterStyle('black', 'white'));
         $this->output->getFormatter()->setStyle('u', new OutputFormatterStyle(null, null, ['underscore']));
@@ -90,7 +91,7 @@ class ConsoleOutput
     }
 
     /**
-     * @return SymfonyConsoleOutput
+     * @return SymfonyConsoleOutput|TrackableOutput
      */
     public function getSymfonyConsoleOutput()
     {

--- a/Classes/Console/Mvc/Cli/Symfony/Output/TrackableOutput.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Output/TrackableOutput.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Mvc\Cli\Symfony\Output;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TrackableOutput extends ConsoleOutput
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var bool
+     */
+    private $outputTracked = false;
+
+    /**
+     * @var TrackableOutput
+     */
+    private $parentOutput;
+
+    public function __construct(OutputInterface $output, self $parentOutput = null)
+    {
+        $this->output = $output;
+        $this->parentOutput = $parentOutput;
+        if ($output instanceof ConsoleOutput) {
+            $output->setErrorOutput(new self($output->getErrorOutput(), $this));
+        }
+        parent::__construct();
+    }
+
+    public function startTracking()
+    {
+        $this->outputTracked = false;
+    }
+
+    public function emitOutputTracked()
+    {
+        $this->outputTracked = true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function wasOutputTracked(): bool
+    {
+        return $this->outputTracked;
+    }
+
+    public function getErrorOutput()
+    {
+        if ($this->output instanceof ConsoleOutput) {
+            return $this->output->getErrorOutput();
+        }
+
+        return new self($this->output, $this);
+    }
+
+    public function setErrorOutput(OutputInterface $error)
+    {
+        parent::setErrorOutput(new self($error, $this));
+    }
+
+    public function write($messages, $newline = false, $type = self::OUTPUT_NORMAL)
+    {
+        $this->outputTracked = true;
+        if ($this->parentOutput) {
+            $this->parentOutput->emitOutputTracked();
+        }
+        $this->output->write($messages, $newline, $type);
+    }
+
+    public function writeln($messages, $type = self::OUTPUT_NORMAL)
+    {
+        $this->write($messages, true, $type);
+    }
+
+    public function setVerbosity($level)
+    {
+        $this->output->setVerbosity($level);
+    }
+
+    public function getVerbosity()
+    {
+        return $this->output->getVerbosity();
+    }
+
+    public function setDecorated($decorated)
+    {
+        $this->output->setDecorated($decorated);
+    }
+
+    public function isDecorated(): bool
+    {
+        return $this->output->isDecorated();
+    }
+
+    public function setFormatter(OutputFormatterInterface $formatter)
+    {
+        $this->output->setFormatter($formatter);
+    }
+
+    public function getFormatter()
+    {
+        return $this->output->getFormatter();
+    }
+
+    public function isQuiet(): bool
+    {
+        return self::VERBOSITY_QUIET === $this->getVerbosity();
+    }
+
+    public function isVerbose(): bool
+    {
+        return self::VERBOSITY_VERBOSE <= $this->getVerbosity();
+    }
+
+    public function isVeryVerbose(): bool
+    {
+        return self::VERBOSITY_VERY_VERBOSE <= $this->getVerbosity();
+    }
+
+    public function isDebug(): bool
+    {
+        return self::VERBOSITY_DEBUG <= $this->getVerbosity();
+    }
+}

--- a/Configuration/Install/InstallSteps.yaml
+++ b/Configuration/Install/InstallSteps.yaml
@@ -1,0 +1,108 @@
+prepareInstall:
+    type: prepareInstall
+    description: 'Prepare installation'
+
+environmentAndFolders:
+    type: install
+    description: 'Check environment and create folders'
+
+databaseConnect:
+    type: install
+    description: 'Set up database connection'
+    arguments:
+        databaseUserName:
+            description: 'User name for database server'
+            option: '--database-user-name'
+            type: string
+            value: '%env(TYPO3_INSTALL_DB_USER)%'
+            default: ''
+
+        databaseUserPassword:
+            description: 'User password for database server'
+            option: '--database-user-password'
+            type: hidden
+            value: '%env(TYPO3_INSTALL_DB_PASSWORD)%'
+            default: ''
+
+        databaseHostName:
+            description: 'Host name of database server'
+            option: '--database-host-name'
+            type: string
+            value: '%env(TYPO3_INSTALL_DB_HOST)%'
+            default: '127.0.0.1'
+
+        databasePort:
+            description: 'TCP Port of database server'
+            option: '--database-port'
+            type: int
+            value: '%env(TYPO3_INSTALL_DB_PORT)%'
+            default: 3306
+
+        databaseSocket:
+            description: 'Unix Socket to connect to'
+            option: '--database-socket'
+            type: string
+            value: '%env(TYPO3_INSTALL_DB_UNIX_SOCKET)%'
+            default: ''
+
+databaseSelect:
+    type: install
+    description: 'Select database'
+    arguments:
+        useExistingDatabase:
+            description: 'Use already existing database?'
+            option: '--use-existing-database'
+            type: bool
+            value: '%env(TYPO3_INSTALL_DB_USE_EXISTING)%'
+            default: false
+
+        databaseName:
+            description: 'Name of the database'
+            option: '--database-name'
+            type: string
+            value: '%env(TYPO3_INSTALL_DB_DBNAME)%'
+
+databaseData:
+    type: install
+    description: 'Set up database'
+    arguments:
+        adminUserName:
+            description: 'Username of to be created administrative user account'
+            option: '--admin-user-name'
+            type: string
+            value: '%env(TYPO3_INSTALL_ADMIN_USER)%'
+
+        adminPassword:
+            description: 'Password of to be created administrative user account'
+            option: '--admin-password'
+            type: hidden
+            value: '%env(TYPO3_INSTALL_ADMIN_PASSWORD)%'
+
+        siteName:
+            description: 'Name of the TYPO3 site'
+            option: '--site-name'
+            type: string
+            default: 'New TYPO3 Console site'
+            value: '%env(TYPO3_INSTALL_SITE_NAME)%'
+
+defaultConfiguration:
+    type: install
+    description: 'Set up configuration'
+    arguments:
+        siteSetupType:
+            description: 'Specify the site setup type'
+            option: '--site-setup-type'
+            type: select
+            values:
+                'no': 'Do nothing'
+                site: 'Create root page'
+            value: '%env(TYPO3_INSTALL_SITE_SETUP_TYPE)%'
+            default: 'no'
+
+extensionSetup:
+    type: extensionSetup
+    description: 'Set up extensions'
+    commands:
+        - command: 'install:generatepackagestates'
+        - command: 'database:updateschema'
+        - command: 'extension:setupactive'

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -194,7 +194,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: NULL
+
 
 
 
@@ -363,7 +363,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: NULL
+
 
 
 
@@ -765,7 +765,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: NULL
+
 
 ``--target-file``
   File path and name of the generated XSD schema. If not specified the schema will be output to standard output.
@@ -773,7 +773,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: NULL
+
 
 
 
@@ -1174,7 +1174,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: ''
+- Default: '127.0.0.1'
 
 ``--database-port``
   TCP Port of database server
@@ -1182,7 +1182,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: ''
+- Default: '3306'
 
 ``--database-socket``
   Unix Socket to connect to (if localhost is given as hostname and this is kept empty, a socket connection will be established)
@@ -1198,7 +1198,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: ''
+
 
 ``--use-existing-database``
   If set an empty database with the specified name will be used. Otherwise a database with the specified name is created.
@@ -1214,7 +1214,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: ''
+
 
 ``--admin-password``
   Password of the administrative backend user account to be created
@@ -1222,7 +1222,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: ''
+
 
 ``--site-name``
   Site Name
@@ -1238,7 +1238,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: 'none'
+- Default: 'no'
 
 ``--non-interactive``
   Deprecated. Use ``--no-interaction`` instead.
@@ -1275,7 +1275,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: NULL
+
 
 ``--force``
   The execution can be forced with this flag. The task will then be executed even if it is not scheduled for execution yet. Only works, when a task is specified.
@@ -1291,7 +1291,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: NULL
+
 
 
 

--- a/Packages/CreateReferenceCommand/Resources/Templates/CommandReferenceTemplate.txt
+++ b/Packages/CreateReferenceCommand/Resources/Templates/CommandReferenceTemplate.txt
@@ -60,7 +60,7 @@ Available Commands
 - Accept value: {description.acceptValue}
 - Is value required: {description.isValueRequired}
 - Is multiple: {description.isMultiple}
-- Default: {description.default -> f:format.raw()}
+<f:if condition="{description.default} != 'NULL'">- Default: {description.default -> f:format.raw()}</f:if>
 
 </f:for>
 </f:if>

--- a/Tests/Console/Functional/Command/Install/InstallCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/Install/InstallCommandControllerTest.php
@@ -53,7 +53,7 @@ class InstallCommandControllerTest extends AbstractCommandTest
             ]
         );
         $this->assertContains('Successfully installed TYPO3 CMS!', $output);
-        $this->assertNotContains('Set up extensions', $output);
+        $this->assertContains('<comment>Skipped</comment> Set up extensions', $output);
     }
 
     /**

--- a/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
@@ -110,7 +110,8 @@ class UpgradeCommandControllerTest extends AbstractCommandTest
     "conflict": {
         "symfony/finder": "2.7.44 || 2.8.37 || 3.4.7 || 4.0.7"
     }
-}');
+}'
+        );
         $this->executeComposerCommand(['config', 'extra.typo3/cms.web-dir', 'public']);
         $this->copyDirectory($this->consoleRootPath, $this->upgradeInstancePath . '/typo3_console', ['.Build', '.git']);
         $consoleComposerJson = file_get_contents($this->upgradeInstancePath . '/typo3_console/composer.json');

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
 
         "doctrine/annotations": "^1.4",
         "symfony/console": "^3.4.4 || ^4.0",
-        "symfony/process": "^3.4.4 || ^4.0"
+        "symfony/process": "^3.4.4 || ^4.0",
+        "helhum/config-loader": "^0.9.0"
     },
     "require-dev": {
         "typo3/cms-reports": "^8.7.10 || >=9.1.0 <9.4 || 9.4.*@dev",
@@ -101,7 +102,7 @@
         "extension-create-libs": [
             "mkdir -p Libraries/temp",
             "[ -f $HOME/.composer/vendor/bin/phar-composer ] || composer global require clue/phar-composer",
-            "if [ ! -f Libraries/symfony-process.phar ]; then cd Libraries/temp && composer require symfony/console=^3.4.4 symfony/process=^3.4.4 && composer config classmap-authoritative true && composer config prepend-autoloader true && composer dump-autoload -o; fi",
+            "if [ ! -f Libraries/symfony-process.phar ]; then cd Libraries/temp && composer require symfony/console=^3.4.4 symfony/process=^3.4.4 helhum/config-loader=^0.9.0 && composer config classmap-authoritative true && composer config prepend-autoloader true && composer dump-autoload -o; fi",
             "[ -f Libraries/symfony-process.phar ] || $HOME/.composer/vendor/bin/phar-composer build Libraries/temp/ Libraries/symfony-process.phar",
             "chmod -x Libraries/*.phar",
             "rm -rf Libraries/temp"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,5 +21,5 @@ sonar.dbcleaner.weeksBeforeKeepingOnlyOneSnapshotByWeek=12
 sonar.dbcleaner.weeksBeforeKeepingOnlyOneSnapshotByMonth=52
 
 # PHPUnit test and coverage results import
-sonar.php.tests.reportPath=junit.xml
-sonar.php.coverage.reportPaths=clover.xml
+sonar.php.tests.reportPath=.Build/junit.xml
+sonar.php.coverage.reportPaths=.Build/clover.xml


### PR DESCRIPTION
The previous implementation came with a lot of downsides.
The main class performing the setup was incredibly complex
and hard to understand. Besides that, it required Extbase
ObjectManager, which in turn needed a TYPO3 bootstrap to
be performed. Because of the latter, we needed to perform
a TYPO3 boot when triggering this setup during a composer install.

Last but not least, all steps were hard coded in this god class,
which made it impossible to add or amend steps. Even extending
this class would have been hard.

Therefore this process is rewritten from scratch, distributed
into several classes and made extendable by simply providing
a different Yaml file, which now defines which actions are taken
during installation.

As a long hanging fruit it is now implemented, that all
setup arguments can also be provided as environment variables:

TYPO3_INSTALL_DB_USER
TYPO3_INSTALL_DB_PASSWORD
TYPO3_INSTALL_DB_HOST
TYPO3_INSTALL_DB_PORT
TYPO3_INSTALL_DB_UNIX_SOCKET
TYPO3_INSTALL_DB_USE_EXISTING
TYPO3_INSTALL_DB_DBNAME
TYPO3_INSTALL_ADMIN_USER
TYPO3_INSTALL_ADMIN_PASSWORD
TYPO3_INSTALL_SITE_NAME
TYPO3_INSTALL_SITE_SETUP_TYPE

If any of these env vars exist, they are used, while given command line
options still take precedence.

Also the output of the individual setup actions is streamlined,
more compact and prettier.