### PR TITLE
Adds --no-tablespaces option

### DIFF
--- a/Classes/Console/Command/Database/DatabaseExportCommand.php
+++ b/Classes/Console/Command/Database/DatabaseExportCommand.php
@@ -132,7 +132,7 @@ EOH
             $arguments[] = sprintf('--ignore-table=%s.%s', $dbConfig['dbname'], $table);
         }
 
-        if ($noTablespaces){
+        if ($noTablespaces) {
             $arguments[] = '--no-tablespaces';
         }
 

--- a/Classes/Console/Command/Database/DatabaseExportCommand.php
+++ b/Classes/Console/Command/Database/DatabaseExportCommand.php
@@ -75,7 +75,6 @@ EOH
                 'Adds --no-tablespaces to the resulting query. Does not dump any tablespace information.',
                 null
             ),
-
         ]);
     }
 

--- a/Classes/Console/Command/Database/DatabaseExportCommand.php
+++ b/Classes/Console/Command/Database/DatabaseExportCommand.php
@@ -132,7 +132,7 @@ EOH
             $arguments[] = sprintf('--ignore-table=%s.%s', $dbConfig['dbname'], $table);
         }
 
-        if($noTablespaces){
+        if ($noTablespaces){
             $arguments[] = '--no-tablespaces';
         }
 

--- a/Documentation/CommandReference/DatabaseExport.rst
+++ b/Documentation/CommandReference/DatabaseExport.rst
@@ -23,7 +23,7 @@ Tables to be excluded from the export can be specified fully qualified or with w
 
 **Example:**
 
-  `typo3cms database:export -c Default -e 'cf_*' -e 'cache_*' -e '[bf]e_sessions' -e sys_log`
+  `typo3cms database:export -y -c Default -e 'cf_*' -e 'cache_*' -e '[bf]e_sessions' -e sys_log`
 
 
 
@@ -44,6 +44,11 @@ Options
 - Accept value: yes
 - Is value required: yes
 - Is multiple: no
+
+`--no-tablespaces|-y`
+   Does not dump any tablespace information.
+
+- Is value required: no
 
 
 


### PR DESCRIPTION
[Like the MySQL docs describes](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html):
> mysqldump requires at least the [...] (as of MySQL 8.0.21) PROCESS if the --no-tablespaces option is not used. [...]

With the `mysqldump` command you can use "-y" to shorthand the "--no-tablespaces"-option. I added it in the same way to the command.

Without the --no-tablespace option, you get an error like this:
> mysqldump: Error: 'Access denied; you need (at least one of) the PROCESS privilege(s) for this operation' when trying to dump tablespaces

In managed hosting environments (e.g. Mittwald), you do not have the privileges and it cannot be added. So --no-tablespaces is the only way to dump a table.