### PR TITLE
[BUGFIX] Use wizard class name to mark wizard done

### DIFF
--- a/Classes/Console/Install/Upgrade/UpgradeWizardExecutor.php
+++ b/Classes/Console/Install/Upgrade/UpgradeWizardExecutor.php
@@ -85,7 +85,7 @@ class UpgradeWizardExecutor
 
         if ($wizardImplementsInterface) {
             $hasPerformed = $upgradeWizard->executeUpdate();
-            GeneralUtility::makeInstance(Registry::class)->set('installUpdate', $upgradeWizard->getIdentifier(), 1);
+            GeneralUtility::makeInstance(Registry::class)->set('installUpdate', get_class($upgradeWizard), 1);
             $messages[] = $output->fetch();
         } else {
             $message = '';


### PR DESCRIPTION
The UpgradeWizardExecutor uses the class name of the wizard
as the registry key for marking the wizard done.

This makes the behavior consistent with TYPO3.

Resolves: #795