### PR TITLE
Add option to exclude TYPO3 cache tables

### DIFF
--- a/Classes/Console/Command/DatabaseCommandController.php
+++ b/Classes/Console/Command/DatabaseCommandController.php
@@ -187,7 +187,7 @@ class DatabaseCommandController extends CommandController
             foreach ($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'] as $name => $configuration) {
                 $cacheBackendClass = '\\' . ltrim($configuration['backend'] ?? Typo3DatabaseBackend::class, '\\');
                 $cacheFrontendClass = '\\' . ltrim($configuration['frontend'] ?? VariableFrontend::class, '\\');
-                if (!is_a($configuration['backend'], Typo3DatabaseBackend::class, true)) {
+                if (!is_a($cacheBackendClass, Typo3DatabaseBackend::class, true)) {
                     continue;
                 }
 

--- a/Classes/Console/Command/DatabaseCommandController.php
+++ b/Classes/Console/Command/DatabaseCommandController.php
@@ -179,11 +179,14 @@ class DatabaseCommandController extends CommandController
         }
 
         if ($excludeVolatile) {
-            array_push($excludeTables, 'fe_sessions', 'be_sessions');
-            array_push($excludeTables, 'cache_md5params', 'cache_treelist');
+            $excludeTables[] = 'fe_sessions';
+            $excludeTables[] = 'be_sessions';
+            $excludeTables[] = 'cache_md5params';
+            $excludeTables[] = 'cache_treelist';
             foreach ($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'] as $name => $configuration) {
                 if (is_a($configuration['backend'], Typo3DatabaseBackend::class, true)) {
-                    array_push($excludeTables, 'cf_' . $name, 'cf_' . $name . '_tags');
+                    $excludeTables[] = 'cf_' . $name;
+                    $excludeTables[] = 'cf_' . $name . '_tags';
                 }
             }
         }

--- a/Classes/Console/Command/DatabaseCommandController.php
+++ b/Classes/Console/Command/DatabaseCommandController.php
@@ -172,6 +172,10 @@ class DatabaseCommandController extends CommandController
             '--single-transaction',
         ];
 
+        if ($this->output->getSymfonyConsoleOutput()->isVerbose()) {
+            $additionalArguments[] = '--verbose';
+        }
+
         foreach ($excludeTables as $table) {
             $additionalArguments[] = sprintf('--ignore-table=%s.%s', $dbConfig['dbname'], $table);
         }


### PR DESCRIPTION
This is related to #721 although it might not be enough to resolve it.

I simply added `--exclude-volatile` to exclude all cache and session tables. While this might not be a complete solution and you may still need to exlclude more tables, this makes a quick dump A LOT easier. It is also completely backwards compatible.

I also [experimented with slimdump](https://github.com/Nemo64/typo3-slimdump) if the higher configuration level is needed but I still think the complexity is too high for a simple command here in typo3-console. But the option is now there so there is that.