### PR TITLE
[BUGFIX] Make database:export use credentials in provided file

### DIFF
--- a/Classes/Console/Database/Process/MysqlCommand.php
+++ b/Classes/Console/Database/Process/MysqlCommand.php
@@ -111,7 +111,7 @@ class MysqlCommand
     private function buildConnectionArguments(): array
     {
         if ($configFile = $this->createTemporaryMysqlConfigurationFile()) {
-            $arguments[] = '--defaults-extra-file=' . $configFile;
+            $arguments[] = '--defaults-file=' . $configFile;
         }
         if (!empty($this->dbConfig['host'])) {
             $arguments[] = '-h';


### PR DESCRIPTION
The created file contains all credential for the current TYPO3
installation and these must not be overridden by potentially available
config files in the home directory of the current user.

Fixes #978