### PR TITLE
[FEATURE] Allow specifying alternative install steps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 /Packages/ export-ignore
 /Resources/Private/ExtensionArtifacts/ export-ignore
+/Resources/Private/Patches/ export-ignore
 /Tests/ export-ignore
 /.gitattributes export-ignore
 /.github/ export-ignore

--- a/Classes/Console/Install/StepsConfig.php
+++ b/Classes/Console/Install/StepsConfig.php
@@ -31,7 +31,8 @@ class StepsConfig
 
     public function getInstallSteps(string $stepsConfigFile = null): array
     {
-        $stepsConfigFile = $stepsConfigFile ?? $this->baseConfigFile;
+        $stepsConfigFile = $stepsConfigFile ?: (string)getenv('TYPO3_INSTALL_SETUP_STEPS') ?: $this->baseConfigFile;
+        $stepsConfigFile = (string)realpath($stepsConfigFile);
 
         return (new PlaceholderValue(false))->processConfig(
             $this->createConfigFactory($stepsConfigFile)

--- a/Resources/Private/Patches/patches.json
+++ b/Resources/Private/Patches/patches.json
@@ -1,0 +1,7 @@
+{
+  "patches": {
+    "phpunit/phpunit": {
+      "Fix environment setting in PHPUnit": "Resources/Private/Patches/phpunit-env.diff"
+    }
+  }
+}

--- a/Resources/Private/Patches/phpunit-env.diff
+++ b/Resources/Private/Patches/phpunit-env.diff
@@ -1,0 +1,11 @@
+--- src/Util/Configuration.php	2018-06-18 15:26:03.000000000 +0200
++++ src/Util/Configuration_fixed.php	2018-06-18 15:18:09.000000000 +0200
+@@ -568,6 +568,8 @@
+                 \putenv("{$name}={$value}");
+             }
+
++            $value = \getenv($name);
++
+             if (!isset($_ENV[$name])) {
+                 $_ENV[$name] = $value;
+             }

--- a/Tests/Console/Functional/Fixtures/Install/custom-install-import.yaml
+++ b/Tests/Console/Functional/Fixtures/Install/custom-install-import.yaml
@@ -1,0 +1,22 @@
+imports:
+    - { resource: 'InstallSteps.yaml', type: console }
+
+prepareInstall:
+    skip: true
+environmentAndFolders:
+    skip: false
+databaseConnect:
+    skip: true
+databaseSelect:
+    skip: true
+databaseData:
+    skip: true
+defaultConfiguration:
+    skip: true
+extensionSetup:
+    skip: true
+customStep:
+    type: commands
+    description: 'Custom step'
+    commands:
+        - command: 'install:fixfolderstructure'

--- a/Tests/Console/Functional/Fixtures/Install/custom-install.yaml
+++ b/Tests/Console/Functional/Fixtures/Install/custom-install.yaml
@@ -1,0 +1,5 @@
+customStep:
+    type: commands
+    description: 'Custom step'
+    commands:
+        - command: 'install:fixfolderstructure'

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
         "typo3-console/php-server-command": "^0.2",
         "typo3-console/create-reference-command": "@dev",
         "symfony/filesystem": "^3.2",
-        "nimut/testing-framework": "dev-master"
+        "nimut/testing-framework": "dev-master",
+        "cweagans/composer-patches": "^1.6"
     },
     "conflict": {
         "typo3-ter/dbal": "*",
@@ -110,6 +111,7 @@
             "@extension-build",
             "rm -rf Packages/",
             "rm -rf Resources/Private/ExtensionArtifacts/",
+            "rm -rf Resources/Private/Patches/",
             "rm -rf Tests/",
             "rm .gitattributes",
             "rm -rf .github/",
@@ -127,6 +129,7 @@
         ]
     },
     "extra": {
+        "patches-file": "Resources/Private/Patches/patches.json",
         "branch-alias": {
             "dev-master": "5.x-dev"
         },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,10 @@
         <env name="TYPO3_INSTALL_DB_HOST" value="127.0.0.1" />
         <env name="TYPO3_INSTALL_DB_PASSWORD" value="" />
         <env name="TYPO3_INSTALL_DB_DBNAME" value="travis_console_test" />
+        <env name="TYPO3_INSTALL_ADMIN_USER" value="admin" />
+        <env name="TYPO3_INSTALL_ADMIN_PASSWORD" value="password" />
+        <env name="TYPO3_INSTALL_SITE_NAME" value="Travis Install" />
+        <env name="TYPO3_INSTALL_SITE_SETUP_TYPE" value="createsite" />
         <env name="TYPO3_VERSION" value="^9.1" />
     </php>
     <testsuites>


### PR DESCRIPTION
It is now possible to specify a different install step
file by providing the TYPO3_INSTALL_SETUP_STEPS environment
variable.

Example:

TYPO3_INSTALL_SETUP_STEPS=/path/to/steps.yaml typo3cms install:setup