### PR TITLE
[BUGFIX] Set input option mode to array for upgrade wizard commands

### DIFF
--- a/Classes/Console/Command/Upgrade/UpgradeAllCommand.php
+++ b/Classes/Console/Command/Upgrade/UpgradeAllCommand.php
@@ -65,6 +65,7 @@ class UpgradeAllCommand extends AbstractConvertedCommand
         }
 
         $arguments = $input->getOption('arguments');
+        $arguments = is_array($arguments) ? $arguments : explode(',', $arguments);
         $verbose = $output->isVerbose();
 
         $output->writeln(PHP_EOL . '<i>Initiating TYPO3 upgrade</i>' . PHP_EOL);

--- a/Classes/Console/Command/Upgrade/UpgradeWizardCommand.php
+++ b/Classes/Console/Command/Upgrade/UpgradeWizardCommand.php
@@ -76,6 +76,7 @@ class UpgradeWizardCommand extends AbstractConvertedCommand
 
         $identifier = $input->getArgument('identifier');
         $arguments = $input->getOption('arguments');
+        $arguments = is_array($arguments) ? $arguments : explode(',', $arguments);
         $force = $input->getOption('force');
 
         $result = $upgradeHandling->executeInSubProcess(


### PR DESCRIPTION
I currently run into a problem with arguments for upgrade wizard command:
```bash
php typo3cms upgrade:wizard --no-interaction realurlAliasNewsSlug --arguments realurlAliasNewsSlug[install]=1
```
But this throws an exception:
```text
[ TypeError ]                                                                                                                                                            
  Argument 2 passed to Helhum\Typo3Console\Install\Upgrade\UpgradeHandling::executeWizard() must be of the type array, string given, called in /var/www/html/htdocs/typo3  
  conf/ext/typo3_console/Libraries/helhum/typo3-console/Classes/Console/Command/Upgrade/UpgradeSubProcessCommand.php on line 53
```

I think the input option mode should be set as an array.

When i change the mode to `InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY` the command is executed correctly.

I have checked all commands and figured out that the problem exists for `UpgradeAllCommand:arguments` and `UpgradeWizardCommand:arguments`.

This PR adds the missing VALUE_IS_ARRAY input option mode.

This may be related to  #795.
