### PR TITLE
[TASK] Migrate FrontendCommandController to Symfony Commands

### DIFF
--- a/Classes/Console/Command/Frontend/FrontendRequestCommand.php
+++ b/Classes/Console/Command/Frontend/FrontendRequestCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\PhpProcess;
 
-class RequestCommand extends Command
+class FrontendRequestCommand extends Command
 {
     protected function configure()
     {
@@ -63,6 +63,8 @@ EOH
         }
 
         $output->write($rawResponse->content, false, OutputInterface::OUTPUT_RAW);
+
+        return 0;
     }
 
     /**

--- a/Configuration/Commands.php
+++ b/Configuration/Commands.php
@@ -232,10 +232,8 @@ return [
     ],
     'frontend:request' => [
         'vendor' => 'typo3_console',
-        'class' => \Helhum\Typo3Console\Mvc\Cli\Symfony\Command\DummyCommand::class,
+        'class' => \Helhum\Typo3Console\Command\Frontend\RequestCommand::class,
         'schedulable' => false,
-        'controller' => \Helhum\Typo3Console\Command\FrontendCommandController::class,
-        'controllerCommandName' => 'request',
     ],
     'install:setup' => [
         'vendor' => 'typo3_console',

--- a/Configuration/Commands.php
+++ b/Configuration/Commands.php
@@ -232,7 +232,7 @@ return [
     ],
     'frontend:request' => [
         'vendor' => 'typo3_console',
-        'class' => \Helhum\Typo3Console\Command\Frontend\RequestCommand::class,
+        'class' => \Helhum\Typo3Console\Command\Frontend\FrontendRequestCommand::class,
         'schedulable' => false,
     ],
     'install:setup' => [

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -1007,7 +1007,7 @@ Arguments
 ~~~~~~~~~
 
 `requestUrl`
-   URL to make a frontend request.
+   URL to make a frontend request
 
 
 

--- a/Tests/Console/Unit/Command/Frontend/RequestCommandTest.php
+++ b/Tests/Console/Unit/Command/Frontend/RequestCommandTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace  Helhum\Typo3Console\Tests\Unit\Command\Frontend;
 
-use Helhum\Typo3Console\Command\Frontend\RequestCommand;
+use Helhum\Typo3Console\Command\Frontend\FrontendRequestCommand;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
 class RequestCommandTest extends UnitTestCase
@@ -33,8 +33,8 @@ class RequestCommandTest extends UnitTestCase
      */
     public function makeAbsoluteTest($expected, $given)
     {
-        /** @var RequestCommand $frontendRequest */
-        $frontendRequest = new RequestCommand();
+        /** @var FrontendRequestCommand $frontendRequest */
+        $frontendRequest = new FrontendRequestCommand();
         $parameter = [ $given ];
         $this->assertEquals($expected, $this->invokeMethod($frontendRequest, 'makeAbsolute', $parameter));
     }

--- a/Tests/Console/Unit/Command/Frontend/RequestCommandTest.php
+++ b/Tests/Console/Unit/Command/Frontend/RequestCommandTest.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
-namespace  Helhum\Typo3Console\Tests\Unit\Command;
+namespace  Helhum\Typo3Console\Tests\Unit\Command\Frontend;
 
-use Helhum\Typo3Console\Command\FrontendCommandController;
+use Helhum\Typo3Console\Command\Frontend\RequestCommand;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
-class FrontendCommandControllerTest extends UnitTestCase
+class RequestCommandTest extends UnitTestCase
 {
     /**
      * Call protected/private method of a class.
@@ -33,8 +33,8 @@ class FrontendCommandControllerTest extends UnitTestCase
      */
     public function makeAbsoluteTest($expected, $given)
     {
-        /** @var FrontendCommandController $frontendRequest */
-        $frontendRequest = new FrontendCommandController();
+        /** @var RequestCommand $frontendRequest */
+        $frontendRequest = new RequestCommand();
         $parameter = [ $given ];
         $this->assertEquals($expected, $this->invokeMethod($frontendRequest, 'makeAbsolute', $parameter));
     }


### PR DESCRIPTION
The following command is migrated from a CommandController structure to a Symfony Command:

- frontend:request