### PR TITLE
[TASK] Migrate documentation:generateXsd to native command

### DIFF
--- a/Classes/Console/Command/Cache/CacheFlushCommand.php
+++ b/Classes/Console/Command/Cache/CacheFlushCommand.php
@@ -114,13 +114,9 @@ EOH
      */
     protected function handleDeprecatedArgumentsAndOptions(InputInterface $input, OutputInterface $output)
     {
-        if ($input->getArgument('force')
-        || $input->getArgument('filesOnly')
-        || $input->getOption('files-only')
-        || $input->getOption('force')
-        ) {
+        if ($input->getOption('force')) {
             $io = new SymfonyStyle($input, $output);
-            $io->getErrorStyle()->writeln('<warning>All options and arguments are deprecated and have no effect any more.</warning>');
+            $io->getErrorStyle()->writeln('<warning>Using "--force" is deprecated and has no effect any more.</warning>');
         }
     }
 }

--- a/Classes/Console/Command/Documentation/GenerateXsdCommand.php
+++ b/Classes/Console/Command/Documentation/GenerateXsdCommand.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Command\Documentation;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Command\AbstractConvertedCommand;
+use Helhum\Typo3Console\Service;
+use Helhum\Typo3Console\Service\XsdGenerator;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GenerateXsdCommand extends AbstractConvertedCommand
+{
+    /**
+     * @var XsdGenerator
+     */
+    protected $xsdGenerator;
+
+    public function __construct(string $name = null, XsdGenerator $xsdGenerator= null)
+    {
+        parent::__construct($name);
+        $this->xsdGenerator = $xsdGenerator;
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Generate Fluid ViewHelper XSD Schema');
+        $this->setHelp(
+            <<<'EOH'
+Generates Schema documentation (XSD) for your ViewHelpers, preparing the
+file to be placed online and used by any XSD-aware editor.
+After creating the XSD file, reference it in your IDE and import the namespace
+in your Fluid template by adding the xmlns:* attribute(s):
+<code><html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers" ...></code>
+EOH
+        );
+        $this->setDefinition($this->createCompleteInputDefinition());
+    }
+
+    protected function createNativeDefinition(): array
+    {
+        return [
+            new InputArgument(
+                'phpNamespace',
+                InputArgument::REQUIRED,
+                'Namespace of the Fluid ViewHelpers without leading backslash (for example \'TYPO3\Fluid\ViewHelpers\' or \'Tx_News_ViewHelpers\'). NOTE: Quote and/or escape this argument as needed to avoid backslashes from being interpreted!'
+            ),
+            new InputOption(
+                'xsd-namespace',
+                '-xsd',
+                InputOption::VALUE_REQUIRED,
+                'Unique target namespace used in the XSD schema (for example "http://yourdomain.org/ns/viewhelpers"). Defaults to "http://typo3.org/ns/<php namespace>".'
+            ),
+            new InputOption(
+                'target-file',
+                '-target',
+                InputOption::VALUE_REQUIRED,
+                'File path and name of the generated XSD schema. If not specified the schema will be output to standard output.'
+            )
+        ];
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $phpNamespace = $input->getOption('phpNamespace');
+        $xsdNamespace = $input->getOption('xsdNamespace');
+        $targetFile = $input->getOption('targetFile');
+        if ($xsdNamespace === null) {
+            $phpNamespace = rtrim($phpNamespace, '_\\');
+            if (strpos($phpNamespace, '\\') === false) {
+                $search = ['Tx_', '_'];
+                $replace = ['', '/'];
+            } else {
+                $search = '\\';
+                $replace = '/';
+            }
+            $xsdNamespace = sprintf('http://typo3.org/ns/%s', str_replace($search, $replace, $phpNamespace));
+        }
+        try {
+            $xsdSchema = $this->xsdGenerator->generateXsd($phpNamespace, $xsdNamespace);
+        } catch (Service\Exception $exception) {
+            $output->writeln('An error occurred while trying to generate the XSD schema:');
+            $output->writeln($exception->getMessage());
+            return 1;
+        }
+        if ($targetFile === null) {
+            echo $xsdSchema;
+        } else {
+            file_put_contents($targetFile, $xsdSchema);
+        }
+    }
+
+
+
+    /**
+     * @deprecated will be removed with 6.0
+     *
+     * @return array
+     */
+    protected function createDeprecatedDefinition(): array
+    {
+        return [];
+    }
+
+    /**
+     * @deprecated will be removed with 6.0
+     */
+    protected function handleDeprecatedArgumentsAndOptions(InputInterface $input, OutputInterface $output)
+    {
+        // nothing to do here
+    }
+}

--- a/Classes/Console/Command/Documentation/GenerateXsdCommand.php
+++ b/Classes/Console/Command/Documentation/GenerateXsdCommand.php
@@ -113,18 +113,8 @@ EOH
         } else {
             file_put_contents($targetFile, $xsdSchema);
         }
-    }
 
-
-
-    /**
-     * @deprecated will be removed with 6.0
-     *
-     * @return array
-     */
-    protected function createDeprecatedDefinition(): array
-    {
-        return [];
+        return 0;
     }
 
     /**

--- a/Classes/Console/Command/DocumentationCommandController.php
+++ b/Classes/Console/Command/DocumentationCommandController.php
@@ -21,6 +21,8 @@ use TYPO3\CMS\Core\SingletonInterface;
 
 /**
  * Command controller for Fluid documentation rendering
+ *
+ * @deprecated will be removed in TYPO3 v6.0 as it is not in use anymore, see Documentation/GenerateXsdCommand class.
  */
 class DocumentationCommandController extends CommandController implements SingletonInterface
 {

--- a/Configuration/Commands.php
+++ b/Configuration/Commands.php
@@ -161,10 +161,7 @@ return [
     ],
     'documentation:generatexsd' => [
         'vendor' => 'typo3_console',
-        'class' => \Helhum\Typo3Console\Mvc\Cli\Symfony\Command\DummyCommand::class,
-        'schedulable' => false,
-        'controller' => \Helhum\Typo3Console\Command\DocumentationCommandController::class,
-        'controllerCommandName' => 'generateXsd',
+        'class' => \Helhum\Typo3Console\Command\Documentation\GenerateXsdCommand::class,
     ],
     'dumpautoload' => [
         'vendor' => 'typo3_console',

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -793,7 +793,7 @@ Arguments
 Options
 ~~~~~~~
 
-`--xsd-namespace`
+`--xsd-namespace|-xsd`
    Unique target namespace used in the XSD schema (for example "http://yourdomain.org/ns/viewhelpers"). Defaults to "http://typo3.org/ns/<php namespace>".
 
 - Accept value: yes
@@ -801,7 +801,7 @@ Options
 - Is multiple: no
 
 
-`--target-file`
+`--target-file|-target`
    File path and name of the generated XSD schema. If not specified the schema will be output to standard output.
 
 - Accept value: yes

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -786,14 +786,14 @@ Arguments
 ~~~~~~~~~
 
 `phpNamespace`
-   Namespace of the Fluid ViewHelpers without leading backslash (for example 'TYPO3\Fluid\ViewHelpers' or 'Tx_News_ViewHelpers'). NOTE: Quote and/or escape this argument as needed to avoid backslashes from being interpreted!
+   Namespace of the Fluid ViewHelpers without leading backslash (for example "TYPO3\Fluid\ViewHelpers" or "Tx_News_ViewHelpers"). NOTE: Quote and/or escape this argument as needed to avoid backslashes from being interpreted!
 
 
 
 Options
 ~~~~~~~
 
-`--xsd-namespace|-xsd`
+`--xsd-namespace|-x`
    Unique target namespace used in the XSD schema (for example "http://yourdomain.org/ns/viewhelpers"). Defaults to "http://typo3.org/ns/<php namespace>".
 
 - Accept value: yes
@@ -801,7 +801,7 @@ Options
 - Is multiple: no
 
 
-`--target-file|-target`
+`--target-file|-t`
    File path and name of the generated XSD schema. If not specified the schema will be output to standard output.
 
 - Accept value: yes

--- a/Tests/Console/Functional/Command/Documentation/GenerateXsdCommandTest.php
+++ b/Tests/Console/Functional/Command/Documentation/GenerateXsdCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace Helhum\Typo3Console\Tests\Functional\Command;
+namespace Helhum\Typo3Console\Tests\Functional\Command\Documentation;
 
 /*
  * This file is part of the TYPO3 Console project.
@@ -14,7 +14,9 @@ namespace Helhum\Typo3Console\Tests\Functional\Command;
  *
  */
 
-class DocumentationCommandControllerTest extends AbstractCommandTest
+use Helhum\Typo3Console\Tests\Functional\Command\AbstractCommandTest;
+
+class GenerateXsdCommandTest extends AbstractCommandTest
 {
     /**
      * @test


### PR DESCRIPTION
The old class is marked as deprecated, as it is not in
use anymore.

New options for generateXsd are available:
-xsd
-target