### PR TITLE
[BUGIFX] Simplify and harden cache:flush command

### DIFF
--- a/Classes/Compatibility/TYPO3v87/Service/CacheLowLevelCleaner.php
+++ b/Classes/Compatibility/TYPO3v87/Service/CacheLowLevelCleaner.php
@@ -45,7 +45,7 @@ class CacheLowLevelCleaner
                 $connection->truncate($tableName);
             }
         }
-        // check tables on other connections
+        // Check tables on other connections
         $remappedTables = isset($GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping'])
             ? array_keys((array)$GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping'])
             : [];

--- a/Classes/Console/Command/Cache/CacheFlushCommand.php
+++ b/Classes/Console/Command/Cache/CacheFlushCommand.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Command\Cache;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Command\AbstractConvertedCommand;
+use Helhum\Typo3Console\Core\Booting\RunLevel;
+use Helhum\Typo3Console\Mvc\Cli\Symfony\Application;
+use Helhum\Typo3Console\Service\CacheLowLevelCleaner;
+use Helhum\Typo3Console\Service\CacheService;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class CacheFlushCommand extends AbstractConvertedCommand
+{
+    protected function configure()
+    {
+        $this->setDescription('Flush all caches');
+        $this->setHelp(
+            <<<'EOH'
+Flushes TYPO3 core caches first and after that, flushes caches from extensions.
+EOH
+        );
+
+        $this->setDefinition($this->createCompleteInputDefinition());
+    }
+
+    protected function createNativeDefinition(): array
+    {
+        return [
+            new InputOption(
+                'files-only',
+                null,
+                InputOption::VALUE_NONE,
+                'Only file caches are flushed'
+            ),
+        ];
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $filesOnly = $input->getOption('files-only');
+        $application = $this->getApplication();
+        if (!$application instanceof Application) {
+            throw new \RuntimeException('Fatal error. Application is not properly initialized.', 1546617606);
+        }
+        $filesOnly = $filesOnly || !$application->isFullyCapable();
+
+        $io = new SymfonyStyle($input, $output);
+
+        $lowLevelCleaner = new CacheLowLevelCleaner();
+        $lowLevelCleaner->forceFlushCachesFiles();
+        if ($filesOnly) {
+            $io->writeln('Flushed all file caches.');
+            // No need to proceed, as files only flush is requested
+            return;
+        }
+
+        $lowLevelCleaner->forceFlushDatabaseCacheTables();
+        $application->boot(RunLevel::LEVEL_FULL);
+
+        $cacheService = new CacheService();
+        $cacheService->flush();
+        $cacheService->flushCachesWithDataHandler();
+
+        $io->writeln('Flushed all caches.');
+    }
+
+    /**
+     * @deprecated will be removed with 6.0
+     *
+     * @return array
+     */
+    protected function createDeprecatedDefinition(): array
+    {
+        return [
+            new InputOption(
+                'force',
+                null,
+                InputOption::VALUE_NONE,
+                'Cache is forcibly flushed (low level operations are performed)'
+            ),
+            new InputArgument(
+                'force',
+                null,
+                'Cache is forcibly flushed (low level operations are performed)',
+                false
+            ),
+            new InputArgument(
+                'filesOnly',
+                null,
+                'Only file caches are flushed',
+                false
+            ),
+        ];
+    }
+
+    /**
+     * @deprecated will be removed with 6.0
+     */
+    protected function handleDeprecatedArgumentsAndOptions(InputInterface $input, OutputInterface $output)
+    {
+        if ($input->getArgument('force')
+        || $input->getArgument('filesOnly')
+        || $input->getOption('files-only')
+        || $input->getOption('force')
+        ) {
+            $io = new SymfonyStyle($input, $output);
+            $io->getErrorStyle()->writeln('<warning>All options and arguments are deprecated and have no effect any more.</warning>');
+        }
+    }
+}

--- a/Classes/Console/Mvc/Cli/Symfony/Application.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Application.php
@@ -15,6 +15,7 @@ namespace Helhum\Typo3Console\Mvc\Cli\Symfony;
  */
 
 use Helhum\Typo3Console\Core\Booting\RunLevel;
+use Helhum\Typo3Console\Core\Booting\StepFailedException;
 use Helhum\Typo3Console\Error\ExceptionRenderer;
 use Helhum\Typo3Console\Exception\CommandNotAvailableException;
 use Helhum\Typo3Console\Mvc\Cli\Symfony\Command\HelpCommand;
@@ -77,6 +78,15 @@ class Application extends BaseApplication
     public function hasErrors(): bool
     {
         return $this->runLevel->getError() !== null;
+    }
+
+    /**
+     * @param string $runLevel
+     * @throws StepFailedException
+     */
+    public function boot(string $runLevel)
+    {
+        $this->runLevel->runSequence($runLevel);
     }
 
     /**

--- a/Classes/Console/Service/CacheLowLevelCleaner.php
+++ b/Classes/Console/Service/CacheLowLevelCleaner.php
@@ -28,8 +28,7 @@ class CacheLowLevelCleaner
      */
     public function forceFlushCachesFiles()
     {
-        // Delete typo3temp/Cache
-        GeneralUtility::flushDirectory(Environment::getVarPath() . '/cache', true, true);
+        GeneralUtility::flushDirectory(Environment::getVarPath() . '/cache', true);
     }
 
     /**
@@ -46,7 +45,7 @@ class CacheLowLevelCleaner
                 $connection->truncate($tableName);
             }
         }
-        // check tables on other connections
+        // Check tables on other connections
         $remappedTables = isset($GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping'])
             ? array_keys((array)$GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping'])
             : [];

--- a/Classes/Console/Service/CacheService.php
+++ b/Classes/Console/Service/CacheService.php
@@ -14,16 +14,8 @@ namespace Helhum\Typo3Console\Service;
  *
  */
 
-use Helhum\Typo3Console\Core\Booting\CompatibilityScripts;
-use Helhum\Typo3Console\Core\Booting\Scripts;
-use Helhum\Typo3Console\Service\Configuration\ConfigurationService;
-use Symfony\Component\Console\Exception\RuntimeException;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
-use TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheGroupException;
-use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
-use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -39,67 +31,28 @@ class CacheService implements SingletonInterface
     protected $cacheManager;
 
     /**
-     * @var ConfigurationService
+     * @var array
      */
-    protected $configurationService;
+    protected $cacheConfiguration;
 
-    /**
-     * @var Bootstrap
-     */
-    private $bootstrap;
-
-    /**
-     * @var CacheLowLevelCleaner
-     */
-    private $lowLevelCleaner;
-
-    /**
-     * Builds the dependencies correctly
-     *
-     * @param ConfigurationService $configurationService
-     */
-    public function __construct(ConfigurationService $configurationService, Bootstrap $bootstrap = null, CacheLowLevelCleaner $lowLevelCleaner = null)
+    public function __construct(array $cacheConfiguration = null)
     {
         // We need a new instance here to get the real caches instead of the disabled ones
         $this->cacheManager = new CacheManager();
-        $this->cacheManager->setCacheConfigurations($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']);
-        $this->configurationService = $configurationService;
-        $this->bootstrap = $bootstrap ?: Bootstrap::getInstance();
-        $this->lowLevelCleaner = $lowLevelCleaner ?: new CacheLowLevelCleaner();
+        $this->cacheConfiguration = $cacheConfiguration ?? $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'];
+        $this->cacheManager->setCacheConfigurations($this->cacheConfiguration);
     }
 
     /**
      * Flushes all caches
-     *
-     * @param bool $force
      */
-    public function flush($force = false)
+    public function flush()
     {
-        $this->ensureDatabaseIsInitialized();
-        if ($force) {
-            $this->lowLevelCleaner->forceFlushCachesFiles();
-            $this->lowLevelCleaner->forceFlushDatabaseCacheTables();
-        }
         $this->cacheManager->flushCaches();
     }
 
     /**
-     * Flushes all file based caches
-     *
-     * @param bool $force
-     */
-    public function flushFileCaches($force = false)
-    {
-        if ($force) {
-            $this->lowLevelCleaner->forceFlushCachesFiles();
-        }
-        foreach ($this->getFileCaches() as $cache) {
-            $cache->flush();
-        }
-    }
-
-    /**
-     * Flushes caches using the data handler. This should not be necessary any more in the future.
+     * Flushes caches using the data handler.
      * Although we trigger the cache flush API here, the real intention is to trigger
      * hook subscribers, so that they can do their job (flushing "other" caches when cache is flushed.
      * For example realurl subscribes to these hooks.
@@ -111,18 +64,12 @@ class CacheService implements SingletonInterface
      * However if you find a valid use case for us to also call "pages" here, then please create
      * a pull request and describe this case. "system" or "temp_cached" will not be added however
      * because these are deprecated since TYPO3 8.x
-     *
-     * Besides that, this DataHandler API is probably something to be removed in TYPO3,
-     * so we deprecate and mark this method as internal at the same time.
-     *
-     * @deprecated Will be removed once DataHandler cache flush methods are removed in supported TYPO3 versions
-     * @internal
      */
     public function flushCachesWithDataHandler()
     {
-        $this->ensureDatabaseIsInitialized();
-        $this->ensureBackendUserIsInitialized();
-        self::createDataHandlerFromGlobals()->clear_cacheCmd('all');
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start([], []);
+        $dataHandler->clear_cacheCmd('all');
     }
 
     /**
@@ -134,7 +81,6 @@ class CacheService implements SingletonInterface
     public function flushGroups(array $groups)
     {
         $this->ensureCacheGroupsExist($groups);
-        $this->ensureDatabaseIsInitialized();
         foreach ($groups as $group) {
             $this->cacheManager->flushCachesInGroup($group);
         }
@@ -148,7 +94,6 @@ class CacheService implements SingletonInterface
      */
     public function flushByTags(array $tags, $group = null)
     {
-        $this->ensureDatabaseIsInitialized();
         foreach ($tags as $tag) {
             if ($group === null) {
                 $this->cacheManager->flushCachesByTag($tag);
@@ -182,35 +127,13 @@ class CacheService implements SingletonInterface
     public function getValidCacheGroups()
     {
         $validGroups = [];
-        foreach ($this->configurationService->getActive('SYS/caching/cacheConfigurations') as $cacheConfiguration) {
+        foreach ($this->cacheConfiguration as $cacheConfiguration) {
             if (isset($cacheConfiguration['groups']) && is_array($cacheConfiguration['groups'])) {
-                $validGroups = array_merge($validGroups, $cacheConfiguration['groups']);
+                $validGroups[] = $cacheConfiguration['groups'];
             }
         }
 
-        return array_unique($validGroups);
-    }
-
-    /**
-     * @deprecated can be removed when TYPO3 8 support is removed
-     */
-    private function ensureDatabaseIsInitialized()
-    {
-        if (!empty($GLOBALS['TYPO3_DB'])) {
-            // Already initialized
-            return;
-        }
-        CompatibilityScripts::initializeDatabaseConnection($this->bootstrap);
-    }
-
-    private function ensureBackendUserIsInitialized()
-    {
-        if (!empty($GLOBALS['BE_USER'])) {
-            // Already initialized
-            return;
-        }
-        Scripts::initializePersistence($this->bootstrap);
-        Scripts::initializeAuthenticatedOperations($this->bootstrap);
+        return array_unique(array_merge(...$validGroups));
     }
 
     /**
@@ -225,46 +148,5 @@ class CacheService implements SingletonInterface
             $invalidGroups = array_diff($groups, $sanitizedGroups);
             throw new NoSuchCacheGroupException('Invalid cache groups "' . implode(', ', $invalidGroups) . '".', 1399630162);
         }
-    }
-
-    /**
-     * @return FrontendInterface[]
-     */
-    private function getFileCaches()
-    {
-        $fileCaches = [];
-        foreach ($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'] as $identifier => $cacheConfiguration) {
-            if (
-                isset($cacheConfiguration['backend'])
-                && (
-                    $cacheConfiguration['backend'] === SimpleFileBackend::class
-                    || is_subclass_of($cacheConfiguration['backend'], SimpleFileBackend::class)
-                )
-            ) {
-                $fileCaches[] = $this->cacheManager->getCache($identifier);
-            }
-        }
-
-        return $fileCaches;
-    }
-
-    /**
-     * Create a data handler instance from global state (with user being admin)
-     *
-     * @internal
-     * @throws RuntimeException
-     * @return DataHandler
-     */
-    private static function createDataHandlerFromGlobals()
-    {
-        if (empty($GLOBALS['BE_USER']) || !$GLOBALS['BE_USER'] instanceof BackendUserAuthentication) {
-            throw new RuntimeException('No backend user initialized. flushCachesWithDataHandler needs fully initialized TYPO3', 1477066610);
-        }
-        $user = clone $GLOBALS['BE_USER'];
-        $user->admin = 1;
-        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
-        $dataHandler->start([], [], $user);
-
-        return $dataHandler;
     }
 }

--- a/Configuration/Commands.php
+++ b/Configuration/Commands.php
@@ -56,19 +56,9 @@ return [
     ],
     'cache:flush' => [
         'vendor' => 'typo3_console',
-        'class' => \Helhum\Typo3Console\Mvc\Cli\Symfony\Command\DummyCommand::class,
+        'class' => \Helhum\Typo3Console\Command\Cache\CacheFlushCommand::class,
         'schedulable' => false,
-        'controller' => \Helhum\Typo3Console\Command\CacheCommandController::class,
-        'controllerCommandName' => 'flush',
         'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
-    ],
-    'cache:flushcomplete' => [
-        'vendor' => 'typo3_console',
-        'class' => \Helhum\Typo3Console\Mvc\Cli\Symfony\Command\DummyCommand::class,
-        'schedulable' => false,
-        'controller' => \Helhum\Typo3Console\Command\CacheCommandController::class,
-        'controllerCommandName' => 'flushComplete',
-        'runLevel' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
     ],
     'cache:flushgroups' => [
         'vendor' => 'typo3_console',

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -319,14 +319,6 @@ Flushes TYPO3 core caches first and after that, flushes caches from extensions.
 Options
 ~~~~~~~
 
-`--force`
-   Cache is forcibly flushed (low level operations are performed)
-
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Default: false
-
 `--files-only`
    Only file caches are flushed
 
@@ -350,7 +342,6 @@ Options
 Flushes all caches in specified groups.
 Valid group names are by default:
 
-- all
 - lowlevel
 - pages
 - system

--- a/Tests/Console/Functional/Command/CacheCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/CacheCommandControllerTest.php
@@ -66,28 +66,10 @@ class CacheCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
-    public function cacheCanBeForceFlushedFlushed()
-    {
-        $output = $this->executeConsoleCommand('cache:flush', ['--force']);
-        $this->assertSame('Force flushed all caches.', $output);
-    }
-
-    /**
-     * @test
-     */
     public function fileCachesCanBeFlushed()
     {
         $output = $this->executeConsoleCommand('cache:flush', ['--files-only']);
         $this->assertSame('Flushed all file caches.', $output);
-    }
-
-    /**
-     * @test
-     */
-    public function fileCachesCanBeForceFlushedFlushed()
-    {
-        $output = $this->executeConsoleCommand('cache:flush', ['--files-only', '--force']);
-        $this->assertSame('Force flushed all file caches.', $output);
     }
 
     /**

--- a/Tests/Console/Unit/Service/CacheServiceTest.php
+++ b/Tests/Console/Unit/Service/CacheServiceTest.php
@@ -15,7 +15,6 @@ namespace Helhum\Typo3Console\Tests\Unit\Service;
  */
 
 use Helhum\Typo3Console\Service\CacheService;
-use Helhum\Typo3Console\Service\Configuration\ConfigurationService;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 class CacheServiceTest extends UnitTestCase
@@ -30,14 +29,9 @@ class CacheServiceTest extends UnitTestCase
      *
      * @param array $mockedConfiguration
      */
-    protected function createCacheManagerWithConfiguration($mockedConfiguration)
+    protected function createCacheServiceWithConfiguration($mockedConfiguration)
     {
-        $configurationServiceMock = $this->getMockBuilder(ConfigurationService::class)->disableOriginalConstructor()->getMock();
-        $configurationServiceMock
-            ->expects($this->atLeastOnce())
-            ->method('getActive')
-            ->will($this->returnValue($mockedConfiguration));
-        $this->subject = new CacheService($configurationServiceMock);
+        $this->subject = new CacheService($mockedConfiguration);
     }
 
     /**
@@ -45,7 +39,7 @@ class CacheServiceTest extends UnitTestCase
      */
     public function cacheGroupsAreRetrievedCorrectlyFromConfiguration()
     {
-        $this->createCacheManagerWithConfiguration(
+        $this->createCacheServiceWithConfiguration(
             [
                 'cache_foo' => ['groups' => ['first', 'second']],
                 'cache_bar' => ['groups' => ['third', 'second']],
@@ -68,7 +62,7 @@ class CacheServiceTest extends UnitTestCase
      */
     public function flushByGroupThrowsExceptionForInvalidGroups()
     {
-        $this->createCacheManagerWithConfiguration(
+        $this->createCacheServiceWithConfiguration(
             [
                 'cache_foo' => ['groups' => ['first', 'second']],
                 'cache_bar' => ['groups' => ['third', 'second']],


### PR DESCRIPTION
This command needs to be as resilient as possible,
therefore many dependencies from the classes have been
removed, especially the dependency to Extbase DI API,
which requires caching and lead to chicken/egg issues,
when we changed our API.

Additionally we now removed the --force flag, as in practice
this options is used all the time, so we make it default
and non optional to low level remove files and truncate db tables.

Fixes: #770