### PR TITLE
[TASK] Call setCache only if it exists

### DIFF
--- a/Classes/Console/Core/Booting/Scripts.php
+++ b/Classes/Console/Core/Booting/Scripts.php
@@ -54,7 +54,10 @@ class Scripts
         $container->get('boot.state')->done = false;
         $assetsCache = $container->get('cache.assets');
         $coreCache = $container->get('cache.core');
-        IconRegistry::setCache($assetsCache);
+        // compatibility to < v11
+        if (method_exists(IconRegistry::class, 'setCache')) {
+            IconRegistry::setCache($assetsCache);
+        }
         PageRenderer::setCache($assetsCache);
         Bootstrap::loadTypo3LoadedExtAndExtLocalconf(true, $coreCache);
         Bootstrap::unsetReservedGlobalVariables();


### PR DESCRIPTION
In TYPO3 v11 (master) the cache in IconRegistry is
injected via DI and the method "setCache" has been
removed. After this change, the code only calls 
"setCache" if available.

(I don't know how the versioning/release strategy is for 
console, this change is following the core master change 
because I stumbled upon it by accident - if you don't need it yet,
feel free to just close this again).