### PR TITLE
[BUGFIX] Drop dependency on saltedpasswords

### DIFF
--- a/Resources/Private/ExtensionArtifacts/ext_emconf.php
+++ b/Resources/Private/ExtensionArtifacts/ext_emconf.php
@@ -21,7 +21,6 @@ $EM_CONF[$_EXTKEY] = [
       'fluid' => '8.7.10-9.4.99',
       'install' => '8.7.10-9.4.99',
       'scheduler' => '8.7.10-9.4.99',
-      'saltedpasswords' => '8.7.10-9.4.99',
     ],
     'conflicts' => [
         'dbal' => '',


### PR DESCRIPTION
This has been merged into core with TYPO3 9.4 and there is no replacement concept for TYPO3 extensions.

Fixes #749