### PR TITLE
[FEATURE] Delay output of booting errors

### DIFF
--- a/Classes/Console/Core/Booting/RunLevel.php
+++ b/Classes/Console/Core/Booting/RunLevel.php
@@ -289,7 +289,7 @@ class RunLevel
     public function getRunLevelForCommand(string $commandIdentifier): string
     {
         if (in_array($commandIdentifier, ['help', 'list'], true)) {
-            return $this->getMaximumAvailableRunLevel();
+            return $this->getMaximumAvailableRunLevel() === self::LEVEL_COMPILE ? self::LEVEL_COMPILE : self::LEVEL_MINIMAL;
         }
         $options = $this->getOptionsForCommand($commandIdentifier);
 

--- a/Classes/Console/Core/Booting/RunLevel.php
+++ b/Classes/Console/Core/Booting/RunLevel.php
@@ -179,14 +179,7 @@ class RunLevel
     {
         $sequence = $this->buildEssentialSequence(self::LEVEL_COMPILE);
 
-        $sequence->addStep(new Step('helhum.typo3console:loadextbaseconfiguration', function () {
-            // TODO: hack alarm :) We remove this in order to prevent double inclusion of the ext_localconf.php
-            // This should be fine although not very nice
-            // We should change that to include all ext_localconf of required exts in configuration step and reset this array key there then
-            // OK, this does not work when there is a cached file... of course, but in compile time we do not have caches
-            unset($GLOBALS['TYPO3_LOADED_EXT']['extbase']['ext_localconf.php']);
-            require PATH_site . 'typo3/sysext/extbase/ext_localconf.php';
-        }));
+        $this->addStep($sequence, 'helhum.typo3console:loadextbaseconfiguration');
 
         return $sequence;
     }
@@ -243,37 +236,49 @@ class RunLevel
         switch ($stepIdentifier) {
             // Part of essential sequence
             case 'helhum.typo3console:coreconfiguration':
-                $sequence->addStep(new Step('helhum.typo3console:coreconfiguration', [Scripts::class, 'initializeConfigurationManagement']));
+                $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializeConfigurationManagement']));
                 break;
             case 'helhum.typo3console:providecleanclassimplementations':
-                $sequence->addStep(new Step('helhum.typo3console:providecleanclassimplementations', [Scripts::class, 'provideCleanClassImplementations']), 'helhum.typo3console:coreconfiguration');
+                $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'provideCleanClassImplementations']), 'helhum.typo3console:coreconfiguration');
                 break;
             case 'helhum.typo3console:disabledcaching':
-                $sequence->addStep(new Step('helhum.typo3console:disabledcaching', [Scripts::class, 'initializeDisabledCaching']), 'helhum.typo3console:coreconfiguration');
+                $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializeDisabledCaching']), 'helhum.typo3console:coreconfiguration');
                 break;
             case 'helhum.typo3console:errorhandling':
-                $sequence->addStep(new Step('helhum.typo3console:errorhandling', [Scripts::class, 'initializeErrorHandling']));
+                $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializeErrorHandling']));
+                break;
+
+            // Part of compile time
+            case 'helhum.typo3console:loadextbaseconfiguration':
+                $sequence->addStep(new Step($stepIdentifier, function () {
+                    // @deprecated in 5.5, will be removed in 6.0
+                    // Requirement for the removal is converting all command controllers to Symfony commands
+                    // and removing all usages of ObjectManager in our code, which is the reason we include
+                    // this file early, to get the ObjectManager configured properly
+                    unset($GLOBALS['TYPO3_LOADED_EXT']['extbase']['ext_localconf.php']);
+                    require PATH_site . 'typo3/sysext/extbase/ext_localconf.php';
+                }));
                 break;
 
             // Part of basic runtime
             case 'helhum.typo3console:extensionconfiguration':
-                $sequence->addStep(new Step('helhum.typo3console:extensionconfiguration', [Scripts::class, 'initializeExtensionConfiguration']));
+                $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializeExtensionConfiguration']));
                 break;
 
             // Part of full runtime
             case 'helhum.typo3console:caching':
                 $sequence->removeStep('helhum.typo3console:disabledcaching');
-                $sequence->addStep(new Step('helhum.typo3console:caching', [Scripts::class, 'initializeCaching']), 'helhum.typo3console:coreconfiguration');
+                $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializeCaching']), 'helhum.typo3console:coreconfiguration');
                 break;
             case 'helhum.typo3console:database':
                 // @deprecated can be removed if TYPO3 8 support is removed
-                $sequence->addStep(new Step('helhum.typo3console:database', [CompatibilityScripts::class, 'initializeDatabaseConnection']), 'helhum.typo3console:errorhandling');
+                $sequence->addStep(new Step($stepIdentifier, [CompatibilityScripts::class, 'initializeDatabaseConnection']), 'helhum.typo3console:errorhandling');
                 break;
             case 'helhum.typo3console:persistence':
-                $sequence->addStep(new Step('helhum.typo3console:persistence', [Scripts::class, 'initializePersistence']), 'helhum.typo3console:extensionconfiguration');
+                $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializePersistence']), 'helhum.typo3console:extensionconfiguration');
                 break;
             case 'helhum.typo3console:authentication':
-                $sequence->addStep(new Step('helhum.typo3console:authentication', [Scripts::class, 'initializeAuthenticatedOperations']), 'helhum.typo3console:extensionconfiguration');
+                $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializeAuthenticatedOperations']), 'helhum.typo3console:extensionconfiguration');
                 break;
 
             default:

--- a/Classes/Console/Core/Booting/RunLevel.php
+++ b/Classes/Console/Core/Booting/RunLevel.php
@@ -39,6 +39,11 @@ class RunLevel
      */
     private $bootstrap;
 
+    /**
+     * @var \Throwable
+     */
+    private $error;
+
     public function __construct(Bootstrap $bootstrap)
     {
         $this->bootstrap = $bootstrap;
@@ -82,12 +87,44 @@ class RunLevel
 
     /**
      * @param string $commandIdentifier
-     * @throws InvalidArgumentException
+     * @throws \Exception
      * @internal
      */
     public function runSequenceForCommand(string $commandIdentifier)
     {
-        $this->buildSequenceForCommand($commandIdentifier)->invoke($this->bootstrap);
+        $sequence = $this->buildSequenceForCommand($commandIdentifier);
+        try {
+            $sequence->invoke($this->bootstrap);
+        } catch (StepFailedException $e) {
+            $failedStep = $e->getFailedStep();
+            if ($this->isLowLevelStep($failedStep) || !$this->isInternalCommand($commandIdentifier)) {
+                // This seems to be a severe error, so we directly throw to expose it
+                // We always expose the error, when a command is called directly
+                throw $e->getPrevious();
+            }
+
+            $this->error = $e->getPrevious();
+        }
+    }
+
+    /**
+     * @return \Throwable|null
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    private function isInternalCommand(string $commandIdentifier): bool
+    {
+        return in_array($commandIdentifier, ['list', 'help'], true);
+    }
+
+    private function isLowLevelStep(Step $step): bool
+    {
+        $runLevelForStep = $this->executedSteps[$step->getIdentifier()];
+
+        return in_array($runLevelForStep, [self::LEVEL_ESSENTIAL, self::LEVEL_COMPILE], true);
     }
 
     /**
@@ -224,32 +261,36 @@ class RunLevel
      */
     private function addStep(Sequence $sequence, string $stepIdentifier)
     {
-        if (!empty($this->executedSteps[$stepIdentifier])) {
+        if (isset($this->executedSteps[$stepIdentifier])) {
             $sequence->addStep(new Step($stepIdentifier, function () {
                 // Don't do anything again, step has been executed already
             }));
 
             return;
         }
-        $this->executedSteps[$stepIdentifier] = true;
 
         switch ($stepIdentifier) {
             // Part of essential sequence
             case 'helhum.typo3console:coreconfiguration':
+                $this->executedSteps[$stepIdentifier] = self::LEVEL_ESSENTIAL;
                 $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializeConfigurationManagement']));
                 break;
             case 'helhum.typo3console:providecleanclassimplementations':
+                $this->executedSteps[$stepIdentifier] = self::LEVEL_ESSENTIAL;
                 $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'provideCleanClassImplementations']), 'helhum.typo3console:coreconfiguration');
                 break;
             case 'helhum.typo3console:disabledcaching':
+                $this->executedSteps[$stepIdentifier] = self::LEVEL_ESSENTIAL;
                 $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializeDisabledCaching']), 'helhum.typo3console:coreconfiguration');
                 break;
             case 'helhum.typo3console:errorhandling':
+                $this->executedSteps[$stepIdentifier] = self::LEVEL_ESSENTIAL;
                 $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializeErrorHandling']));
                 break;
 
             // Part of compile time
             case 'helhum.typo3console:loadextbaseconfiguration':
+                $this->executedSteps[$stepIdentifier] = self::LEVEL_COMPILE;
                 $sequence->addStep(new Step($stepIdentifier, function () {
                     // @deprecated in 5.5, will be removed in 6.0
                     // Requirement for the removal is converting all command controllers to Symfony commands
@@ -262,22 +303,27 @@ class RunLevel
 
             // Part of basic runtime
             case 'helhum.typo3console:extensionconfiguration':
+                $this->executedSteps[$stepIdentifier] = self::LEVEL_MINIMAL;
                 $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializeExtensionConfiguration']));
                 break;
 
             // Part of full runtime
             case 'helhum.typo3console:caching':
+                $this->executedSteps[$stepIdentifier] = self::LEVEL_FULL;
+                unset($this->executedSteps['helhum.typo3console:disabledcaching']);
                 $sequence->removeStep('helhum.typo3console:disabledcaching');
                 $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializeCaching']), 'helhum.typo3console:coreconfiguration');
                 break;
             case 'helhum.typo3console:database':
                 // @deprecated can be removed if TYPO3 8 support is removed
+                $this->executedSteps[$stepIdentifier] = self::LEVEL_FULL;
                 $sequence->addStep(new Step($stepIdentifier, [CompatibilityScripts::class, 'initializeDatabaseConnection']), 'helhum.typo3console:errorhandling');
                 break;
             case 'helhum.typo3console:persistence':
                 $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializePersistence']), 'helhum.typo3console:extensionconfiguration');
                 break;
             case 'helhum.typo3console:authentication':
+                $this->executedSteps[$stepIdentifier] = self::LEVEL_FULL;
                 $sequence->addStep(new Step($stepIdentifier, [Scripts::class, 'initializeAuthenticatedOperations']), 'helhum.typo3console:extensionconfiguration');
                 break;
 
@@ -293,7 +339,7 @@ class RunLevel
      */
     public function getRunLevelForCommand(string $commandIdentifier): string
     {
-        if (in_array($commandIdentifier, ['help', 'list'], true)) {
+        if ($this->isInternalCommand($commandIdentifier)) {
             return $this->getMaximumAvailableRunLevel() === self::LEVEL_COMPILE ? self::LEVEL_COMPILE : self::LEVEL_MINIMAL;
         }
         $options = $this->getOptionsForCommand($commandIdentifier);

--- a/Classes/Console/Core/Booting/Sequence.php
+++ b/Classes/Console/Core/Booting/Sequence.php
@@ -99,14 +99,19 @@ class Sequence
      * Invokes a single step of this sequence and also invokes all steps registered
      * to be executed after the given step.
      *
-     * @param \Helhum\Typo3Console\Core\Booting\Step $step The step to invoke
+     * @param Step $step The step to invoke
      * @param Bootstrap $bootstrap
+     * @throws StepFailedException
      * @return void
      */
     protected function invokeStep(Step $step, Bootstrap $bootstrap)
     {
         $identifier = $step->getIdentifier();
-        $step($bootstrap);
+        try {
+            $step($bootstrap);
+        } catch (\Throwable $e) {
+            throw new StepFailedException($step, $e);
+        }
         if (isset($this->steps[$identifier])) {
             foreach ($this->steps[$identifier] as $followingStep) {
                 $this->invokeStep($followingStep, $bootstrap);

--- a/Classes/Console/Core/Booting/StepFailedException.php
+++ b/Classes/Console/Core/Booting/StepFailedException.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Core\Booting;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Exception;
+
+/**
+ * When executing a step causes an exception to occur
+ */
+class StepFailedException extends Exception
+{
+    /**
+     * @var Step
+     */
+    private $step;
+
+    public function __construct(Step $step, \Throwable $previous)
+    {
+        parent::__construct($previous->getMessage(), $previous->getCode(), $previous);
+        $this->step = $step;
+    }
+
+    public function getFailedStep(): Step
+    {
+        return $this->step;
+    }
+}

--- a/Classes/Console/Core/Kernel.php
+++ b/Classes/Console/Core/Kernel.php
@@ -176,7 +176,7 @@ class Kernel
      */
     public function terminate(int $exitCode = 0)
     {
-        if ($exitCode > 255) {
+        if ($exitCode > 255 || ($exitCode === 0 && $this->runLevel->getError())) {
             $exitCode = 255;
         }
         exit($exitCode);

--- a/Classes/Console/Mvc/Cli/Symfony/Application.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Application.php
@@ -27,6 +27,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -153,5 +154,14 @@ class Application extends BaseApplication
         $output->getFormatter()->setStyle('ins', new OutputFormatterStyle('green'));
         $output->getFormatter()->setStyle('del', new OutputFormatterStyle('red'));
         $output->getFormatter()->setStyle('code', new OutputFormatterStyle(null, null, ['bold']));
+        if ($e = $this->runLevel->getError()) {
+            if ($output->isVerbose()) {
+                throw $e;
+            }
+            if ($output instanceof ConsoleOutput) {
+                $errorOutput = $output->getErrorOutput();
+                $errorOutput->writeln(['', '<error>An error occurred. Some commands might not be available. Run with --verbose to see a detailed error message.</error>', '']);
+            }
+        }
     }
 }


### PR DESCRIPTION
Instead of failing before starting the console application,
we now catch booting errors and output them once the IO
is properly configured.

This means the following:

* Booting errors for all registered commands will lead to an exception just like before.
* list and help commands gracefully work but return exit code 255 and show a tiny error message
* list and help commands also throw the exception when output is verbose

This ensures that no command is executed in limbo state, except help and list,
which are not changing any state.

As "side effect" auto completion will still work, even if the current installation
is broken.