### PR TITLE
Fixed naming of config-only input option

### DIFF
--- a/Classes/Console/Command/Upgrade/UpgradeCheckExtensionCompatibilityCommand.php
+++ b/Classes/Console/Command/Upgrade/UpgradeCheckExtensionCompatibilityCommand.php
@@ -48,7 +48,7 @@ EOH
                 'Extension key for extension to check'
             ),
             new InputOption(
-                'configOnly',
+                'config-only',
                 'c',
                 InputOption::VALUE_NONE,
                 ''
@@ -67,7 +67,7 @@ EOH
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $extensionKey = $input->getArgument('extensionKeys');
-        $configOnly = $input->getOption('configOnly');
+        $configOnly = $input->getOption('config-only');
 
         $output->writeln(\json_encode((new UpgradeHandling())->isCompatible($extensionKey, $configOnly)));
     }


### PR DESCRIPTION
config-only input option of upgrade:checkextensioncompatibility command has wrong name, breaking other scripts such as  upgrade:all