### PR TITLE
[BUGFIX] Handle string Exception codes correctly

### DIFF
--- a/Classes/Console/Error/ExceptionRenderer.php
+++ b/Classes/Console/Error/ExceptionRenderer.php
@@ -123,8 +123,12 @@ class ExceptionRenderer
      */
     private function outputCode(\Throwable $exception, OutputInterface $output)
     {
-        if ($exception->getCode() > 0) {
-            $output->writeln(sprintf('<comment>Exception code:</comment> <info>%s</info>', $exception->getCode()));
+        $code = $exception->getCode();
+        if ($exception instanceof SubProcessException) {
+            $code = $exception->getPreviousExceptionCode();
+        }
+        if (!empty($code)) {
+            $output->writeln(sprintf('<comment>Exception code:</comment> <info>%s</info>', $code));
             $output->writeln('');
         }
     }
@@ -266,11 +270,13 @@ class ExceptionRenderer
         if ($exception) {
             $exceptionClass = get_class($exception);
             $exceptionMessage = $exception->getMessage();
+            $exceptionCode = $exception->getCode();
             $line = $exception->getLine();
             $file = $exception->getFile();
             if ($exception instanceof SubProcessException) {
                 $exceptionClass = $exception->getPreviousExceptionClass();
                 $exceptionMessage = $exception->getPreviousExceptionMessage();
+                $exceptionCode = $exception->getPreviousExceptionCode();
                 $line = $exception->getPreviousExceptionLine();
                 $file = $exception->getPreviousExceptionFile();
             } elseif ($exception instanceof FailedSubProcessCommandException) {
@@ -286,7 +292,7 @@ class ExceptionRenderer
                 'line' => $line,
                 'file' => $file,
                 'message' => $exceptionMessage,
-                'code' => $exception->getCode(),
+                'code' => $exceptionCode,
                 'trace' => $this->getTrace($exception),
                 'previous' => $this->serializeException($exception->getPrevious()),
                 'commandline' => $commandLine ?? null,

--- a/Classes/Console/Mvc/Cli/SubProcessException.php
+++ b/Classes/Console/Mvc/Cli/SubProcessException.php
@@ -30,6 +30,11 @@ class SubProcessException extends \Exception
     private $previousExceptionMessage;
 
     /**
+     * @var mixed
+     */
+    private $previousExceptionCode;
+
+    /**
      * @var string|null
      */
     private $previousExceptionTrace;
@@ -71,11 +76,18 @@ class SubProcessException extends \Exception
         $previousExceptionOutputMessage = null,
         $previousExceptionErrorMessage = null
     ) {
+        $code = $previousExceptionCode;
+        $message = $previousExceptionMessage;
+        if ($previousExceptionCode !== (int)$previousExceptionCode) {
+            $message = sprintf('[%s] %s', $previousExceptionCode, $previousExceptionMessage);
+            $code = 0;
+        }
         $previousException = $previousExceptionData ? self::createFromArray($previousExceptionData) : null;
-        $fullMessage = sprintf('[%s] %s', $previousExceptionClass, $previousExceptionMessage);
-        parent::__construct($fullMessage, $previousExceptionCode, $previousException);
+        $fullMessage = sprintf('[%s] %s', $previousExceptionClass, $message);
+        parent::__construct($fullMessage, $code, $previousException);
         $this->previousExceptionClass = $previousExceptionClass;
         $this->previousExceptionMessage = $previousExceptionMessage;
+        $this->previousExceptionCode = $previousExceptionCode;
         $this->previousExceptionTrace = $previousExceptionTrace;
         $this->previousExceptionLine = $previousExceptionLine;
         $this->previousExceptionFile = $previousExceptionFile;
@@ -121,6 +133,14 @@ class SubProcessException extends \Exception
     public function getPreviousExceptionMessage()
     {
         return $this->previousExceptionMessage;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPreviousExceptionCode()
+    {
+        return $this->previousExceptionCode;
     }
 
     /**

--- a/Tests/Console/Unit/Error/ExceptionRendererTest.php
+++ b/Tests/Console/Unit/Error/ExceptionRendererTest.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Tests\Unit\Mvc\Cli;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Error\ExceptionRenderer;
+use Helhum\Typo3Console\Mvc\Cli\SubProcessException;
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Terminal;
+
+class ExceptionRendererTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function exceptionClassIsRenderedAsTitleMessageAsLinesAndCodeExplicitly()
+    {
+        $subject = new ExceptionRenderer($this->getTerminalStub());
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_VERBOSE);
+        $subject->render(new \RuntimeException('Foo', 4223), $output);
+        $renderedOutput = $output->fetch();
+        $this->assertContains('[ RuntimeException ]', $renderedOutput);
+        $this->assertContains('Foo', $renderedOutput);
+        $this->assertContains('Exception code: 4223', $renderedOutput);
+        $this->assertContains('Exception trace:', $renderedOutput);
+    }
+
+    /**
+     * @test
+     */
+    public function exceptionCodeNotRenderedWhenNotVerbose()
+    {
+        $subject = new ExceptionRenderer($this->getTerminalStub());
+        $output = new BufferedOutput();
+        $subject->render(new \RuntimeException('Foo', 4223), $output);
+        $renderedOutput = $output->fetch();
+        $this->assertContains('[ RuntimeException ]', $renderedOutput);
+        $this->assertContains('Foo', $renderedOutput);
+        $this->assertNotContains('Exception code: 4223', $renderedOutput);
+        $this->assertNotContains('Exception trace:', $renderedOutput);
+    }
+
+    /**
+     * @test
+     */
+    public function exceptionCodeNotRenderedWhenEmpty()
+    {
+        $subject = new ExceptionRenderer($this->getTerminalStub());
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_VERBOSE);
+        $subject->render(new \RuntimeException('Foo'), $output);
+        $renderedOutput = $output->fetch();
+        $this->assertContains('[ RuntimeException ]', $renderedOutput);
+        $this->assertContains('Foo', $renderedOutput);
+        $this->assertNotContains('Exception code:', $renderedOutput);
+    }
+
+    /**
+     * @test
+     */
+    public function subProcessExceptionsRenderWithTheirRealClassName()
+    {
+        $subProcessException = SubProcessException::createFromArray(
+            [
+                'class' => \Exception::class,
+                'message' => 'Error',
+                'code' => 4223,
+                'trace' => [],
+                'line' => 42,
+                'file' => __FILE__,
+                'previous' => null,
+                'commandline' => 'typo3cms test',
+                'output' => 'output',
+                'error' => 'error output',
+            ]
+        );
+
+        $subject = new ExceptionRenderer($this->getTerminalStub());
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_VERBOSE);
+        $subject->render($subProcessException, $output);
+        $renderedOutput = $output->fetch();
+
+        $this->assertNotContains('SubProcessException', $renderedOutput);
+        $this->assertContains('Exception code: 4223', $renderedOutput);
+    }
+
+    /**
+     * @test
+     */
+    public function stringExceptionCodeForSubProcessExceptionsIsRenderedCorrectly()
+    {
+        $subProcessException = SubProcessException::createFromArray(
+            [
+                'class' => \Exception::class,
+                'message' => 'Error',
+                'code' => '42S23',
+                'trace' => [],
+                'line' => 42,
+                'file' => __FILE__,
+                'previous' => null,
+                'commandline' => 'typo3cms test',
+                'output' => 'output',
+                'error' => 'error output',
+            ]
+        );
+
+        $subject = new ExceptionRenderer($this->getTerminalStub());
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_VERBOSE);
+        $subject->render($subProcessException, $output);
+        $renderedOutput = $output->fetch();
+
+        $this->assertContains('Exception code: 42S23', $renderedOutput);
+    }
+
+    private function getTerminalStub(): Terminal
+    {
+        return new class() extends Terminal {
+            public function getWidth()
+            {
+                return 256;
+            }
+
+            public function getHeight()
+            {
+                return 256;
+            }
+
+            public static function hasSttyAvailable()
+            {
+                return false;
+            }
+        };
+    }
+}

--- a/Tests/Console/Unit/Mvc/Cli/SubProcessExceptionTest.php
+++ b/Tests/Console/Unit/Mvc/Cli/SubProcessExceptionTest.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Tests\Unit\Mvc\Cli;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Mvc\Cli\SubProcessException;
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+
+class SubProcessExceptionTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function exceptionClassIsPutInDefaultExceptionMessage()
+    {
+        $subject = SubProcessException::createFromArray(
+            [
+                'class' => \Exception::class,
+                'message' => 'Error',
+                'code' => 4223,
+                'trace' => [],
+                'line' => 42,
+                'file' => __FILE__,
+                'previous' => null,
+                'commandline' => 'typo3cms test',
+                'output' => 'output',
+                'error' => 'error output',
+            ]
+        );
+
+        $this->assertSame('[Exception] Error', $subject->getMessage());
+        $this->assertSame('Error', $subject->getPreviousExceptionMessage());
+        $this->assertSame(4223, $subject->getCode());
+        $this->assertSame(4223, $subject->getPreviousExceptionCode());
+    }
+
+    /**
+     * @test
+     */
+    public function stringExceptionCodeIsPutInDefaultExceptionMessage()
+    {
+        $subject = SubProcessException::createFromArray(
+            [
+                'class' => \Exception::class,
+                'message' => 'Error',
+                'code' => '42S23',
+                'trace' => [],
+                'line' => 42,
+                'file' => __FILE__,
+                'previous' => null,
+                'commandline' => 'typo3cms test',
+                'output' => 'output',
+                'error' => 'error output',
+            ]
+        );
+
+        $this->assertSame('[Exception] [42S23] Error', $subject->getMessage());
+        $this->assertSame('Error', $subject->getPreviousExceptionMessage());
+        $this->assertSame(0, $subject->getCode());
+        $this->assertSame('42S23', $subject->getPreviousExceptionCode());
+    }
+}


### PR DESCRIPTION
Exception codes can be string (e.g. for PDOException),
thus we must not assume codes are always integer.