### PR TITLE
[BUGFIX] Initialize LANG global during boot

### DIFF
--- a/Classes/Console/Core/Booting/Scripts.php
+++ b/Classes/Console/Core/Booting/Scripts.php
@@ -73,5 +73,6 @@ class Scripts
         Bootstrap::loadExtTables();
         Bootstrap::initializeBackendUser(CommandLineUserAuthentication::class);
         Bootstrap::initializeBackendAuthentication();
+        Bootstrap::initializeLanguageObject();
     }
 }


### PR DESCRIPTION
Since there might be some code accessing the global,
we need to still initialize it.

Fixes #907