### PR TITLE
[BUGFIX] Disable extension constraint checks in Composer mode

### DIFF
--- a/Classes/Console/Command/Upgrade/UpgradeCheckExtensionConstraintsCommand.php
+++ b/Classes/Console/Command/Upgrade/UpgradeCheckExtensionConstraintsCommand.php
@@ -46,7 +46,7 @@ EOH
                 null,
                 InputOption::VALUE_REQUIRED,
                 'TYPO3 version to check against. Defaults to current TYPO3 version',
-                (string)(new Typo3Version())
+                (new Typo3Version())->getVersion()
             ),
         ]);
     }

--- a/Classes/Console/Command/Upgrade/UpgradeCheckExtensionConstraintsCommand.php
+++ b/Classes/Console/Command/Upgrade/UpgradeCheckExtensionConstraintsCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Package\Exception\UnknownPackageException;
 
@@ -51,8 +52,19 @@ EOH
         ]);
     }
 
+    public function isHidden()
+    {
+        return !getenv('TYPO3_CONSOLE_RENDERING_REFERENCE') && Environment::isComposerMode();
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (Environment::isComposerMode()) {
+            $output->writeln('<error>The command "upgrade:checkextensionconstraints" is not available in Composer mode, because Composer already enforces such constraints.</error>');
+
+            return 1;
+        }
+
         $extensionKeys = $input->getArgument('extensionKeys');
         $typo3Version = $input->getOption('typo3-version');
         $upgradeHandling = new UpgradeHandling();

--- a/Classes/Console/Extension/ExtensionCompatibilityCheck.php
+++ b/Classes/Console/Extension/ExtensionCompatibilityCheck.php
@@ -15,6 +15,7 @@ namespace Helhum\Typo3Console\Extension;
  */
 
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Package\PackageInterface;
 use TYPO3\CMS\Core\Package\PackageManager;
 
@@ -71,13 +72,13 @@ class ExtensionCompatibilityCheck
             }
             $isCompatible = @\json_decode($this->commandDispatcher->executeCommand('upgrade:checkextensioncompatibility', [$package->getPackageKey(), '--config-only']));
             if (!$isCompatible) {
-                $this->packageManager->deactivatePackage($package->getPackageKey());
+                !Environment::isComposerMode() && $this->packageManager->deactivatePackage($package->getPackageKey());
                 $failedPackages[] = $package->getPackageKey();
                 continue;
             }
             $isCompatible = @\json_decode($this->commandDispatcher->executeCommand('upgrade:checkextensioncompatibility', [$package->getPackageKey()]));
             if (!$isCompatible) {
-                $this->packageManager->deactivatePackage($package->getPackageKey());
+                !Environment::isComposerMode() && $this->packageManager->deactivatePackage($package->getPackageKey());
                 $failedPackages[] = $package->getPackageKey();
             }
         }

--- a/Classes/Console/Extension/ExtensionConstraintCheck.php
+++ b/Classes/Console/Extension/ExtensionConstraintCheck.php
@@ -14,6 +14,7 @@ namespace Helhum\Typo3Console\Extension;
  *
  */
 
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Package\PackageInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
@@ -44,6 +45,9 @@ class ExtensionConstraintCheck
      */
     public function matchConstraints(PackageInterface $package, $typo3Version)
     {
+        if (Environment::isComposerMode()) {
+            return '';
+        }
         $message = '';
         $extConf = $this->emConfReader->includeEmConf($package->getPackageKey(), $package->getPackagePath());
         if (!empty($extConf['constraints']['depends']['typo3'])) {

--- a/Classes/Console/Install/Upgrade/UpgradeHandling.php
+++ b/Classes/Console/Install/Upgrade/UpgradeHandling.php
@@ -19,6 +19,7 @@ use Helhum\Typo3Console\Extension\ExtensionConstraintCheck;
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
 use Helhum\Typo3Console\Service\Configuration\ConfigurationService;
 use Symfony\Component\Console\Style\OutputStyle;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Package\PackageManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -195,7 +196,7 @@ class UpgradeHandling
         $messages = [];
         $failedPackageMessages = $this->matchAllExtensionConstraints($this->typo3Version->getVersion());
         foreach ($failedPackageMessages as $extensionKey => $constraintMessage) {
-            $this->packageManager->deactivatePackage($extensionKey);
+            !Environment::isComposerMode() && $this->packageManager->deactivatePackage($extensionKey);
             $messages[] = sprintf('<error>%s</error>', $constraintMessage);
             $messages[] = sprintf('<info>Deactivated extension "%s".</info>', $extensionKey);
         }

--- a/Classes/Console/Install/Upgrade/UpgradeHandling.php
+++ b/Classes/Console/Install/Upgrade/UpgradeHandling.php
@@ -19,6 +19,7 @@ use Helhum\Typo3Console\Extension\ExtensionConstraintCheck;
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
 use Helhum\Typo3Console\Service\Configuration\ConfigurationService;
 use Symfony\Component\Console\Style\OutputStyle;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Package\PackageManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Install\Updates\ConfirmableInterface;
@@ -77,6 +78,8 @@ class UpgradeHandling
      */
     private $initialUpgradeDone = false;
 
+    private Typo3Version $typo3Version;
+
     public function __construct(
         UpgradeWizardFactory $factory = null,
         UpgradeWizardExecutor $executor = null,
@@ -97,6 +100,7 @@ class UpgradeHandling
         $this->packageManager = $packageManager ?: GeneralUtility::makeInstance(PackageManager::class);
         $this->extensionConstraintCheck = $extensionConstraintCheck ?: new ExtensionConstraintCheck();
         $this->extensionCompatibilityCheck = $extensionCompatibilityCheck ?: new ExtensionCompatibilityCheck($this->packageManager, $this->commandDispatcher);
+        $this->typo3Version = new Typo3Version();
     }
 
     public function runWizards(OutputStyle $io, array $wizards, array $confirmations, array $denies, bool $force): array
@@ -167,7 +171,7 @@ class UpgradeHandling
 
     public function prepareUpgrade(): array
     {
-        $this->configurationService->setLocal('EXTCONF/helhum-typo3-console/initialUpgradeDone', TYPO3_branch, 'string');
+        $this->configurationService->setLocal('EXTCONF/helhum-typo3-console/initialUpgradeDone', $this->typo3Version->getBranch(), 'string');
         $this->commandDispatcher->executeCommand('install:fixfolderstructure');
         $this->silentConfigurationUpgrade->executeSilentConfigurationUpgradesIfNeeded();
         $this->commandDispatcher->executeCommand('cache:flush', ['--group', 'system']);
@@ -182,14 +186,14 @@ class UpgradeHandling
         return $this->initialUpgradeDone
             || (
                 $this->configurationService->hasLocal('EXTCONF/helhum-typo3-console/initialUpgradeDone')
-                && $this->configurationService->getLocal('EXTCONF/helhum-typo3-console/initialUpgradeDone') === TYPO3_branch
+                && $this->configurationService->getLocal('EXTCONF/helhum-typo3-console/initialUpgradeDone') === $this->typo3Version->getBranch()
             );
     }
 
     private function checkExtensionCompatibility(): array
     {
         $messages = [];
-        $failedPackageMessages = $this->matchAllExtensionConstraints(TYPO3_version);
+        $failedPackageMessages = $this->matchAllExtensionConstraints($this->typo3Version->getVersion());
         foreach ($failedPackageMessages as $extensionKey => $constraintMessage) {
             $this->packageManager->deactivatePackage($extensionKey);
             $messages[] = sprintf('<error>%s</error>', $constraintMessage);

--- a/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/UpgradeCommandControllerTest.php
@@ -14,38 +14,10 @@ namespace Helhum\Typo3Console\Tests\Functional\Command;
  *
  */
 
-use Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException;
 use TYPO3\CMS\Install\Updates\RowUpdater\WorkspaceVersionRecordsMigration;
 
 class UpgradeCommandControllerTest extends AbstractCommandTest
 {
-    /**
-     * @test
-     */
-    public function canCheckExtensionConstraints(): void
-    {
-        $output = $this->executeConsoleCommand('upgrade:checkextensionconstraints');
-        $this->assertStringContainsString('All third party extensions claim to be compatible with TYPO3 version', $output);
-    }
-
-    /**
-     * @test
-     */
-    public function checkExtensionConstraintsReturnsErrorCodeOnFailure(): void
-    {
-        self::installFixtureExtensionCode('ext_test');
-        $this->executeConsoleCommand('extension:setup', ['-e', 'ext_test']);
-        try {
-            $this->commandDispatcher->executeCommand('upgrade:checkextensionconstraints', ['--typo3-version' => '3.6.0']);
-            $this->fail('upgrade:checkextensionconstraints should have failed');
-        } catch (FailedSubProcessCommandException $e) {
-            $this->assertSame(1, $e->getExitCode());
-            $this->assertStringContainsString('"ext_test" requires TYPO3 versions 4.5.0', $e->getOutputMessage());
-        } finally {
-            self::removeFixtureExtensionCode('ext_test');
-        }
-    }
-
     /**
      * @test
      */
@@ -70,16 +42,6 @@ class UpgradeCommandControllerTest extends AbstractCommandTest
         $this->assertSame('true', $output);
 
         self::removeFixtureExtensionCode('ext_broken_ext_tables');
-    }
-
-    /**
-     * @test
-     */
-    public function checkExtensionConstraintsIssuesWarningForInvalidExtensionKeys(): void
-    {
-        $output = $this->executeConsoleCommand('upgrade:checkextensionconstraints', ['foo,bar']);
-        $this->assertStringContainsString('Extension "foo" is not found in the system', $output);
-        $this->assertStringContainsString('Extension "bar" is not found in the system', $output);
     }
 
     /**


### PR DESCRIPTION
When TYPO3 and extensions are installed with Composer, it is pointless
to check for ext_emconf.php files and version constraints in them,
because they are not evaluated any more since TYPO3 11.5.

Therefore, even if those files contain outdated information,
those have no effect on the installation and as such should
not lead to any errors.

Also fix upgrade:prepare to not deactivate an extension, as this
leads to errors, as packages can not be deactivated in Composer
mode during runtime any more

Fixes #1040