### PR TITLE
[BUGFIX] Ensure TYPO3 9.4 compatibility

### DIFF
--- a/Classes/Console/Core/Booting/Scripts.php
+++ b/Classes/Console/Core/Booting/Scripts.php
@@ -59,9 +59,9 @@ class Scripts
         define('PATH_thisScript', PATH_site . 'typo3/index.php');
 
         $bootstrap->setRequestType(TYPO3_REQUESTTYPE_BE | TYPO3_REQUESTTYPE_CLI);
-        $bootstrap->baseSetup();
-        // Mute notices
-        error_reporting(E_ALL & ~E_NOTICE);
+        $bootstrap->baseSetup(0);
+        // Mute notices and deprecations
+        error_reporting(E_ALL & ~(E_USER_DEPRECATED | E_NOTICE));
         $exceptionHandler = new ExceptionHandler();
         set_exception_handler([$exceptionHandler, 'handleException']);
 
@@ -160,6 +160,8 @@ class Scripts
      */
     public static function initializeExtensionConfiguration(Bootstrap $bootstrap)
     {
+        // Un-Mute deprecations
+        error_reporting(E_ALL & ~E_NOTICE);
         CompatibilityScripts::initializeExtensionConfiguration($bootstrap);
         ExtensionManagementUtility::loadExtLocalconf();
         $bootstrap->setFinalCachingFrameworkCacheConfiguration();

--- a/Classes/Console/Core/Kernel.php
+++ b/Classes/Console/Core/Kernel.php
@@ -56,6 +56,7 @@ class Kernel
 
     public function __construct(\Composer\Autoload\ClassLoader $classLoader)
     {
+        error_reporting(E_ALL & ~E_USER_DEPRECATED);
         $this->classLoader = $classLoader;
         $this->ensureRequiredEnvironment();
         $this->bootstrap = Bootstrap::getInstance();

--- a/Tests/Console/Unit/Service/CacheServiceTest.php
+++ b/Tests/Console/Unit/Service/CacheServiceTest.php
@@ -18,14 +18,12 @@ use Helhum\Typo3Console\Service\CacheService;
 use Helhum\Typo3Console\Service\Configuration\ConfigurationService;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Core\Bootstrap;
 
-/**
- * Class CacheServiceTest
- */
 class CacheServiceTest extends UnitTestCase
 {
     /**
-     * @var \Helhum\Typo3Console\Service\CacheService|\PHPUnit_Framework_MockObject_MockObject|\TYPO3\CMS\Core\Tests\AccessibleObjectInterface
+     * @var \Helhum\Typo3Console\Service\CacheService
      */
     protected $subject;
 
@@ -33,7 +31,8 @@ class CacheServiceTest extends UnitTestCase
     {
         $cacheManagerMock = $this->getMockBuilder(CacheManager::class)->disableOriginalConstructor()->getMock();
         $configurationServiceMock = $this->getMockBuilder(ConfigurationService::class)->disableOriginalConstructor()->getMock();
-        $this->subject = new CacheService($cacheManagerMock, $configurationServiceMock);
+        $bootstrapMock = $this->getMockBuilder(Bootstrap::class)->disableOriginalConstructor()->getMock();
+        $this->subject = new CacheService($cacheManagerMock, $configurationServiceMock, $bootstrapMock);
     }
 
     /**


### PR DESCRIPTION
Hide deprecations in early bootstrap and
pass an integer to Bootstrap::baseSetup to avoid strict errors