### PR TITLE
[BUGFIX] Allow specifying multiple schema update types

### DIFF
--- a/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
+++ b/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
@@ -76,7 +76,7 @@ EOH
                 'schemaUpdateTypes',
                 InputArgument::OPTIONAL,
                 'List of schema update types (default: "safe")',
-                ['safe']
+                'safe'
             ),
             new InputOption(
                 'dry-run',
@@ -103,7 +103,7 @@ EOH
         );
         $schemaUpdateResultRenderer = new SchemaUpdateResultRenderer();
 
-        $schemaUpdateTypes = (array)$input->getArgument('schemaUpdateTypes');
+        $schemaUpdateTypes = explode(',', $input->getArgument('schemaUpdateTypes'));
         $dryRun = $input->getOption('dry-run');
         $verbose = $output->isVerbose();
 

--- a/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
@@ -31,6 +31,16 @@ class DatabaseCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
+    public function multipleUpdateTypesCanBeSpecified()
+    {
+        $output = $this->executeConsoleCommand('database:updateschema', ['field.add,table.add', '--verbose']);
+        $this->assertContains('No schema updates were performed for update types:', $output);
+        $this->assertContains('"field.add", "table.add"', $output);
+    }
+
+    /**
+     * @test
+     */
     public function allUpdatesCanBePerformedWhenSpecified()
     {
         $output = $this->executeConsoleCommand('database:updateschema', ['*', '--verbose']);


### PR DESCRIPTION
Converting from command controller introduced a regression
that multiple schema types separated by comma were not properly
expanded to an array.

Fixes: #864