### PR TITLE
[FEATURE] Add option to DatabaseUpdateSchemaCommand.php to enable raw output

### DIFF
--- a/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
+++ b/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
@@ -76,6 +76,12 @@ EOH
                     InputOption::VALUE_NONE,
                     'If set the updates are only collected and shown, but not executed'
                 ),
+                new InputOption(
+                    'raw',
+                    '',
+                    InputOption::VALUE_NONE,
+                    'If set the updates are only collected and written in a nice format'
+                ),
             ]
         );
     }
@@ -87,6 +93,7 @@ EOH
 
         $schemaUpdateTypes = explode(',', $input->getArgument('schemaUpdateTypes'));
         $dryRun = $input->getOption('dry-run');
+        $raw = $input->getOption('raw');
         $verbose = $output->isVerbose();
 
         /** @deprecated */
@@ -101,6 +108,15 @@ EOH
         }
 
         $result = $schemaService->updateSchema($expandedSchemaUpdateTypes, $dryRun);
+
+        if ($raw) {
+            foreach ($result->getPerformedUpdates() as $updatesTypes) {
+                foreach ($updatesTypes as $updates) {
+                    $output->writeln($updates . ';' . PHP_EOL);
+                }
+            }
+            return 0;
+        }
 
         if ($result->hasPerformedUpdates()) {
             $output->writeln(sprintf(

--- a/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
+++ b/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
@@ -80,7 +80,7 @@ EOH
                     'raw',
                     '',
                     InputOption::VALUE_NONE,
-                    'If set the updates are only collected and written in a nice format'
+                    'If set, only the SQL statements, that are required to update the schema, are printed'
                 ),
             ]
         );

--- a/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
+++ b/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
@@ -115,6 +115,7 @@ EOH
                     $output->writeln($updates . ';' . PHP_EOL);
                 }
             }
+            
             return 0;
         }
 

--- a/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
+++ b/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
@@ -115,7 +115,7 @@ EOH
                     $output->writeln($updates . ';' . PHP_EOL);
                 }
             }
-            
+
             return 0;
         }
 

--- a/Documentation/CommandReference/DatabaseUpdateschema.rst
+++ b/Documentation/CommandReference/DatabaseUpdateschema.rst
@@ -69,3 +69,8 @@ Options
 - Is value required: no
 - Is multiple: no
 - Default: false
+
+
+
+
+

--- a/Documentation/CommandReference/DatabaseUpdateschema.rst
+++ b/Documentation/CommandReference/DatabaseUpdateschema.rst
@@ -62,7 +62,10 @@ Options
 - Is multiple: no
 - Default: false
 
+`--raw`
+   If set the updates are only collected and written in a nice format
 
-
-
-
+- Accept value: no
+- Is value required: no
+- Is multiple: no
+- Default: false

--- a/Documentation/CommandReference/DatabaseUpdateschema.rst
+++ b/Documentation/CommandReference/DatabaseUpdateschema.rst
@@ -63,7 +63,7 @@ Options
 - Default: false
 
 `--raw`
-   If set the updates are only collected and written in a nice format
+   If set, only the SQL statements, that are required to update the schema, are printed
 
 - Accept value: no
 - Is value required: no


### PR DESCRIPTION
Hi. 

We have talked about this a long time ago, and finally we got upgraded at the latest TYPO3 Console. 

The PR make it possible to generate a raw output for later use in the build process/artefact.

Hope you will consider merging this into the TYPO3 Console.
Stay safe and take care.

