### PR TITLE
[BUGFIX] GH Actions Composer caching

### DIFF
--- a/.github/workflows/Analyze.yml
+++ b/.github/workflows/Analyze.yml
@@ -30,9 +30,9 @@ jobs:
                 uses: actions/cache@v2
                 with:
                     path: ${{ steps.composer-cache.outputs.dir }}
-                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+                    key: ${{ runner.os }}-7.4-stable-composer-${{ hashFiles('**/composer.lock') }}
                     restore-keys: |
-                        ${{ runner.os }}-composer-
+                        ${{ runner.os }}-7.4-stable-composer-
 
             -   name: Set up PHP
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -22,9 +22,9 @@ jobs:
                 uses: actions/cache@v2
                 with:
                     path: ${{ steps.composer-cache.outputs.dir }}
-                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+                    key: ${{ runner.os }}-7.4-stable-composer-${{ hashFiles('**/composer.lock') }}
                     restore-keys: |
-                        ${{ runner.os }}-composer-
+                        ${{ runner.os }}-7.4-stable-composer-
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -18,9 +18,9 @@ jobs:
                 uses: actions/cache@v2
                 with:
                     path: ${{ steps.composer-cache.outputs.dir }}
-                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+                    key: ${{ runner.os }}-7.4-stable-composer-${{ hashFiles('**/composer.lock') }}
                     restore-keys: |
-                        ${{ runner.os }}-composer-
+                        ${{ runner.os }}-7.4-stable-composer-
 
             -   name: Set up PHP Version 7.4
                 uses: shivammathur/setup-php@v2
@@ -96,9 +96,9 @@ jobs:
                 uses: actions/cache@v2
                 with:
                     path: ${{ steps.composer-cache.outputs.dir }}
-                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+                    key: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.dependency-version }}-composer-${{ hashFiles('**/composer.lock') }}
                     restore-keys: |
-                        ${{ runner.os }}-composer-
+                        ${{ runner.os }}-${{ matrix.php }}-${{ matrix.dependency-version }}-composer-
 
             -   name: Set up PHP Version ${{ matrix.php }}
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/Update.yml
+++ b/.github/workflows/Update.yml
@@ -15,11 +15,23 @@ jobs:
                     path: ./typo3-console
 
             -   name: Checkout extension repo
-                uses: actions/checkout@master
+                uses: actions/checkout@v2
                 with:
                     repository: TYPO3-Console/Extension
                     token: ${{ secrets.EXTENSION_UPDATE_TOKEN }}
                     path: ./extension
+
+            -   name: Get composer cache directory
+                id: composer-cache
+                run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+            -   name: Cache dependencies
+                uses: actions/cache@v2
+                with:
+                    path: ${{ steps.composer-cache.outputs.dir }}
+                    key: ${{ runner.os }}-7.4-stable-composer-${{ hashFiles('**/composer.lock') }}
+                    restore-keys: |
+                        ${{ runner.os }}-7.4-stable-composer-
 
             -   name: Set up PHP Version 7.4
                 uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Not including matrix properties to the cache key in matrix jobs leads to errors during the post action because only one job can write access to a cache key. This patch adds the PHP version and dependency version to the cache key to ensure unique keys for matrix jobs.
Using the composer.json hash in the key leads to the behavior no new cache is stored on the post action as long as no change in the composer.json was made since the last run. But if there are newer packages available the cache never gets updated because no change is recognized. Using the composer.lock file instead for hashing solves this issues even if no composer.lock is available after the checkout.
In addition for non matrix jobs the proper PHP version and dependency version `stable` are also added to the key which makes it possible to also share these caches.