### PR TITLE
[FEATURE] Support wildcards for excluding tables on export

### DIFF
--- a/Classes/Console/Database/Schema/TableMatcher.php
+++ b/Classes/Console/Database/Schema/TableMatcher.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Database\Schema;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use TYPO3\CMS\Core\Database\Connection;
+
+class TableMatcher
+{
+    public function match(Connection $connection, string ...$expressions): array
+    {
+        $matchedTables = [];
+        foreach ($expressions as $expression) {
+            $matchesForExpression = $this->matchSingle($connection, $expression);
+            if (!empty($matchesForExpression)) {
+                array_push($matchedTables, ...$matchesForExpression);
+            }
+        }
+
+        return $matchedTables;
+    }
+
+    private function matchSingle(Connection $connection, string $expression): array
+    {
+        return array_filter(
+            $connection->getSchemaManager()->listTableNames(),
+            function ($tableName) use ($expression) {
+                return fnmatch($expression, $tableName);
+            }
+        );
+    }
+}

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -617,12 +617,7 @@ This obviously only works when MySQL is used as DBMS.
 
 A comma-separated list of tables can be passed to exclude from the export:
 
-**Example:** ``typo3cms database:export --exclude-tables be_sessions,fe_sessions,sys_log``
-
-**This command passes the plain text database password to the command line process.**
-This means, that users that have the permission to observe running processes,
-will be able to read your password.
-If this imposes a security risk for you, then refrain from using this command!
+**Example:** ``typo3cms database:export --exclude-tables 'cf_*,cache_*,[bf]e_sessions,sys_log'``
 
 
 
@@ -630,7 +625,7 @@ Options
 ^^^^^^^
 
 ``--exclude-tables``
-  Comma-separated list of table names to exclude from the export
+  Comma-separated list of table names to exclude from the export. Wildcards are supported.
 
 - Accept value: yes
 - Is value required: yes

--- a/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
@@ -142,4 +142,13 @@ class DatabaseCommandControllerTest extends AbstractCommandTest
         $output = $this->executeConsoleCommand('database:export', ['--exclude-tables' => 'sys_log']);
         $this->assertNotContains('CREATE TABLE `sys_log`', $output);
     }
+
+    /**
+     * @test
+     */
+    public function databaseExportCanExcludeTablesWithWildcards()
+    {
+        $output = $this->executeConsoleCommand('database:export', ['--exclude-tables' => 'cf_*']);
+        $this->assertNotContains('CREATE TABLE `cf_', $output);
+    }
 }

--- a/Tests/Console/Unit/Database/Schema/SchemaUpdateTypeTest.php
+++ b/Tests/Console/Unit/Database/Schema/SchemaUpdateTypeTest.php
@@ -17,9 +17,6 @@ namespace Helhum\Typo3Console\Tests\Unit\Database\Schema;
 use Helhum\Typo3Console\Database\Schema\SchemaUpdateType;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
-/**
- * Class SchemaUpdateTypeTest
- */
 class SchemaUpdateTypeTest extends UnitTestCase
 {
     /**

--- a/Tests/Console/Unit/Database/Schema/TableMatcherTest.php
+++ b/Tests/Console/Unit/Database/Schema/TableMatcherTest.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Tests\Unit\Database\Schema;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Helhum\Typo3Console\Database\Schema\TableMatcher;
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Core\Database\Connection;
+
+class TableMatcherTest extends UnitTestCase
+{
+    public function matchReturnsCorrectTableMatchesDataProvider(): array
+    {
+        return [
+            'plain table name' => [
+                'fe_sessions',
+                [
+                    'fe_sessions',
+                ],
+            ],
+            'optionals' => [
+                '[bf]e_sessions',
+                [
+                    'be_sessions',
+                    'fe_sessions',
+                ],
+            ],
+            'optionals inverted' => [
+                '[!f]e_sessions',
+                [
+                    'be_sessions',
+                ],
+            ],
+            'single char' => [
+                '?e_sessions',
+                [
+                    'be_sessions',
+                    'fe_sessions',
+                ],
+            ],
+            'not existing plain table name' => [
+                'foo_bar',
+                [],
+            ],
+            'not matching placeholder' => [
+                'foo_*',
+                [],
+            ],
+            'placeholder at beginning' => [
+                '*_sessions',
+                [
+                    'fe_sessions',
+                    'be_sessions',
+                ],
+            ],
+            'placeholder at end' => [
+                'cf_*',
+                [
+                    'cf_foo',
+                    'cf_foo_tags',
+                    'cf_bar',
+                    'cf_bar_tags',
+                ],
+            ],
+            'placeholder in the middle' => [
+                'cf_*_tags',
+                [
+                    'cf_foo_tags',
+                    'cf_bar_tags',
+                ],
+            ],
+            'multiple placeholders' => [
+                '*_*_tags',
+                [
+                    'cache_foo_tags',
+                    'cf_foo_tags',
+                    'cf_bar_tags',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param string $expression
+     * @param array $expectedMatches
+     * @test
+     * @dataProvider matchReturnsCorrectTableMatchesDataProvider
+     */
+    public function matchReturnsCorrectTableMatches(string $expression, array $expectedMatches)
+    {
+        $tables = [
+            'cf_foo',
+            'cf_foo_tags',
+            'cf_bar',
+            'cf_bar_tags',
+            'cache_foo',
+            'cache_foo_tags',
+            'fe_sessions',
+            'be_sessions',
+        ];
+        $connectionProphecy = $this->prophesize(Connection::class);
+        $schemaManagerProphecy = $this->prophesize(AbstractSchemaManager::class);
+        $schemaManagerProphecy->listTableNames()->willReturn($tables)->shouldBeCalled();
+        $connectionProphecy->getSchemaManager()->willReturn($schemaManagerProphecy->reveal())->shouldBeCalled();
+
+        $tableMatcher = new TableMatcher();
+        $matchedTables = $tableMatcher->match($connectionProphecy->reveal(), $expression);
+
+        foreach ($expectedMatches as $expectedMatch) {
+            $this->assertTrue(in_array($expectedMatch, $matchedTables, true), sprintf('Expected table %s is not found in match result', $expectedMatch));
+        }
+        $this->assertCount(count($expectedMatches), $matchedTables, 'Count of expected matches is not the same as count of actual matches');
+    }
+
+    /**
+     * @test
+     */
+    public function matchAllowsSpecifyingMultipleExpressions()
+    {
+        $tables = [
+            'cf_foo',
+            'cf_foo_tags',
+            'cf_bar',
+            'cf_bar_tags',
+            'cache_foo',
+            'cache_foo_tags',
+            'fe_sessions',
+            'be_sessions',
+        ];
+        $expectedMatches = [
+            'cf_foo',
+            'cf_foo_tags',
+            'cf_bar',
+            'cf_bar_tags',
+            'cache_foo',
+            'cache_foo_tags',
+        ];
+        $connectionProphecy = $this->prophesize(Connection::class);
+        $schemaManagerProphecy = $this->prophesize(AbstractSchemaManager::class);
+        $schemaManagerProphecy->listTableNames()->willReturn($tables)->shouldBeCalled();
+        $connectionProphecy->getSchemaManager()->willReturn($schemaManagerProphecy->reveal())->shouldBeCalled();
+
+        $tableMatcher = new TableMatcher();
+        $matchedTables = $tableMatcher->match($connectionProphecy->reveal(), 'cf_*', 'cache_*');
+
+        foreach ($expectedMatches as $expectedMatch) {
+            $this->assertTrue(in_array($expectedMatch, $matchedTables, true), sprintf('Expected table %s is not found in match result', $expectedMatch));
+        }
+        $this->assertCount(count($expectedMatches), $matchedTables, 'Count of expected matches is not the same as count of actual matches');
+    }
+}


### PR DESCRIPTION
Allow specifying wildcards to database:export like:

    typo3cms database:export --exclude-tables 'cf_*,cache_*'