### PR TITLE
[BUGFIX] Output wizard title before asking for confirmation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,18 +73,17 @@ jobs:
       php: 7.2
       env: TYPO3_VERSION="^10.4.1" PREFER_LOWEST="--prefer-lowest"
     - stage: test
-      php: 7.2
+      php: 7.4
       env: TYPO3_VERSION="dev-master"
     - stage: test
       php: 7.4
       env: TYPO3_VERSION="^10.4.1"
       script:
-        - composer self-update --snapshot --2
         - git clean -dffx
         - composer update
         - .Build/bin/phpunit
     - stage: test
-      php: 7.2
+      php: 7.4
       env: Consistency checks
       before_install: skip
       install: skip
@@ -100,7 +99,7 @@ jobs:
 
     - stage: sonar code scanner
       if: type = push AND branch IN (latest, develop)
-      php: 7.2
+      php: 7.4
       before_install: skip
       install: skip
       script:
@@ -115,7 +114,7 @@ jobs:
 
     - stage: update extension repo
       if: type = push
-      php: 7.2
+      php: 7.4
       before_install: skip
       install: skip
       before_script:
@@ -142,7 +141,7 @@ jobs:
 
     - stage: ship to TER
       if: tag IS present
-      php: 7.2
+      php: 7.4
       install: skip
       before_script: skip
       script:

--- a/Classes/Console/Install/Upgrade/UpgradeHandling.php
+++ b/Classes/Console/Install/Upgrade/UpgradeHandling.php
@@ -18,7 +18,7 @@ use Helhum\Typo3Console\Extension\ExtensionCompatibilityCheck;
 use Helhum\Typo3Console\Extension\ExtensionConstraintCheck;
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
 use Helhum\Typo3Console\Service\Configuration\ConfigurationService;
-use Symfony\Component\Console\Style\StyleInterface;
+use Symfony\Component\Console\Style\OutputStyle;
 use TYPO3\CMS\Core\Package\PackageManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Install\Updates\ConfirmableInterface;
@@ -99,7 +99,7 @@ class UpgradeHandling
         $this->extensionCompatibilityCheck = $extensionCompatibilityCheck ?: new ExtensionCompatibilityCheck($this->packageManager, $this->commandDispatcher);
     }
 
-    public function runWizards(StyleInterface $io, array $wizards, array $confirmations, array $denies, bool $force): array
+    public function runWizards(OutputStyle $io, array $wizards, array $confirmations, array $denies, bool $force): array
     {
         $results = [];
         foreach ($wizards as $identifier) {
@@ -109,7 +109,7 @@ class UpgradeHandling
         return $results;
     }
 
-    public function runWizard(StyleInterface $io, string $identifier, array $confirmations, array $denies, bool $force = false): UpgradeWizardResult
+    public function runWizard(OutputStyle $io, string $identifier, array $confirmations, array $denies, bool $force = false): UpgradeWizardResult
     {
         $wizard = $this->factory->create($identifier);
         $identifier = $wizard->getIdentifier();
@@ -123,6 +123,7 @@ class UpgradeHandling
         $executeWizard = $this->executor->wizardNeedsExecution($identifier) || $force;
         if ($executeWizard && $wizard instanceof ConfirmableInterface && !$isConfirmed && !$isDenied) {
             $confirmation = $wizard->getConfirmation();
+            $io->writeln(sprintf('<comment>%s</comment>', $wizard->getTitle()));
             $question = sprintf(
                 '<info>%s</info>' . LF . '%s' . LF . '%s' . LF . '%s' . LF,
                 $confirmation->getTitle(),


### PR DESCRIPTION
The confirmation messages of TYPO3's upgrade wizards are
a bit inconsistent and sometimes don't mention the action
that is to be confirmed at all.

Therefore output the wizard's title to clarify in which
context the confirmation is requested.