### PR TITLE
[BUGFIX] Include TYPO3 Extensions as command providers

### DIFF
--- a/Classes/Console/Composer/InstallerScript/PopulateCommandConfiguration.php
+++ b/Classes/Console/Composer/InstallerScript/PopulateCommandConfiguration.php
@@ -43,10 +43,8 @@ class PopulateCommandConfiguration implements InstallerScript
             $installPath = ($installPath ?: $basePath);
             $packageName = $package->getName();
             $packageType = $package->getType();
-            if (in_array($packageType, ['metapackage', 'typo3-cms-extension', 'typo3-cms-framework'], true)) {
-                // Commands in TYPO3 extensions are scanned for anyway at a later point.
-                // With that we ensure not showing commands for extensions that aren't active.
-                // Since meta packages have no code, thus cannot include any commands, we ignore them as well.
+            if ($packageType === 'metapackage') {
+                // Meta packages can be skipped
                 continue;
             }
             $packageConfig = $this->getConfigFromPackage($installPath, $packageName);


### PR DESCRIPTION
Since we removed scanning for extensions on runtime,
we must include them during Composer build time.