### PR TITLE
[BUGFIX] Respect repeatable wizards and don't mark them as done

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,10 @@ jobs:
   include:
     - stage: test
       php: 7.3
-      env: TYPO3_VERSION="~9.5.0" TYPO3_UPGRADE_FROM_VERSION="~9.5.0"
+      env: TYPO3_VERSION="~9.5.8" TYPO3_UPGRADE_FROM_VERSION="~9.5.8"
     - stage: test
       php: 7.2
-      env: TYPO3_VERSION="~9.5.0"
+      env: TYPO3_VERSION="~9.5.8"
     - stage: test
       php: 7.2
       env: TYPO3_VERSION=^8.7.22

--- a/Classes/Console/Install/Upgrade/UpgradeWizardExecutor.php
+++ b/Classes/Console/Install/Upgrade/UpgradeWizardExecutor.php
@@ -20,6 +20,7 @@ use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Install\Updates\AbstractUpdate;
 use TYPO3\CMS\Install\Updates\ChattyInterface;
+use TYPO3\CMS\Install\Updates\RepeatableInterface;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
 /**
@@ -85,7 +86,11 @@ class UpgradeWizardExecutor
 
         if ($wizardImplementsInterface) {
             $hasPerformed = $upgradeWizard->executeUpdate();
-            GeneralUtility::makeInstance(Registry::class)->set('installUpdate', get_class($upgradeWizard), 1);
+
+            if (!$upgradeWizard instanceof RepeatableInterface) {
+                GeneralUtility::makeInstance(Registry::class)->set('installUpdate', get_class($upgradeWizard), 1);
+            }
+
             $messages[] = $output->fetch();
         } else {
             $message = '';

--- a/Classes/Console/Install/Upgrade/UpgradeWizardList.php
+++ b/Classes/Console/Install/Upgrade/UpgradeWizardList.php
@@ -81,7 +81,7 @@ class UpgradeWizardList
                 ];
                 $explanation = '';
                 $wizardImplementsInterface = $updateObject instanceof UpgradeWizardInterface && !$updateObject instanceof AbstractUpdate;
-                $markedAsDone = $this->registry->get('installUpdate', $className, false) || $this->registry->get('installUpdate', $identifier, false);
+                $markedAsDone = $this->registry->get('installUpdate', $className, false);
                 if ($wizardImplementsInterface) {
                     $explanation = $updateObject->getDescription();
                     $wizardClaimsExecution = $updateObject->updateNecessary();

--- a/Resources/Private/ExtensionArtifacts/composer.json
+++ b/Resources/Private/ExtensionArtifacts/composer.json
@@ -53,7 +53,7 @@
     },
     "require": {
         "helhum/typo3-console": "@dev",
-        "typo3/cms-core": "~8.7.22 || ~9.5.0"
+        "typo3/cms-core": "~8.7.22 || ~9.5.8"
     },
     "replace": {
         "helhum/typo3-console-plugin": "*",

--- a/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
@@ -161,7 +161,7 @@ class UpgradeCommandControllerTest extends AbstractCommandTest
                 '--no-update',
             ]
         );
-        $output = $this->executeComposerCommand(['update', 'typo3/*', 'doctrine/dbal', 'doctrine/instantiator', 'helhum/typo3-composer-setup']);
+        $output = $this->executeComposerCommand(['update']);
         if (DIRECTORY_SEPARATOR === '\\') {
             $output = preg_replace('/[^\x09-\x0d\x1b\x20-\xff]/', '', $output);
         }

--- a/Tests/Console/Unit/Install/Upgrade/Fixture/DummyUpgradeWizard.php
+++ b/Tests/Console/Unit/Install/Upgrade/Fixture/DummyUpgradeWizard.php
@@ -14,22 +14,53 @@ namespace Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture;
  *
  */
 
-use TYPO3\CMS\Install\Updates\AbstractUpdate;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
-class DummyUpgradeWizard extends AbstractUpdate
+class DummyUpgradeWizard implements UpgradeWizardInterface
 {
-    public function checkForUpdate(&$description)
+    /**
+     * @var bool
+     */
+    private $needsUpdate;
+
+    /**
+     * @var bool
+     */
+    private $succeedsUpdate;
+
+    public function __construct(bool $needsUpdate = true, bool $succeedsUpdate = true)
     {
-        // Dummy
+        $this->needsUpdate = $needsUpdate;
+        $this->succeedsUpdate = $succeedsUpdate;
     }
 
-    public function performUpdate(array &$dbQueries, &$customMessage)
+    public function getIdentifier(): string
     {
-        // Dummy
+        return 'dummy-identifier';
     }
 
-    public function markWizardAsDone($confValue = 1)
+    public function getTitle(): string
     {
-        parent::markWizardAsDone($confValue);
+        return self::class;
+    }
+
+    public function getDescription(): string
+    {
+        return self::class;
+    }
+
+    public function executeUpdate(): bool
+    {
+        return $this->succeedsUpdate;
+    }
+
+    public function updateNecessary(): bool
+    {
+        return $this->needsUpdate;
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [];
     }
 }

--- a/Tests/Console/Unit/Install/Upgrade/Fixture/LegacyUpgradeWizard.php
+++ b/Tests/Console/Unit/Install/Upgrade/Fixture/LegacyUpgradeWizard.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use TYPO3\CMS\Install\Updates\AbstractUpdate;
+
+class LegacyUpgradeWizard extends AbstractUpdate
+{
+    public function checkForUpdate(&$description)
+    {
+        // Dummy
+    }
+
+    public function performUpdate(array &$dbQueries, &$customMessage)
+    {
+        // Dummy
+    }
+
+    public function markWizardAsDone($confValue = 1)
+    {
+        parent::markWizardAsDone($confValue);
+    }
+}

--- a/Tests/Console/Unit/Install/Upgrade/Fixture/RepeatableUpgradeWizard.php
+++ b/Tests/Console/Unit/Install/Upgrade/Fixture/RepeatableUpgradeWizard.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use TYPO3\CMS\Install\Updates\RepeatableInterface;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+class RepeatableUpgradeWizard implements UpgradeWizardInterface, RepeatableInterface
+{
+    /**
+     * @var bool
+     */
+    private $needsUpdate;
+
+    /**
+     * @var bool
+     */
+    private $succeedsUpdate;
+
+    public function __construct(bool $needsUpdate = true, bool $succeedsUpdate = true)
+    {
+        $this->needsUpdate = $needsUpdate;
+        $this->succeedsUpdate = $succeedsUpdate;
+    }
+
+    public function getIdentifier(): string
+    {
+        return self::class;
+    }
+
+    public function getTitle(): string
+    {
+        return self::class;
+    }
+
+    public function getDescription(): string
+    {
+        return self::class;
+    }
+
+    public function executeUpdate(): bool
+    {
+        return $this->succeedsUpdate;
+    }
+
+    public function updateNecessary(): bool
+    {
+        return $this->needsUpdate;
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [];
+    }
+}

--- a/Tests/Console/Unit/Install/Upgrade/LegacyWizardExecutorTest.php
+++ b/Tests/Console/Unit/Install/Upgrade/LegacyWizardExecutorTest.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Tests\Unit\Install\Upgrade;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Install\Upgrade\UpgradeWizardExecutor;
+use Helhum\Typo3Console\Install\Upgrade\UpgradeWizardFactory;
+use Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture\LegacyUpgradeWizard;
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Install\Updates\ChattyInterface;
+
+/**
+ * @deprecated will be removed with 6.0
+ */
+class LegacyWizardExecutorTest extends UnitTestCase
+{
+    protected function setUp()
+    {
+        if (interface_exists(ChattyInterface::class)) {
+            $this->markTestSkipped('Skipping legacy tests on TYPO3 9.5');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function wizardIsNotCalledWhenDone()
+    {
+        $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
+        $upgradeWizardProphecy = $this->prophesize(LegacyUpgradeWizard::class);
+        $upgradeWizardProphecy->shouldRenderWizard()->willReturn(false);
+
+        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphecy->reveal());
+
+        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
+        $result = $subject->executeWizard('Foo\\Test');
+        $this->assertFalse($result->hasPerformed());
+    }
+
+    /**
+     * @test
+     */
+    public function wizardIsCalledWhenNotDone()
+    {
+        $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
+        $upgradeWizardProphecy = $this->prophesize(LegacyUpgradeWizard::class);
+        $upgradeWizardProphecy->shouldRenderWizard()->willReturn(true);
+        $upgradeWizardProphecy->performUpdate($queries = [], $message = '')->willReturn(true);
+
+        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphecy->reveal());
+
+        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
+        $result = $subject->executeWizard('Foo\\Test');
+        $this->assertTrue($result->hasPerformed());
+    }
+
+    /**
+     * @test
+     */
+    public function wizardIsCalledWhenNotDoneButCanStillNotPerform()
+    {
+        $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
+        $upgradeWizardProphecy = $this->prophesize(LegacyUpgradeWizard::class);
+        $upgradeWizardProphecy->shouldRenderWizard()->willReturn(true);
+        $upgradeWizardProphecy->performUpdate($queries = [], $message = '')->willReturn(false);
+
+        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphecy->reveal());
+
+        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
+        $result = $subject->executeWizard('Foo\\Test');
+        $this->assertFalse($result->hasPerformed());
+    }
+
+    /**
+     * @test
+     */
+    public function wizardIsDoneButCalledWhenForced()
+    {
+        $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
+        $upgradeWizardProphecy = $this->prophesize(LegacyUpgradeWizard::class);
+        $upgradeWizardProphecy->shouldRenderWizard()->willReturn(false);
+        $upgradeWizardProphecy->markWizardAsDone(0)->shouldBeCalled();
+        $upgradeWizardProphecy->performUpdate($queries = [], $message = '')->willReturn(true);
+
+        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphecy->reveal());
+
+        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
+        $result = $subject->executeWizard('Foo\\Test', [], true);
+        $this->assertFalse($result->hasPerformed());
+    }
+}

--- a/Tests/Console/Unit/Install/Upgrade/UpgradeWizardExecutorTest.php
+++ b/Tests/Console/Unit/Install/Upgrade/UpgradeWizardExecutorTest.php
@@ -19,28 +19,19 @@ use Helhum\Typo3Console\Install\Upgrade\UpgradeWizardFactory;
 use Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture\ChattyUpgradeWizard;
 use Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture\DummyUpgradeWizard;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
-use Prophecy\Argument;
-use Prophecy\Prophecy\MethodProphecy;
-use Prophecy\Prophecy\ObjectProphecy;
-use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Install\Updates\ChattyInterface;
 
 class UpgradeWizardExecutorTest extends UnitTestCase
 {
-    private $singletonInstances = [];
-
     protected function setUp()
     {
+        if (!interface_exists(ChattyInterface::class)) {
+            // @deprecated will be removed with 6.0
+            $this->markTestSkipped('Skipping new upgrade tests on TYPO3 8.7');
+        }
         $this->singletonInstances = GeneralUtility::getSingletonInstances();
-    }
-
-    protected function tearDown()
-    {
-        parent::tearDown();
-        GeneralUtility::resetSingletonInstances($this->singletonInstances);
     }
 
     /**
@@ -50,10 +41,7 @@ class UpgradeWizardExecutorTest extends UnitTestCase
     {
         $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
         $upgradeWizardProphecy = $this->prophesize(DummyUpgradeWizard::class);
-        $upgradeWizardProphecy->shouldRenderWizard()->willReturn(false);
-        if (interface_exists(ChattyInterface::class)) {
-            $upgradeWizardProphecy->setOutput(new BufferedOutput())->shouldBeCalled();
-        }
+        $upgradeWizardProphecy->updateNecessary()->willReturn(false);
 
         $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphecy->reveal());
 
@@ -65,61 +53,21 @@ class UpgradeWizardExecutorTest extends UnitTestCase
     /**
      * @test
      */
-    public function wizardIsCalledWhenNotDone()
+    public function wizardIsCalledWhenNotDoneAndMarkedExecuted()
     {
         $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
         $upgradeWizardProphecy = $this->prophesize(DummyUpgradeWizard::class);
-        $this->assertOutputInitForChattyWizard($upgradeWizardProphecy);
-        $upgradeWizardProphecy->shouldRenderWizard()->willReturn(true);
-        $upgradeWizardProphecy->performUpdate($queries = [], $message = '')->willReturn(true);
+        $upgradeWizardProphecy->updateNecessary()->willReturn(true);
+        $upgradeWizardProphecy->executeUpdate()->shouldBeCalled()->willReturn(true);
+        $upgradeWizardProphet = $upgradeWizardProphecy->reveal();
+        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphet);
 
-        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphecy->reveal());
+        $registryProphecy = $this->prophesize(Registry::class);
+        $registryProphecy->set('installUpdate', get_class($upgradeWizardProphet), 1)->shouldBeCalled();
 
-        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
+        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal(), $registryProphecy->reveal());
         $result = $subject->executeWizard('Foo\\Test');
         $this->assertTrue($result->hasPerformed());
-    }
-
-    /**
-     * @test
-     */
-    public function updateNecessaryOutputWillBeCapturedForChattyWizard()
-    {
-        if (!interface_exists(ChattyInterface::class)) {
-            $this->markTestSkipped('ChattyInterface not available on TYPO3 8.7');
-        }
-        $registryProphecy = $this->prophesize(Registry::class);
-        $registryProphecy->set('installUpdate', ChattyUpgradeWizard::class, 1)->shouldBeCalled();
-        GeneralUtility::setSingletonInstance(Registry::class, $registryProphecy->reveal());
-
-        $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
-        $upgradeWizard = new ChattyUpgradeWizard();
-
-        $factoryProphecy->create(ChattyUpgradeWizard::class)->willReturn($upgradeWizard);
-
-        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
-        $result = $subject->executeWizard(ChattyUpgradeWizard::class);
-        $this->assertTrue($result->hasPerformed());
-        $this->assertSame('updateNecessaryexecuteUpdate', $result->getMessages()[0] ?? '');
-    }
-
-    /**
-     * @test
-     */
-    public function updateNecessaryOutputWillBeCapturedForChattyWizardEvenIfWizardIsNotPerformed()
-    {
-        if (!interface_exists(ChattyInterface::class)) {
-            $this->markTestSkipped('ChattyInterface not available on TYPO3 8.7');
-        }
-        $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
-        $upgradeWizard = new ChattyUpgradeWizard(false);
-
-        $factoryProphecy->create(ChattyUpgradeWizard::class)->willReturn($upgradeWizard);
-
-        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
-        $result = $subject->executeWizard(ChattyUpgradeWizard::class);
-        $this->assertFalse($result->hasPerformed());
-        $this->assertSame('updateNecessary', $result->getMessages()[0] ?? '');
     }
 
     /**
@@ -129,13 +77,15 @@ class UpgradeWizardExecutorTest extends UnitTestCase
     {
         $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
         $upgradeWizardProphecy = $this->prophesize(DummyUpgradeWizard::class);
-        $this->assertOutputInitForChattyWizard($upgradeWizardProphecy);
-        $upgradeWizardProphecy->shouldRenderWizard()->willReturn(true);
-        $upgradeWizardProphecy->performUpdate($queries = [], $message = '')->willReturn(false);
+        $upgradeWizardProphecy->updateNecessary()->willReturn(true);
+        $upgradeWizardProphecy->executeUpdate()->shouldBeCalled()->willReturn(false);
+        $upgradeWizardProphet = $upgradeWizardProphecy->reveal();
+        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphet);
 
-        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphecy->reveal());
+        $registryProphecy = $this->prophesize(Registry::class);
+        $registryProphecy->set('installUpdate', get_class($upgradeWizardProphet), 1)->shouldBeCalled();
 
-        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
+        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal(), $registryProphecy->reveal());
         $result = $subject->executeWizard('Foo\\Test');
         $this->assertFalse($result->hasPerformed());
     }
@@ -147,33 +97,51 @@ class UpgradeWizardExecutorTest extends UnitTestCase
     {
         $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
         $upgradeWizardProphecy = $this->prophesize(DummyUpgradeWizard::class);
-        $upgradeWizardProphecy->shouldRenderWizard()->willReturn(false);
-        $upgradeWizardProphecy->markWizardAsDone(0)->shouldBeCalled();
-        $upgradeWizardProphecy->performUpdate($queries = [], $message = '')->willReturn(true);
-        if (interface_exists(ChattyInterface::class)) {
-            $upgradeWizardProphecy->setOutput(new BufferedOutput())->shouldBeCalled();
-        }
+        $upgradeWizardProphecy->updateNecessary()->willReturn(true);
+        $upgradeWizardProphecy->executeUpdate()->shouldBeCalled()->willReturn(false);
+        $upgradeWizardProphet = $upgradeWizardProphecy->reveal();
+        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphet);
 
-        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphecy->reveal());
+        $registryProphecy = $this->prophesize(Registry::class);
+        $registryProphecy->set('installUpdate', get_class($upgradeWizardProphet), 0)->shouldBeCalled();
+        $registryProphecy->set('installUpdate', get_class($upgradeWizardProphet), 1)->shouldBeCalled();
 
-        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
+        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal(), $registryProphecy->reveal());
         $result = $subject->executeWizard('Foo\\Test', [], true);
         $this->assertFalse($result->hasPerformed());
     }
 
     /**
-     * @param DummyUpgradeWizard|ObjectProphecy $upgradeWizardProphecy
+     * @test
      */
-    private function assertOutputInitForChattyWizard(ObjectProphecy $upgradeWizardProphecy)
+    public function updateNecessaryOutputWillBeCapturedForChattyWizard()
     {
-        if (!interface_exists(ChattyInterface::class)) {
-            return;
-        }
+        $registryProphecy = $this->prophesize(Registry::class);
+        $registryProphecy->set('installUpdate', ChattyUpgradeWizard::class, 1)->shouldBeCalled();
 
-        /** @var OutputInterface $outputInterfaceArgument */
-        $outputInterfaceArgument = Argument::type(OutputInterface::class);
-        /** @var MethodProphecy $setOutputMethod */
-        $setOutputMethod = $upgradeWizardProphecy->setOutput($outputInterfaceArgument);
-        $setOutputMethod->shouldBeCalled();
+        $upgradeWizard = new ChattyUpgradeWizard();
+        $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
+        $factoryProphecy->create(ChattyUpgradeWizard::class)->willReturn($upgradeWizard);
+
+        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal(), $registryProphecy->reveal());
+        $result = $subject->executeWizard(ChattyUpgradeWizard::class);
+        $this->assertTrue($result->hasPerformed());
+        $this->assertSame('updateNecessaryexecuteUpdate', $result->getMessages()[0] ?? '');
+    }
+
+    /**
+     * @test
+     */
+    public function updateNecessaryOutputWillBeCapturedForChattyWizardEvenIfWizardIsNotPerformed()
+    {
+        $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
+        $upgradeWizard = new ChattyUpgradeWizard(false);
+
+        $factoryProphecy->create(ChattyUpgradeWizard::class)->willReturn($upgradeWizard);
+
+        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
+        $result = $subject->executeWizard(ChattyUpgradeWizard::class);
+        $this->assertFalse($result->hasPerformed());
+        $this->assertSame('updateNecessary', $result->getMessages()[0] ?? '');
     }
 }

--- a/Tests/Console/Unit/Install/Upgrade/UpgradeWizardFactoryTest.php
+++ b/Tests/Console/Unit/Install/Upgrade/UpgradeWizardFactoryTest.php
@@ -15,7 +15,7 @@ namespace Helhum\Typo3Console\Tests\Unit\Install\Upgrade;
  */
 
 use Helhum\Typo3Console\Install\Upgrade\UpgradeWizardFactory;
-use Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture\DummyUpgradeWizard;
+use Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture\LegacyUpgradeWizard;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Install\Updates\AbstractUpdate;
@@ -49,13 +49,13 @@ class UpgradeWizardFactoryTest extends UnitTestCase
         $registryFixture = [];
 
         $objectManagerProphecy = $this->prophesize(ObjectManager::class);
-        $upgradeWizardProphecy = $this->prophesize(DummyUpgradeWizard::class);
+        $upgradeWizardProphecy = $this->prophesize(LegacyUpgradeWizard::class);
 
-        $objectManagerProphecy->get(DummyUpgradeWizard::class)->willReturn($upgradeWizardProphecy->reveal());
-        $upgradeWizardProphecy->setIdentifier(DummyUpgradeWizard::class);
+        $objectManagerProphecy->get(LegacyUpgradeWizard::class)->willReturn($upgradeWizardProphecy->reveal());
+        $upgradeWizardProphecy->setIdentifier(LegacyUpgradeWizard::class);
 
         $subject = new UpgradeWizardFactory($objectManagerProphecy->reveal(), $registryFixture);
-        $this->assertSame($upgradeWizardProphecy->reveal(), $subject->create(DummyUpgradeWizard::class));
+        $this->assertSame($upgradeWizardProphecy->reveal(), $subject->create(LegacyUpgradeWizard::class));
     }
 
     /**

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
   TYPO3_INSTALL_DB_DBNAME: 'appveyor_console_test'
 
   matrix:
-    - TYPO3_VERSION: '9.5.0'
+    - TYPO3_VERSION: '9.5.8'
       PHP_VERSION: '7.2.1-Win32-VC15'
     - TYPO3_VERSION: '~8.7'
       PHP_VERSION: '7.1.13-Win32-VC14'

--- a/composer.json
+++ b/composer.json
@@ -32,18 +32,18 @@
     ],
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=7.0.0 <7.4",
+        "php": "^7",
         "helhum/typo3-console-plugin": "^2.0.2",
 
-        "typo3/cms-backend": "~8.7.22 || ~9.5.0",
-        "typo3/cms-core": "~8.7.22 || ~9.5.0",
-        "typo3/cms-extbase": "~8.7.22 || ~9.5.0",
-        "typo3/cms-extensionmanager": "~8.7.22 || ~9.5.0",
-        "typo3/cms-fluid": "~8.7.22 || ~9.5.0",
-        "typo3/cms-frontend": "~8.7.22 || ~9.5.0",
-        "typo3/cms-install": "~8.7.22 || ~9.5.0",
+        "typo3/cms-backend": "~8.7.22 || ~9.5.8",
+        "typo3/cms-core": "~8.7.22 || ~9.5.8",
+        "typo3/cms-extbase": "~8.7.22 || ~9.5.8",
+        "typo3/cms-extensionmanager": "~8.7.22 || ~9.5.8",
+        "typo3/cms-fluid": "~8.7.22 || ~9.5.8",
+        "typo3/cms-frontend": "~8.7.22 || ~9.5.8",
+        "typo3/cms-install": "~8.7.22 || ~9.5.8",
         "typo3/cms-saltedpasswords": "*",
-        "typo3/cms-scheduler": "~8.7.22 || ~9.5.0",
+        "typo3/cms-scheduler": "~8.7.22 || ~9.5.8",
 
         "doctrine/annotations": "^1.4",
         "symfony/console": "^3.4.4 || ^4.0",
@@ -51,8 +51,8 @@
         "helhum/config-loader": ">=0.9 <0.13"
     },
     "require-dev": {
-        "typo3/cms-reports": "~8.7.22 || ~9.5.0 || dev-master",
-        "typo3/cms-filemetadata": "~8.7.22 || ~9.5.0 || dev-master",
+        "typo3/cms-reports": "~8.7.22 || ~9.5.8 || dev-master",
+        "typo3/cms-filemetadata": "~8.7.22 || ~9.5.8 || dev-master",
 
         "typo3-console/convert-command-controller-command": "@dev",
         "typo3-console/create-reference-command": "@dev",
@@ -60,8 +60,7 @@
         "symfony/filesystem": "^3.2",
         "nimut/testing-framework": "dev-allow-php73",
         "cweagans/composer-patches": "^1.6",
-        "jakub-onderka/php-parallel-lint": "^1.0",
-        "doctrine/dbal": "< 2.8"
+        "jakub-onderka/php-parallel-lint": "^1.0"
     },
     "conflict": {
         "typo3-ter/dbal": "*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,7 +23,7 @@
         <env name="TYPO3_INSTALL_SITE_NAME" value="Travis Install" />
         <env name="TYPO3_INSTALL_WEB_SERVER_SETUP_TYPE" value="none" />
         <env name="TYPO3_INSTALL_SITE_SETUP_TYPE" value="createsite" />
-        <env name="TYPO3_VERSION" value="~9.5.0" />
+        <env name="TYPO3_VERSION" value="~9.5.8" />
         <env name="TYPO3_UPGRADE_FROM_VERSION" value="~8.7.22" />
     </php>
     <testsuites>


### PR DESCRIPTION
The `RepeatableInterface` isn't respected and repeatable wizards are marked as done in the registry after first execution.