### PR TITLE
[BUGFIX] Add type hints to callback implementation

### DIFF
--- a/Classes/Console/Service/Configuration/ConsoleRenderer/DiffConsoleRenderer.php
+++ b/Classes/Console/Service/Configuration/ConsoleRenderer/DiffConsoleRenderer.php
@@ -21,7 +21,7 @@ use cogpowered\FineDiff\Render\Renderer;
  */
 class DiffConsoleRenderer extends Renderer
 {
-    public function callback($opcode, $from, $from_offset, $from_len)
+    public function callback(string $opcode, string $from, int $from_offset, int $from_len): string
     {
         if ($opcode === 'c') {
             $output = substr($from, $from_offset, $from_len);

--- a/Tests/Console/Functional/Command/ConfigurationCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/ConfigurationCommandControllerTest.php
@@ -31,6 +31,16 @@ class ConfigurationCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
+    public function configurationShowsDiff()
+    {
+        $output = $this->executeConsoleCommand('configuration:show', ['SC_OPTIONS/"ext/install"']);
+        $this->assertStringContainsString('update', $output);
+        $this->assertStringContainsString('++ AdditionalConfiguration.php', $output);
+    }
+
+    /**
+     * @test
+     */
     public function localConfigurationCanBeShown()
     {
         $output = $this->executeConsoleCommand('configuration:showlocal', ['BE/installToolPassword']);


### PR DESCRIPTION
When trying to get the MAIL configuration by entering the command

`typo3cms configuration:show MAIL`

I get the following error message:

`Fatal error: Declaration of Helhum\Typo3Console\Service\Configuration\ConsoleRenderer\DiffConsoleRenderer::callback($opcode, $from, $from_offset, $from_len) must be compatible with cogpowered\FineDiff\Render\RendererInterface::callback(string $opcode, string $from, int $from_offset, int $from_len): string in /var/www/vendor/helhum/typo3-console/Classes/Console/Service/Configuration/ConsoleRenderer/DiffConsoleRenderer.php on line 24`

This commit solves the issue by adding the appropriate type hints.

I am using TYPO3 v. 11.5.3 and the latest version of the console (7.0.4).