### PR TITLE
[BUGFIX] Avoid class map of all classes in non composer mode

### DIFF
--- a/Resources/Private/ExtensionArtifacts/Classes/Console/Hook/ExtensionInstallation.php
+++ b/Resources/Private/ExtensionArtifacts/Classes/Console/Hook/ExtensionInstallation.php
@@ -29,6 +29,8 @@ class ExtensionInstallation
     const COPY_SUCCESS_MESSAGE = 'Successfully copied the %s script to TYPO3 root directory. Let\'s dance!';
     const EXTKEY = 'typo3_console';
     const EM_FLASH_MESSAGE_QUEUE_ID = 'extbase.flashmessages.tx_extensionmanager_tools_extensionmanagerextensionmanager';
+    // Replicate Application::COMMAND_NAME to avoid class loading issues in non composer mode
+    const COMMAND_NAME = 'typo3cms';
 
     /**
      * Actions to take after extension has been installed
@@ -40,7 +42,7 @@ class ExtensionInstallation
         if (self::EXTKEY !== $keyOfInstalledExtension) {
             return;
         }
-        $scriptName = $this->isWindowsOs() ? 'Scripts/' . Application::COMMAND_NAME . '.bat' : Application::COMMAND_NAME;
+        $scriptName = $this->isWindowsOs() ? 'Scripts/' . self::COMMAND_NAME . '.bat' : self::COMMAND_NAME;
         $success = $this->safeCopy(PATH_site . self::BINARY_PATH . $scriptName, PATH_site . basename($scriptName));
         if (!$success) {
             self::addFlashMessage(sprintf(self::COPY_FAILED_MESSAGE, $scriptName), sprintf(self::COPY_FAILED_MESSAGE_TITLE, $scriptName, PATH_site), AbstractMessage::WARNING);

--- a/Resources/Private/ExtensionArtifacts/ext_emconf.php
+++ b/Resources/Private/ExtensionArtifacts/ext_emconf.php
@@ -28,6 +28,4 @@ $EM_CONF[$_EXTKEY] = [
     'suggests' => [
     ],
   ],
-  'autoload' => [
-  ],
 ];


### PR DESCRIPTION
With the new extension build process we can avoid
such overhead, which can also lead to issues on updating
the extension