### PR TITLE
[FEATURE] Make database:export a native Symfony command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ script:
   - .Build/bin/parallel-lint --exclude .Build .
   # This fails when command reference is not up to date
   - ./typo3cms commandreference:render > /dev/null 2>&1 && test -z "$(git diff --shortstat 2> /dev/null | tail -n1)";
+  - git diff
   - .Build/bin/phpunit;
 
 # Configure build stages (with build matrix above, test stage is implicitly defined)

--- a/Classes/Console/Command/AbstractConvertedCommand.php
+++ b/Classes/Console/Command/AbstractConvertedCommand.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Command;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @deprecated Will be removed with 6.0
+ */
+abstract class AbstractConvertedCommand extends Command
+{
+    private $synopsis = [];
+
+    public function getNativeDefinition()
+    {
+        $definition = new InputDefinition($this->createNativeDefinition());
+        $definition->addOptions($this->getApplication()->getDefinition()->getOptions());
+
+        return $definition;
+    }
+
+    public function getSynopsis($short = false)
+    {
+        $key = $short ? 'short' : 'long';
+
+        if (!isset($this->synopsis[$key])) {
+            $this->synopsis[$key] = trim(sprintf('%s %s', $this->getName(), (new InputDefinition($this->createNativeDefinition()))->getSynopsis($short)));
+        }
+
+        return $this->synopsis[$key];
+    }
+
+    protected function createCompleteInputDefinition()
+    {
+        return array_merge($this->createNativeDefinition(), $this->createDeprecatedDefinition());
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->handleDeprecatedArgumentsAndOptions($input, $output);
+    }
+
+    abstract protected function createNativeDefinition(): array;
+
+    abstract protected function createDeprecatedDefinition(): array;
+
+    abstract protected function handleDeprecatedArgumentsAndOptions(InputInterface $input, OutputInterface $output);
+}

--- a/Classes/Console/Command/Database/DatabaseExportCommand.php
+++ b/Classes/Console/Command/Database/DatabaseExportCommand.php
@@ -174,11 +174,11 @@ EOH
         $messages = null;
         if ($input->getArgument('excludeTables')) {
             $excludeTables = explode(',', $input->getArgument('excludeTables'));
-            $messages[] = '<warning>Passing excluded tables as argument is deprecated. Please use --exclude-table instead.</warning>';
+            $messages[] = '<warning>Passing excluded tables as argument is deprecated. Please use --exclude instead.</warning>';
         }
         if ($input->getOption('exclude-tables')) {
             $excludeTables = explode(',', $input->getOption('exclude-tables'));
-            $messages[] = '<warning>Option --exclude-tables is deprecated. Please use --exclude-table for each exclude instead.</warning>';
+            $messages[] = '<warning>Option --exclude-tables is deprecated. Please use --exclude for each exclude instead.</warning>';
         }
         if ($messages !== null && $excludeTables !== null) {
             $input->setOption('exclude', $excludeTables);

--- a/Classes/Console/Command/Database/DatabaseExportCommand.php
+++ b/Classes/Console/Command/Database/DatabaseExportCommand.php
@@ -1,0 +1,190 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Command\Database;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Command\AbstractConvertedCommand;
+use Helhum\Typo3Console\Database\Configuration\ConnectionConfiguration;
+use Helhum\Typo3Console\Database\Process\MysqlCommand;
+use Helhum\Typo3Console\Database\Schema\TableMatcher;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class DatabaseExportCommand extends AbstractConvertedCommand
+{
+    /**
+     * @var ConnectionConfiguration
+     */
+    private $connectionConfiguration;
+
+    public function __construct(string $name = null, ConnectionConfiguration $connectionConfiguration = null)
+    {
+        parent::__construct($name);
+        $this->connectionConfiguration = $connectionConfiguration ?: new ConnectionConfiguration();
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Export database to stdout');
+        $this->setHelp(
+            <<<'EOH'
+Export the database (all tables) directly to stdout.
+The mysqldump binary must be available in the path for this command to work.
+This obviously only works when MySQL is used as DBMS.
+
+Tables to be excluded from the export can be specified fully qualified or with wildcards:
+
+<b>Example:</b> <code>%command.full_name% -c Default -e 'cf_*' -e 'cache_*' -e '[bf]e_sessions' -e sys_log</code>
+EOH
+        );
+
+        $this->setDefinition($this->createCompleteInputDefinition());
+    }
+
+    protected function createNativeDefinition(): array
+    {
+        return [
+            new InputOption(
+                'exclude',
+                '-e',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Full table name or wildcard expression to exclude from the export.',
+                []
+            ),
+            new InputOption(
+                'connection',
+                '-c',
+                InputOption::VALUE_REQUIRED,
+                'TYPO3 database connection name (defaults to all configured MySQL connections)',
+                null
+            ),
+        ];
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $connection = $input->getOption('connection');
+        $excludes = $input->getOption('exclude');
+
+        $availableConnectionNames = $connectionNames = $this->connectionConfiguration->getAvailableConnectionNames('mysql');
+        $failureReason = '';
+        if ($connection !== null) {
+            $availableConnectionNames = array_intersect($connectionNames, [$connection]);
+            $failureReason = sprintf(' Given connection "%s" is not configured as MySQL connection.', $connection);
+        }
+        if (empty($availableConnectionNames)) {
+            $output->writeln(sprintf('<error>No MySQL connections found to export.%s</error>', $failureReason));
+
+            return 2;
+        }
+
+        foreach ($availableConnectionNames as $mysqlConnectionName) {
+            $mysqlCommand = new MysqlCommand($this->connectionConfiguration->build($mysqlConnectionName), [], $output);
+            $exitCode = $mysqlCommand->mysqldump(
+                $this->buildArguments($mysqlConnectionName, $excludes, $output),
+                null,
+                $mysqlConnectionName
+            );
+
+            if ($exitCode !== 0) {
+                $output->writeln(sprintf('<error>Could not dump SQL for connection "%s",</error>', $mysqlConnectionName));
+
+                return $exitCode;
+            }
+        }
+
+        return 0;
+    }
+
+    private function buildArguments(string $mysqlConnectionName, array $excludes, OutputInterface $output): array
+    {
+        $dbConfig = $this->connectionConfiguration->build($mysqlConnectionName);
+        $arguments = [
+            '--opt',
+            '--single-transaction',
+        ];
+
+        if ($output->isVerbose()) {
+            $arguments[] = '--verbose';
+        }
+
+        foreach ($this->matchTables($excludes, $mysqlConnectionName) as $table) {
+            $arguments[] = sprintf('--ignore-table=%s.%s', $dbConfig['dbname'], $table);
+        }
+
+        return $arguments;
+    }
+
+    private function matchTables(array $excludes, string $connection): array
+    {
+        if (empty($excludes)) {
+            return [];
+        }
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionByName($connection);
+
+        return (new TableMatcher())->match($connection, ...$excludes);
+    }
+
+    /**
+     * @deprecated will be removed with 6.0
+     *
+     * @return array
+     */
+    protected function createDeprecatedDefinition(): array
+    {
+        return [
+            new InputArgument(
+                'excludeTables',
+                null,
+                'Comma-separated list of table names to exclude from the export. Wildcards are supported.',
+                []
+            ),
+            new InputOption(
+                'exclude-tables',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Comma-separated list of table names to exclude from the export. Wildcards are supported.',
+                []
+            ),
+        ];
+    }
+
+    /**
+     * @deprecated will be removed with 6.0
+     */
+    protected function handleDeprecatedArgumentsAndOptions(InputInterface $input, OutputInterface $output)
+    {
+        $excludeTables = null;
+        $messages = null;
+        if ($input->getArgument('excludeTables')) {
+            $excludeTables = explode(',', $input->getArgument('excludeTables'));
+            $messages[] = '<warning>Passing excluded tables as argument is deprecated. Please use --exclude-table instead.</warning>';
+        }
+        if ($input->getOption('exclude-tables')) {
+            $excludeTables = explode(',', $input->getOption('exclude-tables'));
+            $messages[] = '<warning>Option --exclude-tables is deprecated. Please use --exclude-table for each exclude instead.</warning>';
+        }
+        if ($messages !== null && $excludeTables !== null) {
+            $input->setOption('exclude', $excludeTables);
+            if ($output instanceof ConsoleOutput) {
+                $output->getErrorOutput()->writeln($messages);
+            }
+        }
+    }
+}

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -112,8 +112,7 @@ return [
         ],
         'database:export' => [
             'vendor' => 'typo3_console',
-            'controller' => Helhum\Typo3Console\Command\DatabaseCommandController::class,
-            'controllerCommandName' => 'export',
+            'class' => Helhum\Typo3Console\Command\Database\DatabaseExportCommand::class,
             'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         ],
         'database:import' => [

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -615,24 +615,24 @@ Export the database (all tables) directly to stdout.
 The mysqldump binary must be available in the path for this command to work.
 This obviously only works when MySQL is used as DBMS.
 
-A comma-separated list of tables can be passed to exclude from the export:
+Tables to be excluded from the export can be specified fully qualified or with wildcards:
 
-**Example:** ``typo3cms database:export --exclude-tables 'cf_*,cache_*,[bf]e_sessions,sys_log'``
+**Example:** ``typo3cms database:export -c Default -e 'cf_*' -e 'cache_*' -e '[bf]e_sessions' -e sys_log``
 
 
 
 Options
 ^^^^^^^
 
-``--exclude-tables``
-  Comma-separated list of table names to exclude from the export. Wildcards are supported.
+``--exclude|-e``
+  Full table name or wildcard expression to exclude from the export.
 
 - Accept value: yes
 - Is value required: yes
-- Is multiple: no
+- Is multiple: yes
 - Default: array ()
 
-``--connection``
+``--connection|-c``
   TYPO3 database connection name (defaults to all configured MySQL connections)
 
 - Accept value: yes

--- a/Packages/ConvertCommandControllerCommand/.gitignore
+++ b/Packages/ConvertCommandControllerCommand/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/composer.lock

--- a/Packages/ConvertCommandControllerCommand/Configuration/Console/Commands.php
+++ b/Packages/ConvertCommandControllerCommand/Configuration/Console/Commands.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+return [
+    'commands' => [
+        'convert-command-controller' => [
+            'class' => \Typo3Console\ConvertCommandControllerCommand\Command\ConvertCommandControllerCommand::class,
+            'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
+            'vendor' => 'typo3_console',
+        ],
+    ],
+];

--- a/Packages/ConvertCommandControllerCommand/composer.json
+++ b/Packages/ConvertCommandControllerCommand/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "typo3-console/convert-command-controller-command",
+    "description": "Converts command controller commands to native Symfony commands",
+    "license": "GPL-2.0-or-later",
+    "type": "typo3-console-command",
+    "authors": [
+        {
+            "name": "Helmut Hummel",
+            "email": "info@helhum.io"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Typo3Console\\ConvertCommandControllerCommand\\": "src/"
+        }
+    },
+    "require": {
+        "php": ">=7.0 <7.3",
+        "helhum/typo3-console": "^5.0"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
+}

--- a/Packages/ConvertCommandControllerCommand/src/Command/ConvertCommandControllerCommand.php
+++ b/Packages/ConvertCommandControllerCommand/src/Command/ConvertCommandControllerCommand.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+namespace Typo3Console\ConvertCommandControllerCommand\Command;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Exception;
+use Helhum\Typo3Console\Mvc\Cli\Symfony\Command\CommandControllerCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConvertCommandControllerCommand extends \Symfony\Component\Console\Command\Command
+{
+    protected function configure()
+    {
+        $this->setDefinition(
+            new InputDefinition(
+                [
+                    new InputArgument(
+                        'commandName',
+                        InputArgument::IS_ARRAY,
+                        'Convert these commands'
+                    ),
+                ]
+            )
+        )
+        ->setDescription('Converts command controller commands');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        foreach ($input->getArgument('commandName') as $commandName) {
+            $configureCode = '';
+            $command = $this->getApplication()->get($commandName);
+            if (!$command instanceof CommandControllerCommand) {
+                throw new Exception('Nope', 1530033958);
+            }
+            $configureCode .= $this->getDescriptionCode($command);
+            $configureCode .= $this->getOptionDefinitionCode($command->getDefinition());
+            $configureCode .= $this->getArgumentDefinitionCode($command->getDefinition());
+            echo $configureCode;
+        }
+    }
+
+    private function getDescriptionCode(Command $command)
+    {
+        $help = $command->getHelp();
+        $description = addcslashes($command->getDescription(), '\'');
+
+        return <<<EOD
+\$this->setDescription('$description');
+\$this->setHelp(<<<'EOH'
+$help
+EOH
+);
+
+EOD;
+    }
+
+    private function getOptionDefinitionCode(InputDefinition $inputDefinition)
+    {
+        $optionCodeTemplate = <<<'EOO'
+                    new InputOption(
+                        %s,
+                        null,
+                        %s,
+                        %s,
+                        %s
+                    ),
+
+EOO;
+        $defineOptionsCode = ['               new InputDefinition([' . PHP_EOL];
+        foreach ($inputDefinition->getOptions() as $option) {
+            if ($this->getApplication()->getDefinition()->hasOption($option->getName())) {
+                continue;
+            }
+            $modes = [];
+            if ($option->isValueOptional()) {
+                $modes[] = 'InputOption::VALUE_OPTIONAL';
+            }
+            if ($option->isValueRequired()) {
+                $modes[] = 'InputOption::VALUE_REQUIRED';
+            }
+            if ($option->isArray()) {
+                $modes[] = 'InputOption::VALUE_IS_ARRAY';
+            }
+            $defineOptionsCode[] = sprintf(
+                $optionCodeTemplate,
+                var_export($option->getName(), true),
+                !empty($modes) ? implode(' | ', $modes) : 'null',
+                var_export($option->getDescription(), true),
+                var_export($option->getDefault(), true)
+            );
+        }
+        $defineOptionsCode[] = '              ]);' . PHP_EOL;
+
+        return implode(PHP_EOL, $defineOptionsCode);
+    }
+
+    private function getArgumentDefinitionCode(InputDefinition $inputDefinition)
+    {
+        $argumentCodeTemplate = <<<'EOO'
+                    new InputArgument(
+                        %s,
+                        %s,
+                        %s,
+                        %s
+                    ),
+
+EOO;
+        $defineArgumentsCode = ['               new InputDefinition([' . PHP_EOL];
+        foreach ($inputDefinition->getArguments() as $argument) {
+            $modes = [];
+            if ($argument->isRequired()) {
+                $modes[] = 'InputArgument::REQUIRED';
+            }
+            if ($argument->isArray()) {
+                $modes[] = 'InputArgument::IS_ARRAY';
+            }
+            $defineArgumentsCode[] = sprintf(
+                $argumentCodeTemplate,
+                var_export($argument->getName(), true),
+                !empty($modes) ? implode(' | ', $modes) : 'null',
+                var_export($argument->getDescription(), true),
+                var_export($argument->getDefault(), true)
+            );
+        }
+        $defineArgumentsCode[] = '              ]);' . PHP_EOL;
+
+        return implode(PHP_EOL, $defineArgumentsCode);
+    }
+}

--- a/Packages/CreateReferenceCommand/src/Command/CommandReferenceRenderCommand.php
+++ b/Packages/CreateReferenceCommand/src/Command/CommandReferenceRenderCommand.php
@@ -43,6 +43,7 @@ class CommandReferenceRenderCommand extends \Symfony\Component\Console\Command\C
 {
     private $skipCommands = [
         'commandreference:render',
+        'convert-command-controller',
         'language:update',
         'server:run',
         'swiftmailer:spool:send',

--- a/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
@@ -185,7 +185,7 @@ class DatabaseCommandControllerTest extends AbstractCommandTest
      */
     public function databaseExportCanExcludeTables()
     {
-        $output = $this->executeConsoleCommand('database:export', ['--exclude-tables' => 'sys_log']);
+        $output = $this->executeConsoleCommand('database:export', ['--exclude', 'sys_log']);
         $this->assertNotContains('CREATE TABLE `sys_log`', $output);
     }
 
@@ -194,7 +194,27 @@ class DatabaseCommandControllerTest extends AbstractCommandTest
      */
     public function databaseExportCanExcludeTablesWithWildcards()
     {
-        $output = $this->executeConsoleCommand('database:export', ['--exclude-tables' => 'cf_*']);
+        $output = $this->executeConsoleCommand('database:export', ['--exclude', 'cf_*', '-e', 'cache_*']);
         $this->assertNotContains('CREATE TABLE `cf_', $output);
+        $this->assertNotContains('CREATE TABLE `cache_', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function databaseExportCanExcludeTablesWithDeprecatedOption()
+    {
+        $output = $this->executeConsoleCommand('database:export', ['--exclude-tables', 'sys_log']);
+        $this->assertNotContains('CREATE TABLE `sys_log`', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function databaseExportCanExcludeTablesWithWildcardsWithDeprecatedOption()
+    {
+        $output = $this->executeConsoleCommand('database:export', ['--exclude-tables', 'cf_*,cache_*']);
+        $this->assertNotContains('CREATE TABLE `cf_', $output);
+        $this->assertNotContains('CREATE TABLE `cache_', $output);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,9 @@
         "typo3/cms-reports": "^8.7.10 || >=9.1.0 <9.4 || 9.4.*@dev",
         "typo3/cms-filemetadata": "^8.7.10 || >=9.1.0 <9.4 || 9.4.*@dev",
 
-        "typo3-console/php-server-command": "^0.2",
+        "typo3-console/convert-command-controller-command": "@dev",
         "typo3-console/create-reference-command": "@dev",
+        "typo3-console/php-server-command": "^0.2",
         "symfony/filesystem": "^3.2",
         "nimut/testing-framework": "dev-master",
         "cweagans/composer-patches": "^1.6",


### PR DESCRIPTION
This allows us to use dedicated Symfony features like
array values for options and short option names.

This change also comes with an abstract class, which should
ease conversion of other commands and still handling
backwards compatibility.