### PR TITLE
[BUGFIX] Fix rendering of SubProcessException

### DIFF
--- a/Classes/Console/Command/Upgrade/UpgradeCheckExtensionConstraintsCommand.php
+++ b/Classes/Console/Command/Upgrade/UpgradeCheckExtensionConstraintsCommand.php
@@ -70,7 +70,7 @@ EOH
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $extensionKeys = explode(',', $input->getArgument('extensionKeys'));
+        $extensionKeys = ($extensionKeys = $input->getArgument('extensionKeys')) ? explode(',', $extensionKeys) : [];
         $typo3Version = $input->getOption('typo3-version');
         $upgradeHandling = new UpgradeHandling();
         if (empty($extensionKeys)) {

--- a/Classes/Console/Mvc/Cli/SubProcessException.php
+++ b/Classes/Console/Mvc/Cli/SubProcessException.php
@@ -27,6 +27,11 @@ class SubProcessException extends \Exception
     /**
      * @var string|null
      */
+    private $previousExceptionMessage;
+
+    /**
+     * @var string|null
+     */
     private $previousExceptionTrace;
 
     /**
@@ -67,14 +72,23 @@ class SubProcessException extends \Exception
         $previousExceptionErrorMessage = null
     ) {
         $previousException = $previousExceptionData ? self::createFromArray($previousExceptionData) : null;
-        parent::__construct($previousExceptionMessage, $previousExceptionCode, $previousException);
+        $fullMessage = sprintf('[%s] %s', $previousExceptionClass, $previousExceptionMessage);
+        parent::__construct($fullMessage, $previousExceptionCode, $previousException);
         $this->previousExceptionClass = $previousExceptionClass;
+        $this->previousExceptionMessage = $previousExceptionMessage;
         $this->previousExceptionTrace = $previousExceptionTrace;
         $this->previousExceptionLine = $previousExceptionLine;
         $this->previousExceptionFile = $previousExceptionFile;
         $this->previousExceptionCommandLine = $previousExceptionCommandLine;
         $this->previousExceptionOutputMessage = $previousExceptionOutputMessage;
         $this->previousExceptionErrorMessage = $previousExceptionErrorMessage;
+
+        $this->line = $previousExceptionLine;
+        $this->file = $previousExceptionFile;
+        array_shift($previousExceptionTrace);
+        $traceReflection = new \ReflectionProperty(\Exception::class, 'trace');
+        $traceReflection->setAccessible(true);
+        $traceReflection->setValue($this, $previousExceptionTrace);
     }
 
     public static function createFromArray($previousExceptionData)
@@ -99,6 +113,14 @@ class SubProcessException extends \Exception
     public function getPreviousExceptionClass()
     {
         return $this->previousExceptionClass;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPreviousExceptionMessage()
+    {
+        return $this->previousExceptionMessage;
     }
 
     /**

--- a/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
@@ -55,12 +55,14 @@ class UpgradeCommandControllerTest extends AbstractCommandTest
         $this->executeConsoleCommand('extension:activate', ['ext_test']);
         try {
             $this->commandDispatcher->executeCommand('upgrade:checkextensionconstraints', ['--typo3-version' => '3.6.0']);
+            $this->fail('Extension compatibility check was expected to fail, but did pass.');
         } catch (FailedSubProcessCommandException $e) {
             $this->assertSame(1, $e->getExitCode());
             $this->assertContains('"ext_test" requires TYPO3 versions 4.5.0', $e->getOutputMessage());
+        } finally {
+            $this->executeConsoleCommand('extension:deactivate', ['ext_test']);
+            $this->removeFixtureExtensionCode('ext_test');
         }
-        $this->executeConsoleCommand('extension:deactivate', ['ext_test']);
-        $this->removeFixtureExtensionCode('ext_test');
     }
 
     /**

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
   TYPO3_INSTALL_DB_DBNAME: 'appveyor_console_test'
 
   matrix:
-    - TYPO3_VERSION: '9.5.8'
+    - TYPO3_VERSION: '~9.5.13'
       PHP_VERSION: '7.2.1-Win32-VC15'
     - TYPO3_VERSION: '~8.7'
       PHP_VERSION: '7.1.13-Win32-VC14'

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,6 @@
         "local": {
             "type": "path",
             "url": "Packages/*"
-        },
-        "testing-framework": {
-            "type": "vcs",
-            "url": "https://github.com/helhum/TYPO3-testing-framework.git"
         }
     },
     "name": "helhum/typo3-console",
@@ -58,9 +54,10 @@
         "typo3-console/create-reference-command": "@dev",
         "typo3-console/php-server-command": "^0.2",
         "symfony/filesystem": "^3.2",
-        "nimut/testing-framework": "dev-allow-php73",
+        "nimut/testing-framework": "^4.1",
         "cweagans/composer-patches": "^1.6",
-        "jakub-onderka/php-parallel-lint": "^1.0"
+        "jakub-onderka/php-parallel-lint": "^1.0",
+        "phpunit/phpunit": "^6"
     },
     "conflict": {
         "typo3-ter/dbal": "*",


### PR DESCRIPTION
We can improve the rendering of SubProcessException
in other contexts as our own renderer, by setting the
line, code and trace accordingly.

Also fix our renderer if used outside TYPO3 context.