### PR TITLE
shorten required PHP version @ composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     ],
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=7.4.1",
+        "php": ">=7.4",
         "composer-runtime-api": "^2.1",
 
         "typo3/cms-backend": "^11.5.3 || dev-main",


### PR DESCRIPTION
`helhum/typo3-console dev-main req. php >=7.4.1 -> your v. (7.4; overridden via config.platform,: 7.4.28)`

yes, there was FIX(es) in 7.4.1 but also in all of the following
my sugestion would be to keep the version at the minimum required to run

ref. https://www.php.net/releases/7_4_1.php / https://www.php.net/releases/7_4_2.php / [..]