### PR TITLE
Support command options with a single character name

### DIFF
--- a/Classes/Console/Mvc/Cli/CommandArgumentDefinition.php
+++ b/Classes/Console/Mvc/Cli/CommandArgumentDefinition.php
@@ -106,7 +106,7 @@ class CommandArgumentDefinition
     public function getOptionName(): string
     {
         $dashedName = ucfirst($this->name);
-        $dashedName = preg_replace('/([A-Z][a-z0-9]+)/', '$1-', $dashedName);
+        $dashedName = preg_replace('/([A-Z][a-z0-9]*)/', '$1-', $dashedName);
 
         return strtolower(substr($dashedName, 0, -1));
     }


### PR DESCRIPTION
Fix #738

This commit is meant to replace commit 63d69bdc76b3cb4e5d62b285fb49ecdec744d716