### PR TITLE
add verbose option to database:export

### DIFF
--- a/Classes/Console/Command/DatabaseCommandController.php
+++ b/Classes/Console/Command/DatabaseCommandController.php
@@ -172,6 +172,10 @@ class DatabaseCommandController extends CommandController
             '--single-transaction',
         ];
 
+        if ($this->output->getSymfonyConsoleOutput()->isVerbose()) {
+            $additionalArguments[] = '--verbose';
+        }
+
         foreach ($excludeTables as $table) {
             $additionalArguments[] = sprintf('--ignore-table=%s.%s', $dbConfig['dbname'], $table);
         }


### PR DESCRIPTION
It's a nice option and shouldn't break anything.

`typo3console database:export -v` or `--verbose` now makes `mysqldump` verbose too. Mysqldump outputs its information using stderr so piping the dump into a file still works.