### PR TITLE
[BUGFIX] Stay consistent with new Symfony Console versions

### DIFF
--- a/Classes/Console/Mvc/Cli/Symfony/Command/HelpCommand.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Command/HelpCommand.php
@@ -53,6 +53,19 @@ class HelpCommand extends \Symfony\Component\Console\Command\HelpCommand
     {
         parent::configure();
         $this->setAliases([]);
+        $this->setHelp(
+            <<<'EOF'
+The <info>%command.name%</info> command displays help for a given command:
+
+  <info>%command.full_name% list</info>
+
+You can also output the help in other formats by using the <comment>--format</comment> option:
+
+  <info>%command.full_name% --format=xml list</info>
+
+To display the list of available commands, please use the <info>list</info> command.
+EOF
+        );
     }
 
     /**

--- a/Classes/Console/Mvc/Cli/Symfony/Command/ListCommand.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Command/ListCommand.php
@@ -30,6 +30,25 @@ class ListCommand extends \Symfony\Component\Console\Command\ListCommand
     {
         parent::configure();
         $this->amendDefinition($this->getDefinition());
+        $this->setHelp(
+            <<<'EOF'
+The <info>%command.name%</info> command lists all commands:
+
+  <info>%command.full_name%</info>
+
+You can also display the commands for a specific namespace:
+
+  <info>%command.full_name% test</info>
+
+You can also output the information in other formats by using the <comment>--format</comment> option:
+
+  <info>%command.full_name% --format=xml</info>
+
+It's also possible to get raw list of commands (useful for embedding command runner):
+
+  <info>%command.full_name% --raw</info>
+EOF
+        );
     }
 
     public function getNativeDefinition()

--- a/Documentation/CommandReference/Help.rst
+++ b/Documentation/CommandReference/Help.rst
@@ -17,11 +17,11 @@ help
 
 The `help` command displays help for a given command:
 
-  `php typo3cms help list`
+  `typo3cms help list`
 
 You can also output the help in other formats by using the **--format** option:
 
-  `php typo3cms help --format=xml list`
+  `typo3cms help --format=xml list`
 
 To display the list of available commands, please use the `list` command.
 

--- a/Documentation/CommandReference/List.rst
+++ b/Documentation/CommandReference/List.rst
@@ -17,19 +17,19 @@ list
 
 The `list` command lists all commands:
 
-  `php typo3cms list`
+  `typo3cms list`
 
 You can also display the commands for a specific namespace:
 
-  `php typo3cms list test`
+  `typo3cms list test`
 
 You can also output the information in other formats by using the **--format** option:
 
-  `php typo3cms list --format=xml`
+  `typo3cms list --format=xml`
 
 It's also possible to get raw list of commands (useful for embedding command runner):
 
-  `php typo3cms list --raw`
+  `typo3cms list --raw`
 
 Arguments
 ~~~~~~~~~


### PR DESCRIPTION
New SF Console versions changed the help text of list and help
commands. Since this text is rendered in the command reference,
and compatiblity with older console versions must be kept,
the help text od these commands is now copied to the
sublcasses used here.