### PR TITLE
[FEATURE] Show more helpful messages in error conditions

### DIFF
--- a/Classes/Console/Command/Extension/DumpAutoloadCommand.php
+++ b/Classes/Console/Command/Extension/DumpAutoloadCommand.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Command\Extension;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Mvc\Cli\Symfony\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Core\ClassLoadingInformation;
+
+class DumpAutoloadCommand extends Command
+{
+    protected function configure()
+    {
+        $this->setDescription('Dump class autoload information for extensions');
+        $this->setHelp(
+            <<<'EOH'
+Updates class loading information in non Composer managed TYPO3 installations.
+
+This command is only needed during development. The extension manager takes care
+creating or updating this info properly during extension (de-)activation.
+
+This command is not available in Composer mode.
+EOH
+        );
+    }
+
+    public function isEnabled(): bool
+    {
+        $application = $this->getApplication();
+        if (!$application instanceof Application || getenv('TYPO3_CONSOLE_RENDERING_REFERENCE')) {
+            return true;
+        }
+
+        return !$application->isComposerManaged();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        ClassLoadingInformation::dumpClassLoadingInformation();
+        $output->writeln('<info>Class Loading information has been updated.</info>');
+    }
+}

--- a/Classes/Console/Command/ExtensionCommandController.php
+++ b/Classes/Console/Command/ExtensionCommandController.php
@@ -20,7 +20,6 @@ use Helhum\Typo3Console\Extension\ExtensionSetupResultRenderer;
 use Helhum\Typo3Console\Install\FolderStructure\ExtensionFactory;
 use Helhum\Typo3Console\Mvc\Controller\CommandController;
 use Helhum\Typo3Console\Service\CacheService;
-use TYPO3\CMS\Core\Core\ClassLoadingInformation;
 use TYPO3\CMS\Core\Package\PackageInterface;
 use TYPO3\CMS\Core\Package\PackageManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -265,22 +264,6 @@ class ExtensionCommandController extends CommandController
             $this->outputLine('<warning>Operation not confirmed and has been skipped</warning>');
             $this->quit(1);
         }
-    }
-
-    /**
-     * Dump class auto-load
-     *
-     * Updates class loading information in non Composer managed TYPO3 installations.
-     *
-     * This command is only needed during development. The extension manager takes care
-     * creating or updating this info properly during extension (de-)activation.
-     *
-     * This command is only available in non composer mode.
-     */
-    public function dumpAutoloadCommand()
-    {
-        ClassLoadingInformation::dumpClassLoadingInformation();
-        $this->output->outputLine('Class Loading information has been updated.');
     }
 
     /**

--- a/Classes/Console/Core/Kernel.php
+++ b/Classes/Console/Core/Kernel.php
@@ -176,7 +176,7 @@ class Kernel
      */
     public function terminate(int $exitCode = 0)
     {
-        if ($exitCode > 255 || ($exitCode === 0 && $this->runLevel->getError())) {
+        if ($exitCode > 255) {
             $exitCode = 255;
         }
         exit($exitCode);

--- a/Classes/Console/Exception/CommandNotAvailableException.php
+++ b/Classes/Console/Exception/CommandNotAvailableException.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Exception;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Exception;
+use Throwable;
+
+class CommandNotAvailableException extends Exception
+{
+    /**
+     * @var string
+     */
+    private $commandName;
+
+    public function __construct(string $commandName, string $message = '', int $code = 0, Throwable $previous = null)
+    {
+        $this->commandName = $commandName;
+        $message = $message ?: sprintf('Command "%s" is not available in this context', $commandName);
+        $code = $code ?: 1544277403;
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getCommandName(): string
+    {
+        return $this->commandName;
+    }
+}

--- a/Classes/Console/Mvc/Cli/CommandCollection.php
+++ b/Classes/Console/Mvc/Cli/CommandCollection.php
@@ -41,14 +41,6 @@ class CommandCollection implements CommandLoaderInterface
     private $commandConfiguration;
 
     /**
-     * Only use for rendering the reference
-     *
-     * @var bool
-     * @internal
-     */
-    public static $rendersReference = false;
-
-    /**
      * @var BaseCommand[]
      */
     private $commands = [];
@@ -107,7 +99,7 @@ class CommandCollection implements CommandLoaderInterface
      */
     public function get($name): BaseCommand
     {
-        if (!isset($this->commands[$name]) || !$this->isCommandAvailable($this->commands[$name]['name'])) {
+        if (!isset($this->commands[$name])) {
             throw new CommandNotFoundException(sprintf('The command "%s" does not exist.', $name), [], 1518812618);
         }
         $commandConfig = $this->commands[$name];
@@ -133,7 +125,7 @@ class CommandCollection implements CommandLoaderInterface
      */
     public function has($name): bool
     {
-        return isset($this->commands[$name]) && $this->isCommandAvailable($this->commands[$name]['name']);
+        return isset($this->commands[$name]);
     }
 
     /**
@@ -147,15 +139,6 @@ class CommandCollection implements CommandLoaderInterface
     public function addCommandControllerCommands(array $commandControllers)
     {
         $this->populateCommands($this->commandConfiguration->addCommandControllerCommands($commandControllers));
-    }
-
-    private function isCommandAvailable(string $name): bool
-    {
-        if (self::$rendersReference) {
-            return true;
-        }
-
-        return $this->runLevel->isCommandAvailable($name);
     }
 
     private function populateCommands(array $definitions = null)

--- a/Classes/Console/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Command/CommandControllerCommand.php
@@ -44,14 +44,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CommandControllerCommand extends Command
 {
     /**
-     * Only use for rendering the reference
-     *
-     * @var bool
-     * @internal
-     */
-    public static $rendersReference = false;
-
-    /**
      * @var CommandDefinition
      */
     private $commandDefinition;
@@ -92,36 +84,6 @@ class CommandControllerCommand extends Command
     public function getRelatedCommandNames()
     {
         return $this->commandDefinition->getRelatedCommandIdentifiers();
-    }
-
-    public function isEnabled(): bool
-    {
-        if (self::$rendersReference) {
-            return true;
-        }
-        if ($this->application->isComposerManaged()
-            && $this->getName() === 'extension:dumpautoload'
-        ) {
-            return false;
-        }
-        if (!$this->application->isFullyCapable()
-            && in_array($this->getName(), [
-                // Although these commands are technically available
-                // they call other hidden commands in sub processes
-                // that need all capabilities. Therefore we disable these commands here.
-                // This can be removed, once they implement Symfony commands directly.
-                'upgrade:all',
-                'upgrade:list',
-                'upgrade:wizard',
-            ], true)
-        ) {
-            return false;
-        }
-        if ($this->getName() === 'cache:flushcomplete') {
-            return true;
-        }
-
-        return $this->application->isCommandAvailable($this);
     }
 
     /**
@@ -196,10 +158,6 @@ class CommandControllerCommand extends Command
                 'extension:removeinactive',
             ], true)
         ) {
-            if (self::$rendersReference) {
-                return false;
-            }
-
             return true;
         }
 

--- a/Classes/Console/Mvc/Cli/Symfony/Command/ListCommand.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Command/ListCommand.php
@@ -14,14 +14,29 @@ namespace Helhum\Typo3Console\Mvc\Cli\Symfony\Command;
  *
  */
 
+use Helhum\Typo3Console\Mvc\Cli\Symfony\Application;
 use Helhum\Typo3Console\Mvc\Cli\Symfony\Descriptor\TextDescriptor;
 use Symfony\Component\Console\Helper\DescriptorHelper;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Terminal;
 
 class ListCommand extends \Symfony\Component\Console\Command\ListCommand
 {
+    protected function configure()
+    {
+        parent::configure();
+        $this->amendDefinition($this->getDefinition());
+    }
+
+    public function getNativeDefinition()
+    {
+        return $this->amendDefinition(parent::getNativeDefinition());
+    }
+
     /**
      * Subclass Symfony list command to be able to register our own text descriptor
      *
@@ -37,7 +52,48 @@ class ListCommand extends \Symfony\Component\Console\Command\ListCommand
         $helper->describe($output, $this->getApplication(), [
             'format' => $input->getOption('format'),
             'raw_text' => $input->getOption('raw'),
+            'show_unavailable' => $input->getOption('all'),
+            'namespace' => $input->getArgument('namespace'),
             'screen_width' => (new Terminal())->getWidth() - 4,
         ]);
+        $application = $this->getApplication();
+        if (!$application instanceof Application) {
+            return 0;
+        }
+        if (!$input->getArgument('namespace') && !$application->isFullyCapable() && !$input->getOption('all')) {
+            $outputHelper = new SymfonyStyle($input, $output);
+            $messages = [
+                '',
+                sprintf(
+                    '<comment>TYPO3 %s.</comment>',
+                    $application->hasErrors() ? 'has errors' : 'is not fully set up'
+                ),
+                '<comment>Command list is reduced to only show low level commands.</comment>',
+                sprintf(
+                    '<comment>Not listed commands will not work until %s.</comment>',
+                    $application->hasErrors() ? 'the errors are fixed' : 'TYPO3 is set up'
+                ),
+                sprintf(
+                    '<comment>Run "%s --all" to list all commands.</comment>',
+                    $_SERVER['PHP_SELF']
+                ),
+            ];
+
+            $outputHelper->getErrorStyle()->writeln($messages);
+        }
+
+        return null;
+    }
+
+    private function amendDefinition(InputDefinition $definition): InputDefinition
+    {
+        $definition->addOption(new InputOption(
+            'all',
+            '-a',
+            InputOption::VALUE_NONE,
+            'Show all commands, even the ones not available'
+        ));
+
+        return $definition;
     }
 }

--- a/Classes/Console/Mvc/Cli/Symfony/Descriptor/TextDescriptor.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Descriptor/TextDescriptor.php
@@ -26,7 +26,6 @@ namespace Helhum\Typo3Console\Mvc\Cli\Symfony\Descriptor;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Descriptor\ApplicationDescription;
-use Symfony\Component\Console\Descriptor\Descriptor;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Input\InputArgument;
@@ -174,6 +173,16 @@ class TextDescriptor extends \Symfony\Component\Console\Descriptor\TextDescripto
             $this->writeText("\n");
 
             $commands = $description->getCommands();
+
+            if ($application instanceof \Helhum\Typo3Console\Mvc\Cli\Symfony\Application) {
+                $showUnavailable = $options['show_unavailable'] ?? false;
+                $commands = array_filter(
+                    $commands,
+                    function ($command) use ($application, $showUnavailable) {
+                        return $showUnavailable || $application->isCommandAvailable($command);
+                    }
+                );
+            }
             $namespaces = $description->getNamespaces();
             if ($describedNamespace && $namespaces) {
                 // make sure all alias commands are included when describing a specific namespace

--- a/Configuration/Commands.php
+++ b/Configuration/Commands.php
@@ -176,6 +176,20 @@ return [
         'controller' => \Helhum\Typo3Console\Command\DocumentationCommandController::class,
         'controllerCommandName' => 'generateXsd',
     ],
+    'dumpautoload' => [
+        'vendor' => 'typo3_console',
+        'class' => \Helhum\Typo3Console\Command\Extension\DumpAutoloadCommand::class,
+        'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
+        'replace' => [
+            'core:dumpautoload',
+            'extensionmanager:extension:dumpclassloadinginformation',
+        ],
+        'aliases' => [
+            'extension:dumpautoload',
+            'extension:dumpclassloadinginformation',
+            'extensionmanager:extension:dumpclassloadinginformation',
+        ],
+    ],
     'extension:activate' => [
         'vendor' => 'typo3_console',
         'class' => \Helhum\Typo3Console\Mvc\Cli\Symfony\Command\DummyCommand::class,
@@ -206,21 +220,6 @@ return [
             'extension:uninstall',
             'extensionmanager:extension:uninstall',
             'extensionmanager:extension:deactivate',
-        ],
-    ],
-    'extension:dumpautoload' => [
-        'vendor' => 'typo3_console',
-        'class' => \Helhum\Typo3Console\Mvc\Cli\Symfony\Command\DummyCommand::class,
-        'schedulable' => false,
-        'controller' => \Helhum\Typo3Console\Command\ExtensionCommandController::class,
-        'controllerCommandName' => 'dumpAutoload',
-        'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
-        'replace' => [
-            'extensionmanager:extension:dumpclassloadinginformation',
-        ],
-        'aliases' => [
-            'extension:dumpclassloadinginformation',
-            'extensionmanager:extension:dumpclassloadinginformation',
         ],
     ],
     'extension:list' => [

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -53,6 +53,26 @@ Available Commands
 ------------------
 
 
+.. _`Command Reference: typo3_console dumpautoload`:
+
+`dumpautoload`
+--------------
+
+**Dump class autoload information for extensions**
+
+Updates class loading information in non Composer managed TYPO3 installations.
+
+This command is only needed during development. The extension manager takes care
+creating or updating this info properly during extension (de-)activation.
+
+This command is not available in Composer mode.
+
+
+
+
+
+
+
 .. _`Command Reference: typo3_console help`:
 
 `help`
@@ -151,6 +171,14 @@ Options
 - Is value required: yes
 - Is multiple: no
 - Default: 'txt'
+
+`--all|-a`
+   Show all commands, even the ones not available
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
 
 
 
@@ -836,26 +864,6 @@ Arguments
 
 `extensionKeys`
    Extension keys to deactivate. Separate multiple extension keys with comma.
-
-
-
-
-
-
-
-.. _`Command Reference: typo3_console extension:dumpautoload`:
-
-`extension:dumpautoload`
-------------------------
-
-**Dump class auto-load**
-
-Updates class loading information in non Composer managed TYPO3 installations.
-
-This command is only needed during development. The extension manager takes care
-creating or updating this info properly during extension (de-)activation.
-
-This command is only available in non composer mode.
 
 
 

--- a/Packages/CreateReferenceCommand/src/Command/CommandReferenceRenderCommand.php
+++ b/Packages/CreateReferenceCommand/src/Command/CommandReferenceRenderCommand.php
@@ -24,9 +24,7 @@ namespace Typo3Console\CreateReferenceCommand\Command;
  * The TYPO3 project - inspiring people to share!                         *
  *                                                                        */
 
-use Helhum\Typo3Console\Mvc\Cli\CommandCollection;
 use Helhum\Typo3Console\Mvc\Cli\Symfony\Application;
-use Helhum\Typo3Console\Mvc\Cli\Symfony\Command\CommandControllerCommand;
 use Symfony\Component\Console\Descriptor\ApplicationDescription;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -42,13 +40,22 @@ use TYPO3\CMS\Fluid\View\StandaloneView;
 class CommandReferenceRenderCommand extends \Symfony\Component\Console\Command\Command
 {
     private $skipCommands = [
+        'cache:flushcomplete',
         'commandreference:render',
         'convert-command-controller',
+        'install:actionneedsexecution',
+        'install:databaseconnect',
+        'install:databasedata',
+        'install:databaseselect',
+        'install:defaultconfiguration',
+        'install:environmentandfolders',
         'language:update',
         'server:run',
         'swiftmailer:spool:send',
         'site:list',
         'site:show',
+        'upgrade:checkextensioncompatibility',
+        'upgrade:subprocess',
     ];
 
     protected function configure()
@@ -83,11 +90,10 @@ class CommandReferenceRenderCommand extends \Symfony\Component\Console\Command\C
      */
     protected function renderReference(OutputInterface $output): int
     {
-        CommandCollection::$rendersReference = true;
-        CommandControllerCommand::$rendersReference = true;
+        putenv('TYPO3_CONSOLE_RENDERING_REFERENCE=1');
         $_SERVER['PHP_SELF'] = Application::COMMAND_NAME;
         $application = $this->getApplication();
-        $applicationDescription = new ApplicationDescription($application);
+        $applicationDescription = new ApplicationDescription($application, null, true);
         $commands = $applicationDescription->getCommands();
         $allCommands = [];
         foreach ($commands as $command) {
@@ -147,8 +153,6 @@ class CommandReferenceRenderCommand extends \Symfony\Component\Console\Command\C
                 'relatedCommands' => $relatedCommands,
             ];
         }
-        CommandCollection::$rendersReference = false;
-        CommandControllerCommand::$rendersReference = false;
 
         $applicationOptions = [];
         foreach ($application->getDefinition()->getOptions() as $option) {

--- a/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
@@ -165,7 +165,7 @@ class UpgradeCommandControllerTest extends AbstractCommandTest
                 '--no-update',
             ]
         );
-        $output = $this->executeComposerCommand(['update', 'typo3/*', 'doctrine/dbal', 'helhum/typo3-composer-setup']);
+        $output = $this->executeComposerCommand(['update', 'typo3/*', 'doctrine/dbal', 'doctrine/instantiator', 'helhum/typo3-composer-setup']);
         if (DIRECTORY_SEPARATOR === '\\') {
             $output = preg_replace('/[^\x09-\x0d\x1b\x20-\xff]/', '', $output);
         }


### PR DESCRIPTION
First and foremost, we now always register all commands under
all circumstances. This means, that auto completion will always
work properly. The command listing will still be reduced to the commands
that are likely to work, but optionally allows showing all commands.

Also show a more helpful error message when executing a command
which cannot be run unless TYPO3 is set up instead of showing
an error message that the command does not exist (which is in fact wrong)