### PR TITLE
Replace "Determine tag" step with API if condition

### DIFF
--- a/.github/workflows/Consistency.yaml
+++ b/.github/workflows/Consistency.yaml
@@ -22,15 +22,10 @@ jobs:
                     php --version
                     composer --version
 
-            -   name: "Determine tag"
-                id: "determine-tag"
-                run: "echo \"::set-output name=tag::${GITHUB_REF#refs/tags/}\""
-
             -   name: Consistency Checks
+                if: startsWith(github.ref, 'refs/tags/')
                 run: |
-                    if [ -n "${{ steps.determine-tag.outputs.tag }}" ] && [[ "${{ steps.determine-tag.outputs.tag }}" =~ ^v?([0-9]+\.)([0-9]+\.)([0-9]+)$ ]]; then
-                      composer set-version $(echo ${{ steps.determine-tag.outputs.tag }} | sed s/^v//g)
-                      test -z "$(git diff --shortstat 2> /dev/null | tail -n1)";
-                    fi
-                    composer extension-verify-composer-json
-                    composer extension-release
+                  composer set-version $(echo ${GITHUB_REF#refs/tags/} | sed s/^v//g)
+                  test -z "$(git diff --shortstat 2> /dev/null | tail -n1)";
+                  composer extension-verify-composer-json
+                  composer extension-release


### PR DESCRIPTION
Utilize API jobs.<job_id>.steps[*].if to check if a TAG gets processed
instead of using an extra jobs.<job_id>.step and a long bash condition.