### PR TITLE
[BUGFIX] Provide option to select driver on install:setup

### DIFF
--- a/Classes/Console/Command/InstallCommandController.php
+++ b/Classes/Console/Command/InstallCommandController.php
@@ -57,6 +57,7 @@ class InstallCommandController extends CommandController
      * Command line arguments take precedence over environment variables.
      * The following environment variables are evaluated:
      *
+     * - TYPO3_INSTALL_DB_DRIVER
      * - TYPO3_INSTALL_DB_USER
      * - TYPO3_INSTALL_DB_PASSWORD
      * - TYPO3_INSTALL_DB_HOST
@@ -74,6 +75,7 @@ class InstallCommandController extends CommandController
      * @param bool $skipIntegrityCheck Skip the checking for clean state before executing setup. This allows a pre-defined <code>LocalConfiguration.php</code> to be present. Handle with care. It might lead to unexpected or broken installation results.
      * @param bool $skipExtensionSetup Skip setting up extensions after TYPO3 is set up. Defaults to false in composer setups and to true in non composer setups.
      * @param string $installStepsConfig Override install steps with the ones given in this file
+     * @param string $databaseDriver Database connection type (one of mysqli, pdo_sqlite, pdo_mysql, pdo_pgsql, mssql) Note: pdo_sqlite is only supported with TYPO3 9.5 or higher
      * @param string $databaseUserName User name for database server
      * @param string $databaseUserPassword User password for database server
      * @param string $databaseHostName Host name of database server
@@ -93,6 +95,7 @@ class InstallCommandController extends CommandController
         $skipIntegrityCheck = false,
         $skipExtensionSetup = false,
         $installStepsConfig = null,
+        $databaseDriver = 'mysqli',
         $databaseUserName = '',
         $databaseUserPassword = '',
         $databaseHostName = '127.0.0.1',
@@ -284,11 +287,12 @@ class InstallCommandController extends CommandController
      * @param string $databaseHostName Host name of database server
      * @param string $databasePort TCP Port of database server
      * @param string $databaseSocket Unix Socket to connect to
+     * @param string $databaseDriver Database connection type
      * @internal
      */
-    public function databaseConnectCommand($databaseUserName = '', $databaseUserPassword = '', $databaseHostName = '127.0.0.1', $databasePort = '3306', $databaseSocket = '')
+    public function databaseConnectCommand($databaseUserName = '', $databaseUserPassword = '', $databaseHostName = '127.0.0.1', $databasePort = '3306', $databaseSocket = '', $databaseDriver = 'mysqli')
     {
-        $this->executeActionWithArguments('databaseConnect', ['host' => $databaseHostName, 'port' => $databasePort, 'username' => $databaseUserName, 'password' => $databaseUserPassword, 'socket' => $databaseSocket, 'driver' => 'mysqli']);
+        $this->executeActionWithArguments('databaseConnect', ['host' => $databaseHostName, 'port' => $databasePort, 'username' => $databaseUserName, 'password' => $databaseUserPassword, 'socket' => $databaseSocket, 'driver' => $databaseDriver]);
     }
 
     /**

--- a/Classes/Console/Install/CliMessageRenderer.php
+++ b/Classes/Console/Install/CliMessageRenderer.php
@@ -49,7 +49,7 @@ class CliMessageRenderer
     private function renderSingle($statusMessage)
     {
         $severity = self::$severityMap[$statusMessage['severity']] ?? 'notice';
-        $subject = strtoupper($severity) . ': ' . $statusMessage['title'];
+        $subject = strtoupper($severity) . ': ' . $statusMessage['title'] ?? '';
         switch ($severity) {
             case 'error':
             case 'warning':

--- a/Configuration/Install/InstallSteps.yaml
+++ b/Configuration/Install/InstallSteps.yaml
@@ -10,6 +10,18 @@ databaseConnect:
     type: install
     description: 'Set up database connection'
     arguments:
+        databaseDriver:
+            description: 'Database connection type'
+            option: '--database-driver'
+            type: select
+            values:
+                mysqli: 'MySQL connection'
+                pdo_sqlite: 'SQLite connection (TYPO3 9.5 or higher)'
+                pdo_pgsql: 'PostgreSQL connection'
+                mssql: 'MSSQL connection'
+            value: '%env(TYPO3_INSTALL_DB_DRIVER)%'
+            default: 'mysqli'
+
         databaseUserName:
             description: 'User name for database server'
             option: '--database-user-name'

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -1149,6 +1149,7 @@ As an alternative for providing command line arguments, it is also possible to p
 Command line arguments take precedence over environment variables.
 The following environment variables are evaluated:
 
+- TYPO3_INSTALL_DB_DRIVER
 - TYPO3_INSTALL_DB_USER
 - TYPO3_INSTALL_DB_PASSWORD
 - TYPO3_INSTALL_DB_HOST
@@ -1198,6 +1199,14 @@ Options
 - Is value required: yes
 - Is multiple: no
 
+
+`--database-driver`
+   Database connection type (one of mysqli, pdo_sqlite, pdo_mysql, pdo_pgsql, mssql) Note: pdo_sqlite is only supported with TYPO3 9.5 or higher
+
+- Accept value: yes
+- Is value required: yes
+- Is multiple: no
+- Default: 'mysqli'
 
 `--database-user-name`
    User name for database server


### PR DESCRIPTION
Since we now only support doctrine only TYPO3 versions
(8.7 and 9.5), we can safely ask for alternative drivers,
but fall back to mysqli as default if none is provided.

Fixes: #450