### PR TITLE
[BUGFIX] escape database-password in arguments for mysql-related commands (branch 4.x)

### DIFF
--- a/Classes/Database/Process/MysqlCommand.php
+++ b/Classes/Database/Process/MysqlCommand.php
@@ -103,7 +103,7 @@ class MysqlCommand
             $arguments[] = $this->dbConfig['user'];
         }
         if (!empty($this->dbConfig['password'])) {
-            $arguments[] = '-p' . $this->dbConfig['password'];
+            $arguments[] = '-p' . escapeshellarg($this->dbConfig['password']);
         }
         if (!empty($this->dbConfig['host'])) {
             $arguments[] = '-h';


### PR DESCRIPTION
This PR applies to your `4.x`-branch, other PRs for your other active branches follow.

Issue: Database-credentials are not properly escaped when building the list of arguments for `mysql`- and `mysqldump`-related command. Passwords with characters that need to be escaped on the shell, won't work.

Solution: use `escapeshellarg()` to escape the password. I did not care about the username here, because it's very unlikely, that the username contains shell-sensitive special-chars. (And to be honest - it's not the main cause, why I opened the PR)

Cheers & Thanks,
Stephan