### PR TITLE
[BUGFIX] Ensure extension classloader has precedence

### DIFF
--- a/Classes/Compatibility/CompatibilityClassLoader.php
+++ b/Classes/Compatibility/CompatibilityClassLoader.php
@@ -34,7 +34,7 @@ class CompatibilityClassLoader
     public function __construct(ClassLoader $originalClassLoader)
     {
         $this->originalClassLoader = $this->typo3ClassLoader = $originalClassLoader;
-        $this->handleExtensionCompatibility();
+        $this->handleExtensionCompatibility($originalClassLoader);
         $this->handleTypo3Compatibility();
     }
 
@@ -60,7 +60,7 @@ class CompatibilityClassLoader
         return $this->typo3ClassLoader;
     }
 
-    private function handleExtensionCompatibility()
+    private function handleExtensionCompatibility(ClassLoader $originalClassLoader)
     {
         if (class_exists(Bootstrap::class)) {
             return;
@@ -69,7 +69,9 @@ class CompatibilityClassLoader
         putenv('TYPO3_PATH_ROOT=' . $rootPath);
         $_ENV['TYPO3_PATH_ROOT'] = $rootPath;
         $_SERVER['TYPO3_PATH_ROOT'] = $rootPath;
+        $originalClassLoader->unregister();
         $this->typo3ClassLoader = require $typo3AutoLoadFile;
+        $originalClassLoader->register(true);
     }
 
     private function handleTypo3Compatibility()


### PR DESCRIPTION
Especially for TYPO3 version lower than 9.5 it is important
that the libraries shipped with the extension are used
instead of the ones shipped with TYPO3.

Fixes: #826