### PR TITLE
Remove conflict to dbal package

### DIFF
--- a/Resources/Private/ExtensionArtifacts/ext_emconf.php
+++ b/Resources/Private/ExtensionArtifacts/ext_emconf.php
@@ -20,7 +20,6 @@ $EM_CONF[$_EXTKEY] = [
       'install' => '10.4.0-11.2.99',
     ],
     'conflicts' => [
-        'dbal' => '',
     ],
     'suggests' => [
     ],

--- a/composer.json
+++ b/composer.json
@@ -53,10 +53,6 @@
         "nimut/testing-framework": "5.x-dev",
         "php-parallel-lint/php-parallel-lint": "^1.2"
     },
-    "conflict": {
-        "typo3-ter/dbal": "*",
-        "friendsoftypo3/dbal": "*"
-    },
     "autoload": {
         "psr-4": {
             "Helhum\\Typo3Console\\": [


### PR DESCRIPTION
There is no dbal version compatible with TYPO3 10 or 11,
so we can safly remove the conflict now.