### PR TITLE
[TASK] Apply Symfony command styling

### DIFF
--- a/Classes/Console/Command/Cache/CacheFlushGroupsCommand.php
+++ b/Classes/Console/Command/Cache/CacheFlushGroupsCommand.php
@@ -36,7 +36,9 @@ Valid group names are by default:
 - pages
 - system
 
-<b>Example:</b> <code>%command.full_name% pages,all</code>
+<b>Example:</b>
+
+  <code>%command.full_name% pages,all</code>
 EOH
         );
         /** @deprecated Will be removed with 6.0 */

--- a/Classes/Console/Command/Cache/CacheFlushTagsCommand.php
+++ b/Classes/Console/Command/Cache/CacheFlushTagsCommand.php
@@ -32,7 +32,9 @@ class CacheFlushTagsCommand extends AbstractConvertedCommand
             <<<'EOH'
 Flushes caches by tags, optionally only caches in specified groups.
 
-<b>Example:</b> <code>%command.full_name% news_123 --groups pages,all</code>
+<b>Example:</b>
+
+  <code>%command.full_name% news_123 --groups pages,all</code>
 EOH
         );
         /** @deprecated Will be removed with 6.0 */

--- a/Classes/Console/Command/Configuration/ConfigurationRemoveCommand.php
+++ b/Classes/Console/Command/Configuration/ConfigurationRemoveCommand.php
@@ -35,7 +35,9 @@ Removes a system configuration option by path.
 For this command to succeed, the configuration option(s) must be in
 LocalConfiguration.php and not be overridden elsewhere.
 
-<b>Example:</b> <code>%command.full_name% DB,EXT/EXTCONF/realurl</code>
+<b>Example:</b>
+
+  <code>%command.full_name% DB,EXT/EXTCONF/realurl</code>
 EOH
         );
         /** @deprecated Will be removed with 6.0 */

--- a/Classes/Console/Command/Configuration/ConfigurationSetCommand.php
+++ b/Classes/Console/Command/Configuration/ConfigurationSetCommand.php
@@ -31,9 +31,14 @@ class ConfigurationSetCommand extends AbstractConvertedCommand
 Set system configuration option value by path.
 
 <b>Examples:</b>
-<code>%command.full_name% SYS/fileCreateMask 0664</code>
-<code>%command.full_name% EXTCONF/processor_enabled true --json</code>
-<code>%command.full_name% EXTCONF/lang/availableLanguages '["de", "fr"]' --json</code>
+
+  <code>%command.full_name% SYS/fileCreateMask 0664</code>
+
+  <code>%command.full_name% EXTCONF/processor_enabled true --json</code>
+
+  <code>%command.full_name% EXTCONF/lang/availableLanguages '["de", "fr"]' --json</code>
+
+  <code>%command.full_name% configuration:set BE/adminOnly -- -1</code>
 EOH
         );
         /** @deprecated Will be removed with 6.0 */

--- a/Classes/Console/Command/Configuration/ConfigurationShowActiveCommand.php
+++ b/Classes/Console/Command/Configuration/ConfigurationShowActiveCommand.php
@@ -32,7 +32,9 @@ class ConfigurationShowActiveCommand extends AbstractConvertedCommand
 Shows active system configuration by path.
 Shows the configuration value that is currently effective, no matter where and how it is set.
 
-<b>Example:</b> <code>%command.full_name% DB --json</code>
+<b>Example:</b>
+
+  <code>%command.full_name% DB --json</code>
 EOH
         );
         /** @deprecated Will be removed with 6.0 */

--- a/Classes/Console/Command/Configuration/ConfigurationShowCommand.php
+++ b/Classes/Console/Command/Configuration/ConfigurationShowCommand.php
@@ -32,7 +32,9 @@ Shows system configuration value by path.
 If the currently active configuration differs from the value in LocalConfiguration.php
 the difference between these values is shown.
 
-<b>Example:</b> <code>%command.full_name% DB</code>
+<b>Example:</b>
+
+  <code>%command.full_name% DB</code>
 EOH
         );
         /** @deprecated Will be removed with 6.0 */

--- a/Classes/Console/Command/Configuration/ConfigurationShowLocalCommand.php
+++ b/Classes/Console/Command/Configuration/ConfigurationShowLocalCommand.php
@@ -41,7 +41,9 @@ Shows local configuration option value by path.
 Shows the value which is stored in LocalConfiguration.php.
 Note that this value could be overridden. Use <code>typo3cms configuration:show <path></code> to see if this is the case.
 
-<b>Example:</b> <code>%command.full_name% DB</code>
+<b>Example:</b>
+
+  <code>%command.full_name% DB</code>
 EOH
         );
         /** @deprecated Will be removed with 6.0 */

--- a/Classes/Console/Command/Database/DatabaseExportCommand.php
+++ b/Classes/Console/Command/Database/DatabaseExportCommand.php
@@ -50,7 +50,9 @@ This obviously only works when MySQL is used as DBMS.
 
 Tables to be excluded from the export can be specified fully qualified or with wildcards:
 
-<b>Example:</b> <code>%command.full_name% -c Default -e 'cf_*' -e 'cache_*' -e '[bf]e_sessions' -e sys_log</code>
+<b>Example:</b>
+
+  <code>%command.full_name% -c Default -e 'cf_*' -e 'cache_*' -e '[bf]e_sessions' -e sys_log</code>
 EOH
         );
         /** @deprecated Will be removed with 6.0 */

--- a/Classes/Console/Command/Database/DatabaseImportCommand.php
+++ b/Classes/Console/Command/Database/DatabaseImportCommand.php
@@ -33,9 +33,17 @@ it but works as well to pass SELECT statements to it.
 The mysql binary must be available in the path for this command to work.
 This obviously only works when MySQL is used as DBMS.
 
-<b>Example (import):</b> <code>ssh remote.server '/path/to/typo3cms database:export' | %command.full_name%</code>
-<b>Example (select):</b> <code>echo 'SELECT username from be_users WHERE admin=1;' | %command.full_name%</code>
-<b>Example (interactive):</b> <code>%command.full_name% --interactive</code>
+<b>Example (import):</b>
+
+  <code>ssh remote.server '/path/to/typo3cms database:export' | %command.full_name%</code>
+
+<b>Example (select):</b>
+
+  <code>echo 'SELECT username from be_users WHERE admin=1;' | %command.full_name%</code>
+
+<b>Example (interactive):</b>
+
+  <code>%command.full_name% --interactive</code>
 EOH
         );
         /** @deprecated Will be removed with 6.0 */

--- a/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
+++ b/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
@@ -59,7 +59,9 @@ The list of schema update types supports wildcards to specify multiple types, e.
 
 To avoid shell matching all types with wildcards should be quoted.
 
-<b>Example:</b> <code>%command.full_name% "*.add,*.change"</code>
+<b>Example:</b>
+
+  <code>%command.full_name% "*.add,*.change"</code>
 EOH
         );
         /** @deprecated Will be removed with 6.0 */

--- a/Classes/Console/Command/Install/InstallGeneratePackageStatesCommand.php
+++ b/Classes/Console/Command/Install/InstallGeneratePackageStatesCommand.php
@@ -50,7 +50,9 @@ To require TYPO3 core extensions use the following command:
 
 This updates your composer.json and composer.lock without any other changes.
 
-<b>Example:</b> <code>%command.full_name%</code>
+<b>Example:</b>
+
+  <code>%command.full_name%</code>
 EOH
         );
         /** @deprecated Will be removed with 6.0 */

--- a/Documentation/CommandReference/CacheFlushgroups.rst
+++ b/Documentation/CommandReference/CacheFlushgroups.rst
@@ -22,7 +22,9 @@ Valid group names are by default:
 - pages
 - system
 
-**Example:** `typo3cms cache:flushgroups pages,all`
+**Example:**
+
+  `typo3cms cache:flushgroups pages,all`
 
 Arguments
 ~~~~~~~~~

--- a/Documentation/CommandReference/CacheFlushtags.rst
+++ b/Documentation/CommandReference/CacheFlushtags.rst
@@ -17,7 +17,9 @@ cache:flushtags
 
 Flushes caches by tags, optionally only caches in specified groups.
 
-**Example:** `typo3cms cache:flushtags news_123 --groups pages,all`
+**Example:**
+
+  `typo3cms cache:flushtags news_123 --groups pages,all`
 
 Arguments
 ~~~~~~~~~

--- a/Documentation/CommandReference/ConfigurationRemove.rst
+++ b/Documentation/CommandReference/ConfigurationRemove.rst
@@ -20,7 +20,9 @@ Removes a system configuration option by path.
 For this command to succeed, the configuration option(s) must be in
 LocalConfiguration.php and not be overridden elsewhere.
 
-**Example:** `typo3cms configuration:remove DB,EXT/EXTCONF/realurl`
+**Example:**
+
+  `typo3cms configuration:remove DB,EXT/EXTCONF/realurl`
 
 Arguments
 ~~~~~~~~~

--- a/Documentation/CommandReference/ConfigurationSet.rst
+++ b/Documentation/CommandReference/ConfigurationSet.rst
@@ -18,9 +18,14 @@ configuration:set
 Set system configuration option value by path.
 
 **Examples:**
-`typo3cms configuration:set SYS/fileCreateMask 0664`
-`typo3cms configuration:set EXTCONF/processor_enabled true --json`
-`typo3cms configuration:set EXTCONF/lang/availableLanguages '["de", "fr"]' --json`
+
+  `typo3cms configuration:set SYS/fileCreateMask 0664`
+
+  `typo3cms configuration:set EXTCONF/processor_enabled true --json`
+
+  `typo3cms configuration:set EXTCONF/lang/availableLanguages '["de", "fr"]' --json`
+
+  `typo3cms configuration:set configuration:set BE/adminOnly -- -1`
 
 Arguments
 ~~~~~~~~~

--- a/Documentation/CommandReference/ConfigurationShow.rst
+++ b/Documentation/CommandReference/ConfigurationShow.rst
@@ -19,7 +19,9 @@ Shows system configuration value by path.
 If the currently active configuration differs from the value in LocalConfiguration.php
 the difference between these values is shown.
 
-**Example:** `typo3cms configuration:show DB`
+**Example:**
+
+  `typo3cms configuration:show DB`
 
 Arguments
 ~~~~~~~~~

--- a/Documentation/CommandReference/ConfigurationShowactive.rst
+++ b/Documentation/CommandReference/ConfigurationShowactive.rst
@@ -18,7 +18,9 @@ configuration:showactive
 Shows active system configuration by path.
 Shows the configuration value that is currently effective, no matter where and how it is set.
 
-**Example:** `typo3cms configuration:showactive DB --json`
+**Example:**
+
+  `typo3cms configuration:showactive DB --json`
 
 Arguments
 ~~~~~~~~~

--- a/Documentation/CommandReference/ConfigurationShowlocal.rst
+++ b/Documentation/CommandReference/ConfigurationShowlocal.rst
@@ -19,7 +19,9 @@ Shows local configuration option value by path.
 Shows the value which is stored in LocalConfiguration.php.
 Note that this value could be overridden. Use `typo3cms configuration:show <path>` to see if this is the case.
 
-**Example:** `typo3cms configuration:showlocal DB`
+**Example:**
+
+  `typo3cms configuration:showlocal DB`
 
 Arguments
 ~~~~~~~~~

--- a/Documentation/CommandReference/DatabaseExport.rst
+++ b/Documentation/CommandReference/DatabaseExport.rst
@@ -21,7 +21,9 @@ This obviously only works when MySQL is used as DBMS.
 
 Tables to be excluded from the export can be specified fully qualified or with wildcards:
 
-**Example:** `typo3cms database:export -c Default -e 'cf_*' -e 'cache_*' -e '[bf]e_sessions' -e sys_log`
+**Example:**
+
+  `typo3cms database:export -c Default -e 'cf_*' -e 'cache_*' -e '[bf]e_sessions' -e sys_log`
 
 
 

--- a/Documentation/CommandReference/DatabaseImport.rst
+++ b/Documentation/CommandReference/DatabaseImport.rst
@@ -20,9 +20,17 @@ it but works as well to pass SELECT statements to it.
 The mysql binary must be available in the path for this command to work.
 This obviously only works when MySQL is used as DBMS.
 
-**Example (import):** `ssh remote.server '/path/to/typo3cms database:export' | typo3cms database:import`
-**Example (select):** `echo 'SELECT username from be_users WHERE admin=1;' | typo3cms database:import`
-**Example (interactive):** `typo3cms database:import --interactive`
+**Example (import):**
+
+  `ssh remote.server '/path/to/typo3cms database:export' | typo3cms database:import`
+
+**Example (select):**
+
+  `echo 'SELECT username from be_users WHERE admin=1;' | typo3cms database:import`
+
+**Example (interactive):**
+
+  `typo3cms database:import --interactive`
 
 
 

--- a/Documentation/CommandReference/DatabaseUpdateschema.rst
+++ b/Documentation/CommandReference/DatabaseUpdateschema.rst
@@ -39,7 +39,9 @@ The list of schema update types supports wildcards to specify multiple types, e.
 
 To avoid shell matching all types with wildcards should be quoted.
 
-**Example:** `typo3cms database:updateschema "*.add,*.change"`
+**Example:**
+
+  `typo3cms database:updateschema "*.add,*.change"`
 
 Arguments
 ~~~~~~~~~

--- a/Documentation/CommandReference/InstallGeneratepackagestates.rst
+++ b/Documentation/CommandReference/InstallGeneratepackagestates.rst
@@ -31,7 +31,9 @@ To require TYPO3 core extensions use the following command:
 
 This updates your composer.json and composer.lock without any other changes.
 
-**Example:** `typo3cms install:generatepackagestates`
+**Example:**
+
+  `typo3cms install:generatepackagestates`
 
 
 


### PR DESCRIPTION
This patch streamlines the command help descriptions according to the Symfony
command styling.