### PR TITLE
Remove dependency to Composer plugin helper

### DIFF
--- a/Classes/Console/Command/Database/DatabaseExportCommand.php
+++ b/Classes/Console/Command/Database/DatabaseExportCommand.php
@@ -157,15 +157,13 @@ EOH
             new InputArgument(
                 'excludeTables',
                 null,
-                'Comma-separated list of table names to exclude from the export. Wildcards are supported.',
-                []
+                'Comma-separated list of table names to exclude from the export. Wildcards are supported.'
             ),
             new InputOption(
                 'exclude-tables',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Comma-separated list of table names to exclude from the export. Wildcards are supported.',
-                []
+                'Comma-separated list of table names to exclude from the export. Wildcards are supported.'
             ),
         ];
     }

--- a/Classes/Console/Command/Install/InstallGeneratePackageStatesCommand.php
+++ b/Classes/Console/Command/Install/InstallGeneratePackageStatesCommand.php
@@ -69,15 +69,13 @@ EOH
                 'framework-extensions',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'TYPO3 system extensions that should be marked as active. Extension keys separated by comma.',
-                []
+                'TYPO3 system extensions that should be marked as active. Extension keys separated by comma.'
             ),
             new InputOption(
                 'excluded-extensions',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Extensions which should stay inactive. This does not affect provided framework extensions or framework extensions that are required or part as minimal usable system.',
-                []
+                'Extensions which should stay inactive. This does not affect provided framework extensions or framework extensions that are required or part as minimal usable system.'
             ),
             new InputOption(
                 'activate-default',
@@ -98,20 +96,21 @@ EOH
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $frameworkExtensions = $input->getOption('framework-extensions');
-        $frameworkExtensions = is_array($frameworkExtensions)
-            ? $frameworkExtensions : explode(',', $frameworkExtensions);
-        $excludedExtensions = $input->getOption('excluded-extensions');
-        $excludedExtensions = is_array($excludedExtensions)
-            ? $excludedExtensions : explode(',', $excludedExtensions);
+        $frameworkExtensions = $excludedExtensions = null;
         $activateDefault = $input->getOption('activate-default');
+        if ($input->getOption('framework-extensions')) {
+            $frameworkExtensions = explode(',', $input->getOption('framework-extensions'));
+        }
+        if ($input->getOption('excluded-extensions')) {
+            $excludedExtensions = explode(',', $input->getOption('excluded-extensions'));
+        }
 
         if ($activateDefault && Environment::isComposerMode()) {
             // @deprecated for composer usage in 5.0 will be removed with 6.0
             $output->writeln('<warning>Using --activate-default is deprecated in composer managed TYPO3 installations.</warning>');
             $output->writeln('<warning>Instead of requiring typo3/cms in your project, you should consider only requiring individual packages you need.</warning>');
         }
-        $frameworkExtensions = $frameworkExtensions ?: explode(
+        $frameworkExtensions = $frameworkExtensions ?? explode(
             ',',
             (string)getenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS')
         );
@@ -120,7 +119,7 @@ EOH
         $packageStatesGenerator = new PackageStatesGenerator($packageManager);
         $activatedExtensions = $packageStatesGenerator->generate(
             $frameworkExtensions,
-            $excludedExtensions,
+            $excludedExtensions ?? [],
             $activateDefault
         );
 

--- a/Classes/Console/Command/Install/InstallGeneratePackageStatesCommand.php
+++ b/Classes/Console/Command/Install/InstallGeneratePackageStatesCommand.php
@@ -100,6 +100,11 @@ EOH
         $activateDefault = $input->getOption('activate-default');
         if ($input->getOption('framework-extensions')) {
             $frameworkExtensions = explode(',', $input->getOption('framework-extensions'));
+        } elseif (getenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS')) {
+            $frameworkExtensions = explode(
+                ',',
+                getenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS')
+            );
         }
         if ($input->getOption('excluded-extensions')) {
             $excludedExtensions = explode(',', $input->getOption('excluded-extensions'));
@@ -110,15 +115,11 @@ EOH
             $output->writeln('<warning>Using --activate-default is deprecated in composer managed TYPO3 installations.</warning>');
             $output->writeln('<warning>Instead of requiring typo3/cms in your project, you should consider only requiring individual packages you need.</warning>');
         }
-        $frameworkExtensions = $frameworkExtensions ?? explode(
-            ',',
-            (string)getenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS')
-        );
         $dependencyOrderingService = GeneralUtility::makeInstance(DependencyOrderingService::class);
         $packageManager = GeneralUtility::makeInstance(UncachedPackageManager::class, $dependencyOrderingService);
-        $packageStatesGenerator = new PackageStatesGenerator($packageManager);
+        $packageStatesGenerator = new PackageStatesGenerator($packageManager, Environment::isComposerMode());
         $activatedExtensions = $packageStatesGenerator->generate(
-            $frameworkExtensions,
+            $frameworkExtensions ?? [],
             $excludedExtensions ?? [],
             $activateDefault
         );

--- a/Classes/Console/Composer/InstallerScript/PopulateCommandConfiguration.php
+++ b/Classes/Console/Composer/InstallerScript/PopulateCommandConfiguration.php
@@ -18,7 +18,7 @@ use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Script\Event as ScriptEvent;
-use Composer\Util\PackageSorter;
+use Helhum\Typo3Console\Composer\Util\PackageSorter;
 use Symfony\Component\Console\Exception\RuntimeException;
 use TYPO3\CMS\Composer\Plugin\Core\InstallerScript;
 
@@ -111,6 +111,10 @@ class PopulateCommandConfiguration implements InstallerScript
         }
 
         $sortedPackages = PackageSorter::sortPackages($packages);
+
+        if (PackageSorter::isDeprecated()) {
+            $this->io->writeError('<error>Your Composer version is outdated. Please update by running "composer self-update".</error>');
+        }
 
         $sortedPackageMap = [];
         $sortedPackageMap[] = [$packages['helhum/typo3-console'], $paths['helhum/typo3-console']];

--- a/Classes/Console/Composer/InstallerScripts.php
+++ b/Classes/Console/Composer/InstallerScripts.php
@@ -15,10 +15,7 @@ namespace Helhum\Typo3Console\Composer;
  */
 
 use Composer\Script\Event;
-use Composer\Semver\Constraint\EmptyConstraint;
 use Helhum\Typo3Console\Composer\InstallerScript\PopulateCommandConfiguration;
-use TYPO3\CMS\Composer\Plugin\Core\InstallerScripts\AutoloadConnector;
-use TYPO3\CMS\Composer\Plugin\Core\InstallerScripts\WebDirectory;
 use TYPO3\CMS\Composer\Plugin\Core\InstallerScriptsRegistration;
 use TYPO3\CMS\Composer\Plugin\Core\ScriptDispatcher;
 
@@ -38,13 +35,5 @@ class InstallerScripts implements InstallerScriptsRegistration
     public static function register(Event $event, ScriptDispatcher $scriptDispatcher)
     {
         $scriptDispatcher->addInstallerScript(new PopulateCommandConfiguration(), 70);
-        if (!class_exists(\TYPO3\CMS\Core\Composer\InstallerScripts::class)
-            && !class_exists(\Helhum\Typo3ComposerSetup\Composer\InstallerScripts::class)
-            && $event->getComposer()->getRepositoryManager()->getLocalRepository()->findPackage('typo3/cms', new EmptyConstraint()) !== null
-        ) {
-            // @deprecated can be removed once TYPO3 8 support is removed
-            $scriptDispatcher->addInstallerScript(new WebDirectory());
-            $scriptDispatcher->addInstallerScript(new AutoloadConnector());
-        }
     }
 }

--- a/Classes/Console/Composer/Util/PackageSorter.php
+++ b/Classes/Console/Composer/Util/PackageSorter.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Composer\Util;
+
+/**
+ * @deprecated Can be removed when Composer 2.0 is made mandatory
+ */
+class PackageSorter
+{
+    protected static $isDeprecated = false;
+
+    public static function sortPackages(array $packages): array
+    {
+        if (!class_exists(\Composer\Util\PackageSorter::class)) {
+            self::$isDeprecated = true;
+
+            return $packages;
+        }
+
+        return \Composer\Util\PackageSorter::sortPackages($packages);
+    }
+
+    public static function isDeprecated(): bool
+    {
+        return self::$isDeprecated;
+    }
+}

--- a/Classes/Console/Install/PackageStatesGenerator.php
+++ b/Classes/Console/Install/PackageStatesGenerator.php
@@ -31,13 +31,20 @@ class PackageStatesGenerator
     private $packageManager;
 
     /**
+     * @var bool
+     */
+    private $isComposerMode;
+
+    /**
      * PackageStatesGenerator constructor.
      *
      * @param UncachedPackageManager $packageManager
+     * @param bool|null $isComposerMode
      */
-    public function __construct(UncachedPackageManager $packageManager)
+    public function __construct(UncachedPackageManager $packageManager, bool $isComposerMode = null)
     {
         $this->packageManager = $packageManager;
+        $this->isComposerMode = $isComposerMode ?? Environment::isComposerMode();
     }
 
     /**
@@ -50,10 +57,11 @@ class PackageStatesGenerator
     {
         $this->ensureDirectoryExists(Environment::getPublicPath() . '/typo3conf');
         $this->packageManager->scanAvailablePackages();
+        $allFrameWorkExtensions = $this->isComposerMode && $frameworkExtensionsToActivate === [];
         foreach ($this->packageManager->getAvailablePackages() as $package) {
             $extKey = $package->getPackageKey();
             $isLocalExt = strpos(PathUtility::stripPathSitePrefix($package->getPackagePath()), 'typo3conf/ext/') !== false;
-            $isFrameWorkExtToActivate = in_array($extKey, $frameworkExtensionsToActivate, true);
+            $isFrameWorkExtToActivate = (!$isLocalExt && $allFrameWorkExtensions) || in_array($extKey, $frameworkExtensionsToActivate, true);
             $isExcludedExt = in_array($extKey, $excludedExtensions, true);
             $isFactoryDefault = $activateDefaultExtensions && $package->isPartOfFactoryDefault();
             $isRequiredFrameworkExt = $isFrameWorkExtToActivate || $package->isProtected() || $package->isPartOfMinimalUsableSystem();

--- a/Classes/Console/Service/CacheLowLevelCleaner.php
+++ b/Classes/Console/Service/CacheLowLevelCleaner.php
@@ -29,7 +29,8 @@ class CacheLowLevelCleaner
     {
         $cacheDirPattern = Environment::getVarPath() . '/cache/*/*';
         foreach (glob($cacheDirPattern) as $path) {
-            GeneralUtility::flushDirectory($path, true);
+            GeneralUtility::rmdir($path, true);
+            GeneralUtility::mkdir($path);
         }
     }
 }

--- a/Documentation/CommandReference/InstallGeneratepackagestates.rst
+++ b/Documentation/CommandReference/InstallGeneratepackagestates.rst
@@ -46,7 +46,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: array ()
+
 
 `--excluded-extensions`
    Extensions which should stay inactive. This does not affect provided framework extensions or framework extensions that are required or part as minimal usable system.
@@ -54,7 +54,7 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
-- Default: array ()
+
 
 `--activate-default`
    (DEPRECATED) If true, `typo3/cms` extensions that are marked as TYPO3 factory default, will be activated, even if not in the list of configured active framework extensions.

--- a/Packages/CreateReferenceCommand/src/Command/CommandReferenceRenderCommand.php
+++ b/Packages/CreateReferenceCommand/src/Command/CommandReferenceRenderCommand.php
@@ -88,7 +88,8 @@ class CommandReferenceRenderCommand extends \Symfony\Component\Console\Command\C
         putenv('TYPO3_CONSOLE_RENDERING_REFERENCE=1');
         $_SERVER['PHP_SELF'] = Application::COMMAND_NAME;
         $commandReferenceDir = getenv('TYPO3_PATH_COMPOSER_ROOT') . '/Documentation/CommandReference/';
-        GeneralUtility::flushDirectory($commandReferenceDir, true);
+        GeneralUtility::rmdir($commandReferenceDir, true);
+        GeneralUtility::mkdir($commandReferenceDir);
         $commandCollection = new CommandCollection(new CommandConfiguration(), new EmptyTypo3CommandRegistry());
         $application = new class($this->getApplication()) extends \Symfony\Component\Console\Application {
             /**

--- a/Tests/Console/Unit/Install/PackageStatesGeneratorTest.php
+++ b/Tests/Console/Unit/Install/PackageStatesGeneratorTest.php
@@ -76,7 +76,7 @@ class PackageStatesGeneratorTest extends UnitTestCase
     /**
      * @test
      */
-    public function frameworkExtensionsAreNotMarkedAsActiveByDefault()
+    public function frameworkExtensionsAreNotMarkedAsActiveByDefaultInNonComposerMode()
     {
         $packageProphecy = $this->prophesize(PackageInterface::class);
         $packageProphecy->getPackageKey()->willReturn('foo');
@@ -95,14 +95,41 @@ class PackageStatesGeneratorTest extends UnitTestCase
         $packageManagerProphecy->deactivatePackage('foo')->shouldBeCalled();
         $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
         $packageManagerProphecy->getActivePackages()->shouldBeCalled();
-        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal(), false);
         $packageStatesGenerator->generate();
     }
 
     /**
      * @test
      */
-    public function defaultFrameworkExtensionsAreNotMarkedAsActiveByDefault()
+    public function frameworkExtensionsAreMarkedAsActiveByDefaultInComposerMode()
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('foo');
+        $packageProphecy->isProtected()->willReturn(false);
+        $packageProphecy->isPartOfMinimalUsableSystem()->willReturn(false);
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3/sysext/foo');
+
+        $packages = [
+            $packageProphecy->reveal(),
+        ];
+
+        $packageManagerProphecy = $this->prophesize(UncachedPackageManager::class);
+        $packageManagerProphecy->scanAvailablePackages()->shouldBeCalled();
+        $packageManagerProphecy->forceSortAndSavePackageStates()->shouldBeCalled();
+
+        $packageManagerProphecy->deactivatePackage('foo')->shouldNotBeCalled();
+        $packageManagerProphecy->activatePackage('foo')->shouldBeCalled();
+        $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
+        $packageManagerProphecy->getActivePackages()->shouldBeCalled();
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal(), true);
+        $packageStatesGenerator->generate();
+    }
+
+    /**
+     * @test
+     */
+    public function defaultFrameworkExtensionsAreNotMarkedAsActiveByDefaultInNonComposerMode()
     {
         $packageProphecy = $this->prophesize(PackageInterface::class);
         $packageProphecy->getPackageKey()->willReturn('foo');
@@ -122,14 +149,14 @@ class PackageStatesGeneratorTest extends UnitTestCase
         $packageManagerProphecy->deactivatePackage('foo')->shouldBeCalled();
         $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
         $packageManagerProphecy->getActivePackages()->shouldBeCalled();
-        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal(), false);
         $packageStatesGenerator->generate();
     }
 
     /**
      * @test
      */
-    public function defaultFrameworkExtensionsAreMarkedAsActiveWhenSwitchProvided()
+    public function defaultFrameworkExtensionsAreMarkedAsActiveWhenSwitchProvidedInNonComposerMode()
     {
         $packageProphecy = $this->prophesize(PackageInterface::class);
         $packageProphecy->getPackageKey()->willReturn('foo');
@@ -149,14 +176,14 @@ class PackageStatesGeneratorTest extends UnitTestCase
         $packageManagerProphecy->activatePackage('foo')->shouldBeCalled();
         $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
         $packageManagerProphecy->getActivePackages()->shouldBeCalled();
-        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal(), false);
         $packageStatesGenerator->generate([], [], true);
     }
 
     /**
      * @test
      */
-    public function defaultFrameworkExtensionsAreNotMarkedAsActiveWhenSwitchProvidedButExcluded()
+    public function defaultFrameworkExtensionsAreNotMarkedAsActiveWhenSwitchProvidedButExcludedInNonComposerMode()
     {
         $packageProphecy = $this->prophesize(PackageInterface::class);
         $packageProphecy->getPackageKey()->willReturn('foo');
@@ -176,7 +203,7 @@ class PackageStatesGeneratorTest extends UnitTestCase
         $packageManagerProphecy->deactivatePackage('foo')->shouldBeCalled();
         $packageManagerProphecy->getAvailablePackages()->willReturn($packages);
         $packageManagerProphecy->getActivePackages()->shouldBeCalled();
-        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal());
+        $packageStatesGenerator = new PackageStatesGenerator($packageManagerProphecy->reveal(), false);
         $packageStatesGenerator->generate([], ['foo'], true);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": "^7.2",
-        "helhum/typo3-console-plugin": "^2.0.2",
 
         "typo3/cms-backend": "^10.4.1",
         "typo3/cms-core": "^10.4.1",


### PR DESCRIPTION
Since TYPO3 9.5 there is no possibility to use the
typo3/cms mono repo for Composer installations.

Therefore we must not compile the list of to be activated
framework extensions based on the required packages any more,
because only required framework extensions will be installed
anyway. Therefore we can just activate all framework extensions
that are found in Composer mode.

Since compiling this list was the remaining purpose of the plugin,
we can remove the dependency now.