### PR TITLE
[BUGFIX] Fix writing webserver config from composer install

### DIFF
--- a/Classes/Console/Install/Action/WriteWebServerConfigAction.php
+++ b/Classes/Console/Install/Action/WriteWebServerConfigAction.php
@@ -47,15 +47,22 @@ class WriteWebServerConfigAction implements InstallActionInterface
 
     public function execute(array $actionDefinition, array $options = []): bool
     {
-        $isLegacySystem = !class_exists(Environment::class);
         $argumentDefinitions = $actionDefinition['arguments'] ?? [];
         $interactiveArguments = new InteractiveActionArguments($this->output);
         $arguments = $interactiveArguments->populate($argumentDefinitions, $options);
         if ($arguments['webServerConfig'] === 'none') {
             return true;
         }
-        $publicPath = getenv('TYPO3_PATH_WEB') ?: Environment::getPublicPath();
-        $sourcePath = $isLegacySystem ? dirname(__DIR__, 4) . '/Resources/Private/Compatibility/TYPO3v87/FolderStructureTemplateFiles' : Environment::getPublicPath() . '/typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles';
+        $isLegacySystem = !class_exists(Environment::class);
+        $publicPath = getenv('TYPO3_PATH_WEB');
+        $rootPath = getenv('TYPO3_PATH_ROOT');
+        if (!$publicPath) {
+            $publicPath = $isLegacySystem ? PATH_site : Environment::getPublicPath();
+        }
+        if (!$rootPath) {
+            $rootPath = $isLegacySystem ? PATH_site : Environment::getPublicPath();
+        }
+        $sourcePath = $isLegacySystem ? dirname(__DIR__, 4) . '/Resources/Private/Compatibility/TYPO3v87/FolderStructureTemplateFiles' : $rootPath . '/typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles';
         if ($arguments['webServerConfig'] === 'apache') {
             $source = $sourcePath . '/root-htaccess';
             $target = $publicPath . '/.htaccess';


### PR DESCRIPTION
When executing TYPO3 setup in composer context, we do
not have the Environment object nor PATH_site set up
because TYPO3 is not booted. Therfor we must not
rely on any of those.