### PR TITLE
[Documentation] Try different markup for options

### DIFF
--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -101,21 +101,21 @@ Arguments
 Options
 ~~~~~~~
 
-`--format`
-   The output format (txt, xml, json, or md)
+--format
+  The output format (txt, xml, json, or md)
 
-- Accept value: yes
-- Is value required: yes
-- Is multiple: no
-- Default: 'txt'
+  - Accept value: yes
+  - Is value required: yes
+  - Is multiple: no
+  - Default: 'txt'
 
-`--raw`
-   To output raw command help
+--raw
+  To output raw command help
 
-- Accept value: no
-- Is value required: no
-- Is multiple: no
-- Default: false
+  - Accept value: no
+  - Is value required: no
+  - Is multiple: no
+  - Default: false
 
 
 


### PR DESCRIPTION
In response to issue 806 https://github.com/TYPO3-Console/TYPO3-Console/issues/806 

The "definition list" markup is currently used for option description.  Here I ① drop the extra "code" markup from the DT part and ② indent the affiliated property description to make them appear in the DD part as well. That's where the belong. Note: The first line is the DT line. Then NO blank line must follow. The next indented line establishes the DL construct and is the DD line. All DD follow up lines must have the same indentation. 

Applying this everywhere will probably be quite a bit of work. But I can imagine well that there are volunteers who would be willing to do that. My advice: Check this in first and see how it looks like and does the job.

We had to deal with the question how we want to style this kind of information several times before. If somebody is doing an overhaul of the documentation source I personally would use this kind of markup: https://docs.typo3.org/typo3cms/HowToDocument/WritingReST/DefinitionLists.html#example-2-nicely-styled The purpose of those "sep" and "aspect" ist to give that inline texts a special CSS class in a span-tag.