### PR TITLE
Fix deprecation notices in actions

### DIFF
--- a/.github/workflows/Analyze.yml
+++ b/.github/workflows/Analyze.yml
@@ -7,6 +7,10 @@ on:
             - develop
             - /^v?([0-9]+\.){1,2}(x|[0-9]+)-?[a-z]*[1-9]*$/
 
+defaults:
+    run:
+        shell: bash
+
 jobs:
     Sonar-Cloud:
         name: 'Sonar Cloud'
@@ -25,8 +29,8 @@ jobs:
             -   name: Composer Cache Vars
                 id: composer-cache-vars
                 run: |
-                    echo "::set-output name=dir::$(composer config cache-files-dir)"
-                    echo "::set-output name=timestamp::$(date +"%s")"
+                    echo "dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+                    echo "timestamp::$(date +"%s")" >> $GITHUB_OUTPUT
 
             -   name: Cache Composer dependencies
                 uses: actions/cache@v3

--- a/.github/workflows/Analyze.yml
+++ b/.github/workflows/Analyze.yml
@@ -18,7 +18,7 @@ jobs:
                 run: sudo /etc/init.d/mysql start
 
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     fetch-depth: 0
 
@@ -29,7 +29,7 @@ jobs:
                     echo "::set-output name=timestamp::$(date +"%s")"
 
             -   name: Cache Composer dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ${{ steps.composer-cache-vars.outputs.dir }}
                     key: ${{ runner.os }}-composer-^11.5.3-stable-7.4-${{ steps.composer-cache-vars.outputs.timestamp }}

--- a/.github/workflows/Analyze.yml
+++ b/.github/workflows/Analyze.yml
@@ -29,8 +29,8 @@ jobs:
             -   name: Composer Cache Vars
                 id: composer-cache-vars
                 run: |
-                    echo "dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-                    echo "timestamp::$(date +"%s")" >> $GITHUB_OUTPUT
+                    echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+                    echo "timestamp=$(date +"%s")" >> $GITHUB_OUTPUT
 
             -   name: Cache Composer dependencies
                 uses: actions/cache@v3

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -5,6 +5,10 @@ on:
         tags:
             - "v?[0-9]+.[0-9]+.[0-9]+"
 
+defaults:
+    run:
+        shell: bash
+
 jobs:
     Ship-to-TER:
         name: 'Ship to TER'
@@ -17,8 +21,8 @@ jobs:
             -   name: Composer Cache Vars
                 id: composer-cache-vars
                 run: |
-                    echo "::set-output name=dir::$(composer config cache-files-dir)"
-                    echo "::set-output name=timestamp::$(date +"%s")"
+                    echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+                    echo "timestamp=$(date +"%s")" >> $GITHUB_OUTPUT
 
             -   name: Cache Composer dependencies
                 uses: actions/cache@v3
@@ -40,9 +44,9 @@ jobs:
             -   name: "Extract tag, branch, version from GITHUB_REF"
                 id: "github-ref"
                 run: |
-                    echo "::set-output name=tag::$(echo $GITHUB_REF | sed -E -n 's#^refs/tags/(.*)$#\1#p')"
-                    echo "::set-output name=branch::$(echo $GITHUB_REF | sed -E -n 's#^refs/heads/(.*)$#\1#p')"
-                    echo "::set-output name=version::$(echo $GITHUB_REF | sed -E -n 's#^refs/tags/v?([0-9]+\.)([0-9]+\.)([0-9]+)#\1\2\3#p')"
+                    echo "tag=$(echo $GITHUB_REF | sed -E -n 's#^refs/tags/(.*)$#\1#p')" >> $GITHUB_OUTPUT
+                    echo "branch=$(echo $GITHUB_REF | sed -E -n 's#^refs/heads/(.*)$#\1#p')" >> $GITHUB_OUTPUT
+                    echo "version=$(echo $GITHUB_REF | sed -E -n 's#^refs/tags/v?([0-9]+\.)([0-9]+\.)([0-9]+)#\1\2\3#p')" >> $GITHUB_OUTPUT
 
             -   name: Deploy to TER
                 run: |

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -   name: Composer Cache Vars
                 id: composer-cache-vars
@@ -21,7 +21,7 @@ jobs:
                     echo "::set-output name=timestamp::$(date +"%s")"
 
             -   name: Cache Composer dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ${{ steps.composer-cache-vars.outputs.dir }}
                     key: ${{ runner.os }}-composer-^11.5.3-stable-7.4-${{ steps.composer-cache-vars.outputs.timestamp }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -2,6 +2,10 @@ name: Test
 
 on: [ push, pull_request ]
 
+defaults:
+    run:
+        shell: bash
+
 jobs:
     Consistency:
         name: 'Consistency'
@@ -13,8 +17,8 @@ jobs:
             -   name: Composer Cache Vars
                 id: composer-cache-vars
                 run: |
-                    echo "::set-output name=dir::$(composer config cache-files-dir)"
-                    echo "::set-output name=timestamp::$(date +"%s")"
+                    echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+                    echo "timestamp=$(date +"%s")" >> $GITHUB_OUTPUT
 
             -   name: Cache Composer dependencies
                 uses: actions/cache@v3
@@ -37,9 +41,9 @@ jobs:
             -   name: "Extract tag, branch, version from GITHUB_REF"
                 id: "github-ref"
                 run: |
-                    echo "::set-output name=tag::$(echo $GITHUB_REF | sed -E -n 's#^refs/tags/(.*)$#\1#p')"
-                    echo "::set-output name=branch::$(echo $GITHUB_REF | sed -E -n 's#^refs/heads/(.*)$#\1#p')"
-                    echo "::set-output name=version::$(echo $GITHUB_REF | sed -E -n 's#^refs/tags/v?([0-9]+\.)([0-9]+\.)([0-9]+)#\1\2\3#p')"
+                    echo "tag=$(echo $GITHUB_REF | sed -E -n 's#^refs/tags/(.*)$#\1#p')" >> $GITHUB_OUTPUT
+                    echo "branch=$(echo $GITHUB_REF | sed -E -n 's#^refs/heads/(.*)$#\1#p')" >> $GITHUB_OUTPUT
+                    echo "version=$(echo $GITHUB_REF | sed -E -n 's#^refs/tags/v?([0-9]+\.)([0-9]+\.)([0-9]+)#\1\2\3#p')" >> $GITHUB_OUTPUT
 
             -   name: Compare tag version with committed version
                 if: steps.github-ref.outputs.version != ''
@@ -92,8 +96,8 @@ jobs:
             -   name: Composer Cache Vars
                 id: composer-cache-vars
                 run: |
-                    echo "::set-output name=dir::$(composer config cache-files-dir)"
-                    echo "::set-output name=timestamp::$(date +"%s")"
+                    echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+                    echo "timestamp=$(date +"%s")" >> $GITHUB_OUTPUT
 
             -   name: Cache Composer dependencies
                 uses: actions/cache@v3

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -   name: Composer Cache Vars
                 id: composer-cache-vars
@@ -17,7 +17,7 @@ jobs:
                     echo "::set-output name=timestamp::$(date +"%s")"
 
             -   name: Cache Composer dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ${{ steps.composer-cache-vars.outputs.dir }}
                     key: ${{ runner.os }}-composer-^11.5.3-stable-7.4-${{ steps.composer-cache-vars.outputs.timestamp }}
@@ -87,7 +87,7 @@ jobs:
                 run: sudo /etc/init.d/mysql start
 
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -   name: Composer Cache Vars
                 id: composer-cache-vars
@@ -96,7 +96,7 @@ jobs:
                     echo "::set-output name=timestamp::$(date +"%s")"
 
             -   name: Cache Composer dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ${{ steps.composer-cache-vars.outputs.dir }}
                     key: ${{ runner.os }}-composer-${{ matrix.typo3 }}-${{ matrix.dependency-version }}-${{ matrix.php }}-${{ steps.composer-cache-vars.outputs.timestamp }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -66,13 +66,13 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ 'ubuntu-18.04' ]
+                os: [ 'ubuntu-latest' ]
                 typo3: [ '^11.5.3' ]
                 php: [ '7.4', '8.0', '8.1' ]
                 dependency-version: [ lowest, stable ]
                 experimental: [ false ]
                 include:
-#                    -   os: 'ubuntu-18.04'
+#                    -   os: 'ubuntu-latest'
 #                        php: 8.1
 #                        typo3: dev-main
 #                        dependency-version: stable
@@ -87,7 +87,7 @@ jobs:
 
         steps:
             -   name: Start database server
-                if: matrix.os == 'ubuntu-18.04'
+                if: matrix.os == 'ubuntu-latest'
                 run: sudo /etc/init.d/mysql start
 
             -   name: Checkout
@@ -137,13 +137,13 @@ jobs:
 
             # This fails when command reference is not up to date
             -   name: Test Command Reference
-                if: matrix.os == 'ubuntu-18.04' && !matrix.experimental
+                if: matrix.os == 'ubuntu-latest' && !matrix.experimental
                 run: |
                     ./typo3cms commandreference:render
                     git diff --exit-code
 
             -   name: Test Install (Unix)
-                if: matrix.os == 'ubuntu-18.04' && !matrix.experimental
+                if: matrix.os == 'ubuntu-latest' && !matrix.experimental
                 run: 'php ./typo3cms install:setup --install-steps-config=Tests/Console/Functional/Fixtures/Install/mysql-install.yaml --no-interaction -vvv'
 
             -   name: Test Install (Windows)
@@ -151,7 +151,7 @@ jobs:
                 run: 'php ./typo3cms install:setup --install-steps-config=Tests/Console/Functional/Fixtures/Install/sqlite-install.yaml --no-interaction -vvv'
 
             -   name: Test
-                if: matrix.os == 'ubuntu-18.04' && !matrix.experimental
+                if: matrix.os == 'ubuntu-latest' && !matrix.experimental
                 run: .Build/bin/phpunit
 
             -   name: Test - allow failure

--- a/.github/workflows/Update.yml
+++ b/.github/workflows/Update.yml
@@ -10,12 +10,12 @@ jobs:
 
         steps:
             -   name: Checkout main repo
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     path: ./typo3-console
 
             -   name: Checkout extension repo
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     repository: TYPO3-Console/Extension
                     token: ${{ secrets.EXTENSION_UPDATE_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
                     echo "::set-output name=timestamp::$(date +"%s")"
 
             -   name: Cache Composer dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ${{ steps.composer-cache-vars.outputs.dir }}
                     key: ${{ runner.os }}-composer-^11.5.3-stable-7.4-${{ steps.composer-cache-vars.outputs.timestamp }}

--- a/.github/workflows/Update.yml
+++ b/.github/workflows/Update.yml
@@ -2,6 +2,10 @@ name: Update
 
 on: [ push ]
 
+defaults:
+    run:
+        shell: bash
+
 jobs:
     Extension-Repo:
         name: 'Extension Repo'
@@ -24,8 +28,8 @@ jobs:
             -   name: Composer Cache Vars
                 id: composer-cache-vars
                 run: |
-                    echo "::set-output name=dir::$(composer config cache-files-dir)"
-                    echo "::set-output name=timestamp::$(date +"%s")"
+                    echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+                    echo "timestamp=$(date +"%s")" >> $GITHUB_OUTPUT
 
             -   name: Cache Composer dependencies
                 uses: actions/cache@v3
@@ -48,9 +52,9 @@ jobs:
             -   name: "Extract tag, branch, version from GITHUB_REF"
                 id: "github-ref"
                 run: |
-                    echo "::set-output name=tag::$(echo $GITHUB_REF | sed -E -n 's#^refs/tags/(.*)$#\1#p')"
-                    echo "::set-output name=branch::$(echo $GITHUB_REF | sed -E -n 's#^refs/heads/(.*)$#\1#p')"
-                    echo "::set-output name=version::$(echo $GITHUB_REF | sed -E -n 's#^refs/tags/v?([0-9]+\.)([0-9]+\.)([0-9]+)#\1\2\3#p')"
+                    echo "tag=$(echo $GITHUB_REF | sed -E -n 's#^refs/tags/(.*)$#\1#p')" >> $GITHUB_OUTPUT
+                    echo "branch=$(echo $GITHUB_REF | sed -E -n 's#^refs/heads/(.*)$#\1#p')" >> $GITHUB_OUTPUT
+                    echo "version=$(echo $GITHUB_REF | sed -E -n 's#^refs/tags/v?([0-9]+\.)([0-9]+\.)([0-9]+)#\1\2\3#p')" >> $GITHUB_OUTPUT
 
             -   name: Checkout extension branch
                 if: steps.github-ref.outputs.branch != ''


### PR DESCRIPTION
The following changes are done:

* Update deprecated actions
* Replace deprecated commands
* Update deprecated runner for tests

The remaining notices are generated by actions and will be fixed automatically on new action releases.

The new procedure to provide output from a job is currently not supported in PowerShell and therefor Bash is now also used on Windows. See also https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/