### PR TITLE
[FEATURE] Add scheduler:enabletask and scheduler:disabletask commands

### DIFF
--- a/Classes/Console/Command/SchedulerCommandController.php
+++ b/Classes/Console/Command/SchedulerCommandController.php
@@ -117,4 +117,42 @@ class SchedulerCommandController extends CommandController
             }
         }
     }
+
+    /**
+     * Enable a scheduler task
+     *
+     * <b>Example:</b> <code>typo3cms scheduler:enable 42</code>
+     *
+     * @param int $taskId Uid of the task that should be enabled
+     */
+    public function enableTaskCommand($taskId)
+    {
+        $task = $this->scheduler->fetchTask($taskId);
+        if ($this->scheduler->isValidTaskObject($task) && $task->isDisabled()) {
+            try {
+                $task->setDisabled(false);
+                $this->scheduler->saveTask($task);
+            } catch (\Exception $e) {
+            }
+        }
+    }
+
+    /**
+     * Disable a scheduler task
+     *
+     * <b>Example:</b> <code>typo3cms scheduler:disable 42</code>
+     *
+     * @param int $taskId Uid of the task that should be disabled
+     */
+    public function disableTaskCommand($taskId)
+    {
+        $task = $this->scheduler->fetchTask($taskId);
+        if ($this->scheduler->isValidTaskObject($task) && !$task->isDisabled()) {
+            try {
+                $task->setDisabled(true);
+                $this->scheduler->saveTask($task);
+            } catch (\Exception $e) {
+            }
+        }
+    }
 }

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -281,6 +281,16 @@ return [
                 'scheduler:scheduler:run',
             ],
         ],
+        'scheduler:enabletask' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\SchedulerCommandController::class,
+            'controllerCommandName' => 'enableTask',
+        ],
+        'scheduler:disabletask' => [
+            'vendor' => 'typo3_console',
+            'controller' => Helhum\Typo3Console\Command\SchedulerCommandController::class,
+            'controllerCommandName' => 'disableTask',
+        ],
         'upgrade:all' => [
             'vendor' => 'typo3_console',
             'controller' => Helhum\Typo3Console\Command\UpgradeCommandController::class,

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -1300,6 +1300,48 @@ Options
 
 
 
+.. _`Command Reference: typo3_console scheduler:disabletask`:
+
+`scheduler:disabletask`
+-----------------------
+
+**Disable a scheduler task**
+
+**Example:** `typo3cms scheduler:disable 42`
+
+Arguments
+~~~~~~~~~
+
+`taskId`
+   Uid of the task that should be disabled
+
+
+
+
+
+
+
+.. _`Command Reference: typo3_console scheduler:enabletask`:
+
+`scheduler:enabletask`
+----------------------
+
+**Enable a scheduler task**
+
+**Example:** `typo3cms scheduler:enable 42`
+
+Arguments
+~~~~~~~~~
+
+`taskId`
+   Uid of the task that should be enabled
+
+
+
+
+
+
+
 .. _`Command Reference: typo3_console scheduler:run`:
 
 `scheduler:run`


### PR DESCRIPTION
This is useful for activating or deactivating of tasks that should/
shouldn't be available in a certain environment, e.g. for deactivating
Solr indexing of sending mails in a non-production environment.