### PR TITLE
Remove default value for required arguments

### DIFF
--- a/Classes/Console/Command/Upgrade/UpgradeRunCommand.php
+++ b/Classes/Console/Command/Upgrade/UpgradeRunCommand.php
@@ -67,8 +67,7 @@ EOH
         $this->addArgument(
             'wizardIdentifiers',
             InputArgument::REQUIRED | InputArgument::IS_ARRAY,
-            'One or more wizard identifiers to run',
-            []
+            'One or more wizard identifiers to run'
         );
         $this->addOption(
             'confirm',


### PR DESCRIPTION
With the change https://github.com/symfony/symfony/pull/46264 it's not
longer possible to provide a default value for required arguments and
the TYPO3 Console stops working with Symfony 6.0.9, 5.4.9 and 4.4.42.