### PR TITLE
[BUGFIX] Fix execution of chatty upgrade wizards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ notifications:
 
 # This is executed for all stages
 before_install:
-  - if php -i | grep -q xdebug; then phpenv config-rm xdebug.ini || true; fi
+  - if php -i | grep -v TRAVIS_CMD | grep -q xdebug; then phpenv config-rm xdebug.ini; fi
   - mkdir -p .Build/external
   - git clone https://github.com/helhum/TYPO3-testing-framework.git .Build/external/nimut-testing-framework -b allow-php73
   - composer config repositories.testing-framework vcs .Build/external/nimut-testing-framework

--- a/Classes/Console/Install/Upgrade/UpgradeWizardFactory.php
+++ b/Classes/Console/Install/Upgrade/UpgradeWizardFactory.php
@@ -15,9 +15,11 @@ namespace Helhum\Typo3Console\Install\Upgrade;
  */
 
 use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Output\BufferedOutput;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Install\Updates\AbstractUpdate;
+use TYPO3\CMS\Install\Updates\ChattyInterface;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
 /**
@@ -61,6 +63,10 @@ class UpgradeWizardFactory
         $upgradeWizard = $this->objectManager->get($this->getClassNameFromIdentifier($identifier));
         if ($upgradeWizard instanceof AbstractUpdate) {
             $upgradeWizard->setIdentifier($identifier);
+        }
+        if ($upgradeWizard instanceof ChattyInterface) {
+            $output = new BufferedOutput();
+            $upgradeWizard->setOutput($output);
         }
 
         return $upgradeWizard;

--- a/Tests/Console/Unit/Install/Upgrade/Fixture/ChattyUpgradeWizard.php
+++ b/Tests/Console/Unit/Install/Upgrade/Fixture/ChattyUpgradeWizard.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Install\Updates\ChattyInterface;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+class ChattyUpgradeWizard implements UpgradeWizardInterface, ChattyInterface
+{
+    /**
+     * @var bool
+     */
+    private $needsUpdate;
+
+    /**
+     * @var bool
+     */
+    private $succeedsUpdate;
+
+    public function __construct(bool $needsUpdate = true, bool $succeedsUpdate = true)
+    {
+        $this->needsUpdate = $needsUpdate;
+        $this->succeedsUpdate = $succeedsUpdate;
+    }
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    public function setOutput(OutputInterface $output): void
+    {
+        $this->output = $output;
+    }
+
+    public function getIdentifier(): string
+    {
+        return self::class;
+    }
+
+    public function getTitle(): string
+    {
+        return self::class;
+    }
+
+    public function getDescription(): string
+    {
+        return self::class;
+    }
+
+    public function executeUpdate(): bool
+    {
+        $this->output->write('executeUpdate');
+
+        return $this->succeedsUpdate;
+    }
+
+    public function updateNecessary(): bool
+    {
+        $this->output->write('updateNecessary');
+
+        return $this->needsUpdate;
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Ensure upgrade wizards implementing ChattyInterface and
using the output in updateNecessary method work correctly
and output is tracked and returned correctly.

Fixes: #788