### PR TITLE
[BUGFIX] Allow XCLASS of DependencyOrderingService

### DIFF
--- a/Classes/Console/Command/Install/InstallGeneratePackageStatesCommand.php
+++ b/Classes/Console/Command/Install/InstallGeneratePackageStatesCommand.php
@@ -19,11 +19,13 @@ use Helhum\Typo3Console\Core\Booting\CompatibilityScripts;
 use Helhum\Typo3Console\Install\PackageStatesGenerator;
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
 use Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException;
+use Helhum\Typo3Console\Package\UncachedPackageManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Package\PackageInterface;
 use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Service\DependencyOrderingService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class InstallGeneratePackageStatesCommand extends AbstractConvertedCommand
@@ -113,6 +115,10 @@ EOH
             (string)getenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS')
         );
         $packageManager = GeneralUtility::makeInstance(PackageManager::class);
+        if (!$packageManager instanceof UncachedPackageManager) {
+            throw new \RuntimeException('Expected UncachedPackageManager', 1576244721);
+        }
+        $packageManager->injectDependencyOrderingService(GeneralUtility::makeInstance(DependencyOrderingService::class));
         $packageStatesGenerator = new PackageStatesGenerator($packageManager);
         $activatedExtensions = $packageStatesGenerator->generate(
             $frameworkExtensions,

--- a/Classes/Console/Package/UncachedPackageManager.php
+++ b/Classes/Console/Package/UncachedPackageManager.php
@@ -16,6 +16,7 @@ namespace Helhum\Typo3Console\Package;
 
 use TYPO3\CMS\Core\Package\PackageInterface;
 use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Service\DependencyOrderingService;
 
 class UncachedPackageManager extends PackageManager
 {
@@ -28,6 +29,14 @@ class UncachedPackageManager extends PackageManager
      * @var bool
      */
     protected $packageStatesFileExists = false;
+
+    /**
+     * @param DependencyOrderingService $dependencyOrderingService
+     */
+    public function injectDependencyOrderingService(DependencyOrderingService $dependencyOrderingService)
+    {
+        $this->dependencyOrderingService = $dependencyOrderingService;
+    }
 
     public function init()
     {


### PR DESCRIPTION
When generating PackageStates.php file, we now allow
DependencyOrderingService to be XCLASSed to be in line
with current TYPO3 behavior.

Fixes: #804