### PR TITLE
[TASK] Add option to fail on error to extensionsetupifpossible

### DIFF
--- a/Classes/Console/Command/Install/InstallExtensionSetupIfPossibleCommand.php
+++ b/Classes/Console/Command/Install/InstallExtensionSetupIfPossibleCommand.php
@@ -19,6 +19,7 @@ use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
 use Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class InstallExtensionSetupIfPossibleCommand extends Command implements RelatableCommandInterface
@@ -32,6 +33,12 @@ class InstallExtensionSetupIfPossibleCommand extends Command implements Relatabl
 
     protected function configure()
     {
+        $this->addOption(
+            'fail-on-error',
+            null,
+            InputOption::VALUE_NONE,
+            'Instead of gracefully exiting this command if something goes wrong, throw an error'
+        );
         $this->setDescription('Setup TYPO3 with extensions if possible');
         $this->setHelp(
             <<<'EOH'
@@ -54,6 +61,9 @@ EOH
             $output->writeln($commandDispatcher->executeCommand('cache:flush'));
             $output->writeln($commandDispatcher->executeCommand('extension:setupactive'));
         } catch (FailedSubProcessCommandException $e) {
+            if ($input->getOption('fail-on-error')) {
+                throw $e;
+            }
             $output->writeln('<warning>Extension setup skipped.</warning>');
         }
 

--- a/Classes/Console/Core/Booting/RunLevel.php
+++ b/Classes/Console/Core/Booting/RunLevel.php
@@ -243,7 +243,7 @@ class RunLevel
      * @param string $identifier
      * @return Sequence
      */
-    private function buildExtendedRuntimeSequence(string $identifier = self::LEVEL_UNCACHED): Sequence
+    private function buildExtendedRuntimeSequence(string $identifier = self::LEVEL_FULL): Sequence
     {
         $sequence = $this->buildBasicRuntimeSequence($identifier);
 

--- a/Documentation/CommandReference/InstallExtensionsetupifpossible.rst
+++ b/Documentation/CommandReference/InstallExtensionsetupifpossible.rst
@@ -25,6 +25,18 @@ but also works for subsequent deployments.
 
 
 
+Options
+~~~~~~~
+
+`--fail-on-error`
+   Instead of gracefully exiting this command if something goes wrong, throw an error
+
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false
+
+
 
 
 Related commands


### PR DESCRIPTION
This command is a wrapper to execute:

database:updateschema
cache:flush
extension:setupactive

Initially this was meant to be used in Composer scripts to
not interfere Composer install on build systems, but at the same
time perform necessary steps in dev systems.

It was, until now, not suitable for deployment scenarios though,
because during a deployment it is important that the command fails
when something goes wrong to avoid a broken state after a deployment.

The added option makes it now suitable for deployments, too.

Fixes: #925