### PR TITLE
[TASK] Migrate scheduler:run Command to Symfony Command

### DIFF
--- a/Classes/Console/Command/Scheduler/RunCommand.php
+++ b/Classes/Console/Command/Scheduler/RunCommand.php
@@ -1,7 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace Helhum\Typo3Console\Command;
-
+namespace Helhum\Typo3Console\Command\Scheduler;
 /*
  * This file is part of the TYPO3 Console project.
  *
@@ -13,50 +12,74 @@ namespace Helhum\Typo3Console\Command;
  * LICENSE file that was distributed with this source code.
  *
  */
-
-use Helhum\Typo3Console\Mvc\Controller\CommandController;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Scheduler\Scheduler;
 
-class SchedulerCommandController extends CommandController
+class RunCommand extends Command
 {
     /**
      * @var Scheduler
      */
-    protected $scheduler;
+    private $scheduler;
 
-    public function __construct(Scheduler $scheduler)
+    public function __construct(string $name = null, Scheduler $scheduler = null)
     {
+        parent::__construct($name);
         $this->scheduler = $scheduler;
     }
 
-    /**
-     * Run scheduler
-     *
-     * Executes tasks that are registered in the scheduler module.
-     *
-     * <b>Example:</b> <code>%command.full_name% 42 --force</code>
-     *
-     * @param int $task Uid of the task that should be executed (instead of all scheduled tasks)
-     * @param bool $force The execution can be forced with this flag. The task will then be executed even if it is not scheduled for execution yet. Only works, when a task is specified.
-     * @param int $taskId Deprecated option (same as --task)
-     */
-    public function runCommand($task = null, $force = false, $taskId = null)
+    protected function configure()
     {
-        if ($taskId !== null) {
+        $this->setDescription('Run scheduler');
+        $this->setHelp('Executes tasks that are registered in the scheduler module.
+
+<b>Example:</b> <code>%command.full_name% 42 --force</code>');
+        $this->addOption(
+            'task',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Uid of the task that should be executed (instead of all scheduled tasks)'
+        );
+        $this->addOption(
+            'force',
+            null,
+            InputOption::VALUE_NONE,
+            'The execution can be forced with this flag. The task will then be executed even if it is not scheduled for execution yet. Only works, when a task is specified.'
+        );
+        $this->addOption(
+            'task-id',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Deprecated option (same as --task)'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+        $task = $input->hasOption('task') ? $input->getOption('task') : null;
+        $force = $input->hasOption('force') ? $input->getOption('force') : false;
+        if ($input->hasOption('task-id')) {
             // @deprecated in 5.0 will be removed in 6.0
-            $this->outputLine('<warning>Using --task-id is deprecated. Please use --task instead.</warning>');
-            $task = $taskId;
+            $io->warning('Using --task-id is deprecated. Please use --task instead.');
+            $task = $input->getOption('task-id');
         }
         if ($task !== null) {
             if ($task <= 0) {
-                $this->outputLine('Task Id must be higher than zero.');
-                $this->quit(1);
+                $io->error('Task Id must be higher than zero.');
+
+                return 1;
             }
             $this->executeSingleTask($task, $force);
         } else {
             if ($force) {
-                $this->outputLine('Execution can only be forced when a single task is specified.');
-                $this->quit(2);
+                $io->error('Execution can only be forced when a single task is specified.');
+
+                return 2;
             }
             $this->executeScheduledTasks();
         }
@@ -72,7 +95,6 @@ class SchedulerCommandController extends CommandController
             // Try getting the next task and execute it
             // If there are no more tasks to execute, an exception is thrown by \TYPO3\CMS\Scheduler\Scheduler::fetchTask()
             try {
-                /** @var $task \TYPO3\CMS\Scheduler\Task\AbstractTask */
                 $task = $this->scheduler->fetchTask();
                 $hasTask = true;
                 try {

--- a/Configuration/Commands.php
+++ b/Configuration/Commands.php
@@ -330,10 +330,8 @@ return [
     ],
     'scheduler:run' => [
         'vendor' => 'typo3_console',
-        'class' => \Helhum\Typo3Console\Mvc\Cli\Symfony\Command\DummyCommand::class,
+        'class' => \Helhum\Typo3Console\Command\Scheduler\RunCommand::class,
         'schedulable' => false,
-        'controller' => \Helhum\Typo3Console\Command\SchedulerCommandController::class,
-        'controllerCommandName' => 'run',
         'replace' => [
             'scheduler:scheduler:run',
         ],

--- a/Configuration/Commands.php
+++ b/Configuration/Commands.php
@@ -330,7 +330,7 @@ return [
     ],
     'scheduler:run' => [
         'vendor' => 'typo3_console',
-        'class' => \Helhum\Typo3Console\Command\Scheduler\RunCommand::class,
+        'class' => \Helhum\Typo3Console\Command\Scheduler\SchedulerRunCommand::class,
         'schedulable' => false,
         'replace' => [
             'scheduler:scheduler:run',


### PR DESCRIPTION
The scheduler:run command is migrated from a CommandController
structure to a Symfony Command while keeping all existing
options as they are (including deprecated --task-id option).