### PR TITLE
[BUGFIX] Use correct reference to call writeln() method

### DIFF
--- a/Classes/Console/Command/Install/InstallSetupCommand.php
+++ b/Classes/Console/Command/Install/InstallSetupCommand.php
@@ -200,7 +200,7 @@ EOH
 
         if ($nonInteractive) {
             // @deprecated in 5.0 will be removed with 6.0
-            $this->writeln('<warning>Option --non-interactive is deprecated. Please use --no-interaction instead.</warning>');
+            $output->writeln('<warning>Option --non-interactive is deprecated. Please use --no-interaction instead.</warning>');
             $isInteractive = false;
         }
 


### PR DESCRIPTION
The FIX resolves the problem, when a user is calling the command with the deprectated --non-interactive flag.
The deprecation warning leads to an unhandled Exception.

Call to undefined method Helhum\Typo3Console\Command\Install\InstallSetupCommand::writeln()