### PR TITLE
[BUGFIX] Improve error and exception handling

### DIFF
--- a/Classes/Console/Core/Booting/Scripts.php
+++ b/Classes/Console/Core/Booting/Scripts.php
@@ -81,8 +81,18 @@ class Scripts
 
     public static function initializeErrorHandling()
     {
+        $enforcedExceptionalErrors = E_WARNING | E_USER_WARNING | E_USER_ERROR | E_RECOVERABLE_ERROR;
+        $errorHandlerErrors = $GLOBALS['TYPO3_CONF_VARS']['SYS']['errorHandlerErrors'] ?? E_ALL & ~(E_STRICT | E_NOTICE | E_COMPILE_WARNING | E_COMPILE_ERROR | E_CORE_WARNING | E_CORE_ERROR | E_PARSE | E_ERROR);
+        // Ensure all exceptional errors are handled including E_USER_NOTICE
+        $errorHandlerErrors = $errorHandlerErrors | E_USER_NOTICE | $enforcedExceptionalErrors;
+        // Ensure notices are excluded to avoid overhead in the error handler
+        $errorHandlerErrors &= ~E_NOTICE;
         $errorHandler = new ErrorHandler();
-        $errorHandler->setExceptionalErrors([E_WARNING, E_USER_ERROR, E_USER_WARNING, E_USER_NOTICE, E_RECOVERABLE_ERROR]);
+        $errorHandler->setErrorsToHandle($errorHandlerErrors);
+        $exceptionalErrors = $GLOBALS['TYPO3_CONF_VARS']['SYS']['exceptionalErrors'] ?? E_ALL & ~(E_STRICT | E_NOTICE | E_COMPILE_WARNING | E_COMPILE_ERROR | E_CORE_WARNING | E_CORE_ERROR | E_PARSE | E_ERROR | E_DEPRECATED | E_USER_DEPRECATED | E_USER_NOTICE);
+        // Ensure warnings and errors are turned into exceptions
+        $exceptionalErrors = ($exceptionalErrors | $enforcedExceptionalErrors) & ~E_USER_DEPRECATED;
+        $errorHandler->setExceptionalErrors($exceptionalErrors);
         set_error_handler([$errorHandler, 'handleError']);
     }
 

--- a/Classes/Console/Error/ExceptionRenderer.php
+++ b/Classes/Console/Error/ExceptionRenderer.php
@@ -21,6 +21,8 @@ use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Terminal;
+use TYPO3\CMS\Core\Log\LogManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ExceptionRenderer
 {
@@ -43,6 +45,7 @@ class ExceptionRenderer
      */
     public function render(\Throwable $exception, OutputInterface $output, Application $application = null)
     {
+        $this->writeLog($exception);
         if (getenv('TYPO3_CONSOLE_SUB_PROCESS')) {
             $output->write(\json_encode($this->serializeException($exception)), false, OutputInterface::VERBOSITY_QUIET);
 
@@ -64,6 +67,15 @@ class ExceptionRenderer
         } while ($exception);
 
         $this->outputSynopsis($output, $application);
+    }
+
+    private function writeLog(\Throwable $exception)
+    {
+        if (empty($GLOBALS['TYPO3_CONF_VARS']['LOG'])) {
+            return;
+        }
+        $logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
+        $logger->critical($exception->getMessage(), ['exception' => $exception]);
     }
 
     /**

--- a/Classes/Console/Mvc/Cli/CommandConfiguration.php
+++ b/Classes/Console/Mvc/Cli/CommandConfiguration.php
@@ -15,6 +15,7 @@ namespace Helhum\Typo3Console\Mvc\Cli;
  */
 
 use Symfony\Component\Console\Exception\RuntimeException;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Package\PackageInterface;
 use TYPO3\CMS\Core\Package\PackageManager;
 
@@ -137,12 +138,18 @@ class CommandConfiguration
         return $this->commandDefinitions;
     }
 
+    /**
+     * @deprecated will be removed with 6.0
+     *
+     * @param array $commandControllers
+     * @return array
+     */
     public function addCommandControllerCommands(array $commandControllers): array
     {
         $addedCommandDefinitions = self::unifyCommandConfiguration(['controllers' => $commandControllers], '_lateCommands');
         $this->commandDefinitions = array_merge($this->commandDefinitions, $addedCommandDefinitions);
 
-        if (!empty($addedCommandDefinitions)) {
+        if (!empty($addedCommandDefinitions[1]) && $addedCommandDefinitions[0]['name'] !== 'help:error') {
             trigger_error('Registering commands via $GLOBALS[\'TYPO3_CONF_VARS\'][\'SC_OPTIONS\'][\'extbase\'][\'commandControllers\'] is deprecated and will be removed with 6.0. Register Symfony commands in Configuration/Commands.php instead.', E_USER_DEPRECATED);
         }
 
@@ -174,8 +181,11 @@ class CommandConfiguration
     private function getConfigFromExtension(PackageInterface $package): array
     {
         $commandConfiguration = [];
+        // @deprecated will be removed with 6.0
         if (file_exists($commandConfigurationFile = $package->getPackagePath() . 'Configuration/Console/Commands.php')) {
-            trigger_error('Configuration/Console/Commands.php for registering commands is deprecated and will be removed with 6.0. Register Symfony commands in Configuration/Commands.php instead.', E_USER_DEPRECATED);
+            if (class_exists(Environment::class)) {
+                trigger_error($package->getPackageKey() . ': Configuration/Console/Commands.php for registering commands is deprecated and will be removed with 6.0. Register Symfony commands in Configuration/Commands.php instead.', E_USER_DEPRECATED);
+            }
             $commandConfiguration = require $commandConfigurationFile;
         }
         if (file_exists($commandConfigurationFile = $package->getPackagePath() . 'Configuration/Commands.php')) {


### PR DESCRIPTION
Previously we ignored all TYPO3 configuration regarding
error and exception handling, to get a more reliable behavior
and a decent error output.

With this change we loosen this strictness a bit and at least look
at the configured error levels that should be logged or turned
into exceptions, but still enforce a reasonable configuration, by not
allowing warnings to be omitted.

Additionally we make sure both exceptions and errors are properly logged
using the logging framework.

We still disallow changing the error and exception handler to disallow
misconfiguration and also still not log errors to the legacy database log.

In case the latter is needed, it would still be possible to create a writer,
that writes to the database in a way that the TYPO3 backend log module
can use it.