### PR TITLE
[BUGFIX] Use TYPO3 public extension setup API

### DIFF
--- a/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
+++ b/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
@@ -25,8 +25,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Type\Exception\InvalidEnumerationValueException;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 
 class DatabaseUpdateSchemaCommand extends Command
 {
@@ -84,10 +82,7 @@ EOH
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $schemaService = new SchemaService(
-            new SchemaUpdate(),
-            GeneralUtility::makeInstance(Dispatcher::class)
-        );
+        $schemaService = new SchemaService(new SchemaUpdate());
         $schemaUpdateResultRenderer = new SchemaUpdateResultRenderer();
 
         $schemaUpdateTypes = explode(',', $input->getArgument('schemaUpdateTypes'));

--- a/Classes/Console/Command/Extension/ExtensionStateCommandsHelper.php
+++ b/Classes/Console/Command/Extension/ExtensionStateCommandsHelper.php
@@ -15,13 +15,14 @@ namespace Helhum\Typo3Console\Command\Extension;
  */
 
 use Helhum\Typo3Console\Extension\ExtensionSetup;
+use Helhum\Typo3Console\Extension\ExtensionSetupEventDispatcher;
 use Helhum\Typo3Console\Extension\ExtensionSetupResultRenderer;
 use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Package\PackageInterface;
 use TYPO3\CMS\Core\Package\PackageManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 
 /**
  * Convenience object to handle extension state switches from commands
@@ -54,11 +55,12 @@ class ExtensionStateCommandsHelper
         PackageManager $packageManager = null,
         ExtensionSetupResultRenderer $extensionSetupResultRenderer = null
     ) {
+        $eventDispatcher = new ExtensionSetupEventDispatcher(GeneralUtility::makeInstance(EventDispatcherInterface::class));
         // @deprecated. should be changed to OutputStyle instead
         $this->output = new ConsoleOutput($output);
-        $this->extensionSetup = $extensionSetup ?? new ExtensionSetup();
+        $this->extensionSetup = $extensionSetup ?? new ExtensionSetup(null, $eventDispatcher);
         $this->packageManager = $packageManager ?? GeneralUtility::makeInstance(PackageManager::class);
-        $this->extensionSetupResultRenderer = $extensionSetupResultRenderer ?? new ExtensionSetupResultRenderer(GeneralUtility::makeInstance(Dispatcher::class));
+        $this->extensionSetupResultRenderer = $extensionSetupResultRenderer ?? new ExtensionSetupResultRenderer($eventDispatcher);
     }
 
     /**

--- a/Classes/Console/Extension/DatabaseSchemaUpdateEvent.php
+++ b/Classes/Console/Extension/DatabaseSchemaUpdateEvent.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Extension;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Database\Schema\SchemaUpdateResult;
+
+class DatabaseSchemaUpdateEvent
+{
+    /**
+     * @var SchemaUpdateResult
+     */
+    public $result;
+}

--- a/Classes/Console/Extension/ExtensionSetupEventDispatcher.php
+++ b/Classes/Console/Extension/ExtensionSetupEventDispatcher.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Extension;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Proxy class to handle events
+ */
+class ExtensionSetupEventDispatcher implements EventDispatcherInterface
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $parentEventDispatcher;
+
+    private $additionalListeners = [];
+
+    public function __construct(EventDispatcherInterface $parentEventDispatcher)
+    {
+        $this->parentEventDispatcher = $parentEventDispatcher;
+    }
+
+    public function updateParentEventDispatcher(EventDispatcherInterface $parentEventDispatcher): void
+    {
+        $this->parentEventDispatcher = $parentEventDispatcher;
+    }
+
+    public function dispatch(object $event)
+    {
+        $eventClass = get_class($event);
+        if (isset($this->additionalListeners[$eventClass])) {
+            foreach ($this->additionalListeners[$eventClass] as $callable) {
+                $callable($event);
+            }
+        }
+
+        return $this->parentEventDispatcher->dispatch($event);
+    }
+
+    public function addListener(string $eventClass, callable $callable): void
+    {
+        $this->additionalListeners[$eventClass][] = $callable;
+    }
+}


### PR DESCRIPTION
Instead of calling protected methods, now public
API is called instead.

Also usage signal slot dispatcher is replaced
with even dispatcher API to properly collect
results from the process.