### PR TITLE
[TASK] Harden install action execution

### DIFF
--- a/Classes/Console/Install/Action/Typo3InstallAction.php
+++ b/Classes/Console/Install/Action/Typo3InstallAction.php
@@ -19,6 +19,7 @@ use Helhum\Typo3Console\Install\InstallStepResponse;
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
 use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
 use Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException;
+use Symfony\Component\Console\Exception\RuntimeException;
 
 class Typo3InstallAction implements InstallActionInterface
 {
@@ -104,6 +105,12 @@ class Typo3InstallAction implements InstallActionInterface
         $arguments = array_merge($arguments, $options);
         $actionResult = $this->commandDispatcher->executeCommand('install:' . $actionName, $arguments);
 
-        return @unserialize($actionResult);
+        $response = @unserialize($actionResult, ['allowed_classes' => [InstallStepResponse::class]]);
+
+        if (!$response instanceof InstallStepResponse) {
+            throw new RuntimeException(sprintf('Executing install action "%s" failed with errors. Returned result is:%s%s', $actionName, chr(10), $actionResult), 1626771483);
+        }
+
+        return $response;
     }
 }

--- a/Classes/Console/Install/InstallStepResponse.php
+++ b/Classes/Console/Install/InstallStepResponse.php
@@ -14,8 +14,6 @@ namespace Helhum\Typo3Console\Install;
  *
  */
 
-use TYPO3\CMS\Install\Status\StatusInterface;
-
 /**
  * Response of an install step
  */
@@ -27,7 +25,7 @@ class InstallStepResponse
     private $actionNeedsExecution;
 
     /**
-     * @var StatusInterface[]
+     * @var array[]
      */
     private $messages = [];
 
@@ -38,7 +36,7 @@ class InstallStepResponse
 
     /**
      * @param bool $actionNeedsExecution
-     * @param StatusInterface[] $messages
+     * @param array[] $messages
      * @param bool $actionNeedsReevaluation
      */
     public function __construct($actionNeedsExecution, array $messages, $actionNeedsReevaluation = false)
@@ -57,7 +55,7 @@ class InstallStepResponse
     }
 
     /**
-     * @return StatusInterface[]
+     * @return array[]
      */
     public function getMessages()
     {


### PR DESCRIPTION
Only allow InstallStepRepsonse unserialisation
and throw an exception with a specific error message
in case this fails.

This will also ease error hunting in case installation process fails.