### PR TITLE
[BUGFIX] Recreation after cache:flush command

### DIFF
--- a/Classes/Console/Service/CacheLowLevelCleaner.php
+++ b/Classes/Console/Service/CacheLowLevelCleaner.php
@@ -29,6 +29,9 @@ class CacheLowLevelCleaner
     {
         $cacheDirPattern = Environment::getVarPath() . '/cache/*/*';
         foreach (glob($cacheDirPattern) as $path) {
+            if (!is_dir($path)) {
+                continue;
+            }
             GeneralUtility::rmdir($path, true);
             GeneralUtility::mkdir($path);
         }


### PR DESCRIPTION
- Recreate only if it was a directory. Otherwise files in the cache directory will be rewritten to directories