### PR TITLE
[BUGFIX] Allow final view helper classes in XSD generation

### DIFF
--- a/Classes/Console/Parser/PhpParser.php
+++ b/Classes/Console/Parser/PhpParser.php
@@ -96,7 +96,7 @@ class PhpParser implements PhpParserInterface
      */
     protected function parseClassNameRaw($classContent): string
     {
-        preg_match('/^\\s*(abstract)*\\s*(class|interface) ([a-zA-Z_\x7f-\xff][a-zA-Z0-9\\\\_\x7f-\xff]*)/ims', $classContent, $matches);
+        preg_match('/^\\s*(abstract|final)*\\s*(class|interface) ([a-zA-Z_\x7f-\xff][a-zA-Z0-9\\\\_\x7f-\xff]*)/ims', $classContent, $matches);
         if (!isset($matches[2])) {
             throw new ParsingException('Class file does not contain a class or interface definition', 1399285302);
         }

--- a/Tests/Console/Unit/Parser/PhpParserTest.php
+++ b/Tests/Console/Unit/Parser/PhpParserTest.php
@@ -118,6 +118,7 @@ class PhpParserTest extends UnitTestCase
         return [
             'normal class' => ['class Tx_Ext_Bar {', ['className' => 'Bar', 'namespace' => 'Tx_Ext', 'separator' => '_', 'full' => 'Tx_Ext_Bar']],
             'abstract class' => ['abstract class Tx_Ext_BarAbstract {', ['className' => 'BarAbstract', 'namespace' => 'Tx_Ext', 'separator' => '_', 'full' => 'Tx_Ext_BarAbstract']],
+            'final class' => ['final class Tx_Ext_BarFinal {', ['className' => 'BarFinal', 'namespace' => 'Tx_Ext', 'separator' => '_', 'full' => 'Tx_Ext_BarFinal']],
             'without namespace' => ['class TxExtBar {', ['className' => 'TxExtBar', 'namespace' => '', 'separator' => '', 'full' => 'TxExtBar']],
         ];
     }


### PR DESCRIPTION
Declaring a view helper as final didn't recognized
it when generating an XSD.