### PR TITLE
[FEATURE] Make it possible to abort installation process

### DIFF
--- a/Classes/Console/Install/Action/InstallationFailedException.php
+++ b/Classes/Console/Install/Action/InstallationFailedException.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Install\Action;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Exception;
+
+class InstallationFailedException extends Exception
+{
+}


### PR DESCRIPTION
Install actions currently can throw exceptions to abort,
but we now introduce an exception that makes the installation
abort, but gracefully let's the dispatcher return false
instead of letting the exception bubble up.

We use this now to add the integrity check to the preparation step
and removing this check from the command controller.