### PR TITLE
[FEATURE] Handle positive list for upgrade wizard confirmations

### DIFF
--- a/Documentation/CommandReference/UpgradeRun.rst
+++ b/Documentation/CommandReference/UpgradeRun.rst
@@ -34,8 +34,8 @@ When no identifier is specified a select UI is presented to select a wizard out 
 Arguments
 ~~~~~~~~~
 
-`wizardIdentifier`
-   
+`wizardIdentifiers`
+   One or more wizard identifiers to run
 
 
 

--- a/Documentation/CommandReference/UpgradeRun.rst
+++ b/Documentation/CommandReference/UpgradeRun.rst
@@ -24,11 +24,15 @@ When no identifier is specified a select UI is presented to select a wizard out 
 
   `typo3cms upgrade:run all`
 
-  `typo3cms upgrade:run all --no-interaction --confirm all --deny typo3DbLegacyExtension --deny funcExtension`
-
-  `typo3cms upgrade:run all --no-interaction --deny all`
+  `typo3cms upgrade:run all --confirm all`
 
   `typo3cms upgrade:run argon2iPasswordHashes --confirm all`
+
+  `typo3cms upgrade:run all --confirm all --deny typo3DbLegacyExtension --deny funcExtension`
+
+  `typo3cms upgrade:run all --deny all`
+
+  `typo3cms upgrade:run all --no-interaction --deny all --confirm argon2iPasswordHashes`
 
 
 Arguments
@@ -51,7 +55,7 @@ Options
 - Default: array ()
 
 `--deny|-d`
-   Identifier of the wizard, that should be denied. Keyword "all" denies all wizards.
+   Identifier of the wizard, that should be denied. Keyword "all" denies all wizards. Deny takes precedence except when "all" is specified.
 
 - Accept value: yes
 - Is value required: yes

--- a/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
@@ -214,6 +214,46 @@ class UpgradeCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
+    public function upgradeRunCanConfirmAllAndDenySomeConfirmableWizards(): void
+    {
+        $this->installFixtureExtensionCode('ext_upgrade');
+        $this->executeConsoleCommand('install:generatepackagestates');
+        $this->executeConsoleCommand('extension:setup', ['ext_upgrade']);
+        try {
+            $this->executeMysqlQuery('DELETE FROM sys_registry WHERE entry_namespace = \'installUpdate\' AND (entry_key LIKE \'%ext_upgrade%\' OR entry_key LIKE \'%RsaauthExtractionUpdate%\')');
+            $output = $this->executeConsoleCommand('upgrade:run', ['all', '--confirm', 'all', '--deny', 'rsaauthExtension']);
+            $this->assertContains('Skipped wizard "rsaauthExtension"', $output);
+            $this->assertContains('Successfully executed upgrade wizard "confirmableWizard"', $output);
+            $this->assertContains('Successfully executed upgrade wizard "normalWizard"', $output);
+        } finally {
+            $this->removeFixtureExtensionCode('ext_upgrade');
+            $this->executeConsoleCommand('install:generatepackagestates');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function upgradeRunCanDenyAllAndConfirmSomeConfirmableWizards(): void
+    {
+        $this->installFixtureExtensionCode('ext_upgrade');
+        $this->executeConsoleCommand('install:generatepackagestates');
+        $this->executeConsoleCommand('extension:setup', ['ext_upgrade']);
+        try {
+            $this->executeMysqlQuery('DELETE FROM sys_registry WHERE entry_namespace = \'installUpdate\' AND (entry_key LIKE \'%ext_upgrade%\' OR entry_key LIKE \'%RsaauthExtractionUpdate%\')');
+            $output = $this->executeConsoleCommand('upgrade:run', ['all', '--deny', 'all', '--confirm', 'confirmableWizard']);
+            $this->assertContains('Skipped wizard "rsaauthExtension"', $output);
+            $this->assertContains('Successfully executed upgrade wizard "confirmableWizard"', $output);
+            $this->assertContains('Successfully executed upgrade wizard "normalWizard"', $output);
+        } finally {
+            $this->removeFixtureExtensionCode('ext_upgrade');
+            $this->executeConsoleCommand('install:generatepackagestates');
+        }
+    }
+
+    /**
+     * @test
+     */
     public function rowUpdaterCanBeForced(): void
     {
         $output = $this->executeConsoleCommand('upgrade:list');

--- a/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
@@ -191,6 +191,29 @@ class UpgradeCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
+    public function upgradeRunCanRunMultipleSpecifiedWizards(): void
+    {
+        $this->installFixtureExtensionCode('ext_upgrade');
+        $this->executeConsoleCommand('install:generatepackagestates');
+        $this->executeConsoleCommand('extension:setup', ['ext_upgrade']);
+        try {
+            $this->executeMysqlQuery('DELETE FROM sys_registry WHERE entry_namespace = \'installUpdate\' AND entry_key LIKE \'%ext_upgrade%\'');
+            $output = $this->executeConsoleCommand('upgrade:run', ['normalWizard', 'confirmableWizard', '--confirm', 'all']);
+            $this->assertContains('Successfully executed upgrade wizard "confirmableWizard"', $output);
+            $this->assertContains('Successfully executed upgrade wizard "normalWizard"', $output);
+            $output = $this->executeConsoleCommand('upgrade:list', [], ['TYPO3_CONSOLE_DISABLE_REPEATABLE_WIZARD' => 1]);
+            $this->assertContains('None', $output);
+            $output = $this->executeConsoleCommand('upgrade:run', ['all'], ['TYPO3_CONSOLE_DISABLE_REPEATABLE_WIZARD' => 1]);
+            $this->assertContains('All wizards done. Nothing to do.', $output);
+        } finally {
+            $this->removeFixtureExtensionCode('ext_upgrade');
+            $this->executeConsoleCommand('install:generatepackagestates');
+        }
+    }
+
+    /**
+     * @test
+     */
     public function rowUpdaterCanBeForced(): void
     {
         $output = $this->executeConsoleCommand('upgrade:list');


### PR DESCRIPTION
Allow to use "--deny all" with a positive list of confirmations,
as well as "--confirm all" with a negative list of denials,
because depending on which amount of which kind of confirmable
wizards are available the one or the other might be
more convenient.

Resolves #913