### PR TITLE
[BUGFIX] Hide container errors for low level commands

### DIFF
--- a/Classes/Console/Core/Booting/ContainerBuildFailedException.php
+++ b/Classes/Console/Core/Booting/ContainerBuildFailedException.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console\Core\Booting;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+/**
+ * When container building failed
+ */
+class ContainerBuildFailedException extends StepFailedException
+{
+    public function __construct(\Throwable $previous)
+    {
+        parent::__construct(
+            new Step(
+                'build-container',
+                function () {
+                }
+            ),
+            $previous
+        );
+    }
+}

--- a/Classes/Console/Core/Booting/RunLevel.php
+++ b/Classes/Console/Core/Booting/RunLevel.php
@@ -110,10 +110,18 @@ class RunLevel
     }
 
     /**
+     * @param string|null $commandIdentifier
      * @return StepFailedException|null
      */
-    public function getError(): ?StepFailedException
+    public function getError(string $commandIdentifier = null): ?StepFailedException
     {
+        if ($commandIdentifier !== null
+            && $this->error instanceof ContainerBuildFailedException
+            && $this->isLowLevelCommand($commandIdentifier)
+        ) {
+            return null;
+        }
+
         return $this->error;
     }
 
@@ -166,7 +174,19 @@ class RunLevel
     public function isCommandAvailable($commandIdentifier): bool
     {
         return $this->getMaximumAvailableRunLevel() === self::LEVEL_FULL
-            || $this->getRunLevelForCommand($commandIdentifier) === self::LEVEL_COMPILE;
+            || $this->isLowLevelCommand($commandIdentifier);
+    }
+
+    /**
+     * @param string $commandIdentifier
+     * @return bool
+     */
+    public function isLowLevelCommand($commandIdentifier): bool
+    {
+        $options = $this->getOptionsForCommand($commandIdentifier);
+        $runLevel = $options['runLevel'] ?? self::LEVEL_FULL;
+
+        return $runLevel === self::LEVEL_COMPILE;
     }
 
     /**

--- a/Classes/Console/Core/Kernel.php
+++ b/Classes/Console/Core/Kernel.php
@@ -15,10 +15,9 @@ namespace Helhum\Typo3Console\Core;
  */
 
 use Helhum\Typo3Console\CompatibilityClassLoader;
+use Helhum\Typo3Console\Core\Booting\ContainerBuildFailedException;
 use Helhum\Typo3Console\Core\Booting\RunLevel;
 use Helhum\Typo3Console\Core\Booting\Scripts;
-use Helhum\Typo3Console\Core\Booting\Step;
-use Helhum\Typo3Console\Core\Booting\StepFailedException;
 use Helhum\Typo3Console\Exception;
 use Helhum\Typo3Console\Mvc\Cli\CommandCollection;
 use Helhum\Typo3Console\Mvc\Cli\CommandConfiguration;
@@ -138,14 +137,7 @@ class Kernel
             ExtensionManagementUtility::setEventDispatcher($this->container->get(EventDispatcherInterface::class));
         } catch (\Throwable $e) {
             $this->container = $failsafeContainer;
-            $error = new StepFailedException(
-                new Step(
-                    'build-container',
-                    function () {
-                    }
-                ),
-                $e
-            );
+            $error = new ContainerBuildFailedException($e);
         }
         $this->runLevel = new RunLevel($this->container, $error);
     }


### PR DESCRIPTION
Low level commands don't need the full Symfony DI container,
thus we can gracefully execute them without showing errors
or even throw exceptions related to building this container.

Fixes #930