### PR TITLE
[BUGFIX] Correctly detect old process version

### DIFF
--- a/Classes/Console/Mvc/Cli/CommandDispatcher.php
+++ b/Classes/Console/Mvc/Cli/CommandDispatcher.php
@@ -242,8 +242,13 @@ class CommandDispatcher
         if (isset($commandParameters[0]) && $commandParameters[0]->getType() !== null) {
             return $commandParameters[0]->getType()->getName() === 'array';
         }
+        $docComment = $constructorReflector->getDocComment();
+        if (!$docComment) {
+            // No annotation, count parameters. Newer versions of symfony/process has 5 parameters.
+            return count($commandParameters) < 6;
+        }
         // No PHP type hint, look in annotation
-        preg_match("/@param[ ]*([^ ]*)[ ]*\\\${$commandParameters[0]->getName()}/", $constructorReflector->getDocComment(), $matches);
+        preg_match("/@param[ ]*([^ ]*)[ ]*\\\${$commandParameters[0]->getName()}/", $docComment, $matches);
 
         return ($matches[1] ?? '') === 'array';
     }


### PR DESCRIPTION
When Composer is compiled to phar, the comments are stripped,
so a fallback is needed and parameters are counted in that
case instead.

Fixes #1054