### PR TITLE
Support command options with a single character name

### DIFF
--- a/Classes/Console/Mvc/Cli/CommandArgumentDefinition.php
+++ b/Classes/Console/Mvc/Cli/CommandArgumentDefinition.php
@@ -105,6 +105,9 @@ class CommandArgumentDefinition
      */
     public function getOptionName(): string
     {
+        if (strlen($this->name) === 1) {
+            return strtolower($this->name);
+        }
         $dashedName = ucfirst($this->name);
         $dashedName = preg_replace('/([A-Z][a-z0-9]+)/', '$1-', $dashedName);
 


### PR DESCRIPTION
Fix #738 

If the option name has only one character just return it.