### PR TITLE
[BUGFIX] escape database-username and -password in options-file created by mysql-command (branch latest)

### DIFF
--- a/Classes/Console/Database/Process/MysqlCommand.php
+++ b/Classes/Console/Database/Process/MysqlCommand.php
@@ -141,10 +141,10 @@ class MysqlCommand
         $userDefinition = '';
         $passwordDefinition = '';
         if (!empty($this->dbConfig['user'])) {
-            $userDefinition = sprintf('user="%s"', $this->dbConfig['user']);
+            $userDefinition = sprintf('user="%s"', addcslashes($this->dbConfig['user'], '"\\'));
         }
         if (!empty($this->dbConfig['password'])) {
-            $passwordDefinition = sprintf('password="%s"', $this->dbConfig['password']);
+            $passwordDefinition = sprintf('password="%s"', addcslashes($this->dbConfig['password'], '"\\'));
         }
         $confFileContent = <<<EOF
 [mysqldump]


### PR DESCRIPTION
This PR applies to your `latest`-branch, other PRs for your other active branches follow.

Issue: Database-credentials are not properly escaped when writing the `--defaults-extra-file`. Usernames or passwords with backslashes (\\) and double-quotes (") won't work.

Solution: use `addslashes()` to escape username and password.

- @see https://dev.mysql.com/doc/refman/5.7/en/option-files.html
- @see https://dev.mysql.com/doc/refman/8.0/en/option-files.html

> Leading and trailing spaces are automatically deleted from option names and values.
>
> You can use the escape sequences \b, \t, \n, \r, \\\\, and \s in option values to represent the backspace, tab, newline, carriage return, backslash, and space characters. In option files, these escaping rules apply:
>
> A backslash followed by a valid escape sequence character is converted to the character represented by the sequence. For example, \s is converted to a space.
>
> A backslash not followed by a valid escape sequence character remains unchanged. For example, \S is retained as is.
>
> The preceding rules mean that a literal backslash can be given as \\\\, or as \\ if it is not followed by a valid escape sequence character.

Hence, the MySQL option-files escaping-rules are not 100% `addslashes()` compatible, but using `addslashes()` solves 99% of the escaping-issues for now.

Cheers & Thanks,
Stephan