### PR TITLE
[DRAFT][TASK] Provide compatibility with TYPO3 v12

### DIFF
--- a/Classes/Console/Command/Backend/CreateBackendAdminUserCommand.php
+++ b/Classes/Console/Command/Backend/CreateBackendAdminUserCommand.php
@@ -25,7 +25,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class CreateBackendAdminUserCommand extends Command
@@ -132,17 +131,11 @@ class CreateBackendAdminUserCommand extends Command
              ->removeByType(StartTimeRestriction::class)
              ->removeByType(EndTimeRestriction::class)
              ->removeByType(HiddenRestriction::class);
-        $queryBuilder->count('uid')
+        $userExists = $queryBuilder->count('uid')
             ->from('be_users')
             ->where(
                 $queryBuilder->expr()->eq('username', $queryBuilder->createNamedParameter($username))
-            );
-
-        if ((new Typo3Version())->getMajorVersion() > 11) {
-            $userExists = $queryBuilder->executeQuery()->fetchOne() > 0;
-        } else {
-            $userExists = $queryBuilder->execute()->fetchColumn() > 0;
-        }
+            )->execute()->fetchOne() > 0;
 
         if ($userExists) {
             return sprintf('A user with username "%s" already exists.', $username);

--- a/Classes/Console/Core/Booting/Scripts.php
+++ b/Classes/Console/Core/Booting/Scripts.php
@@ -21,7 +21,6 @@ use Symfony\Component\DependencyInjection\Container;
 use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
 use TYPO3\CMS\Core\Core\BootService;
 use TYPO3\CMS\Core\Core\Bootstrap;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Page\PageRenderer;
 
 class Scripts
@@ -56,10 +55,9 @@ class Scripts
             $bootService->makeCurrent($container);
         }
         $container->get('boot.state')->done = false;
-        $assetsCache = $container->get('cache.assets');
         $coreCache = $container->get('cache.core');
-        if ((new Typo3Version())->getMajorVersion() < 12) {
-            PageRenderer::setCache($assetsCache);
+        if (method_exists(PageRenderer::class, 'setCache')) {
+            PageRenderer::setCache($container->get('cache.assets'));
         }
         Bootstrap::loadTypo3LoadedExtAndExtLocalconf(true, $coreCache);
         Bootstrap::unsetReservedGlobalVariables();

--- a/Classes/Console/Core/Booting/Scripts.php
+++ b/Classes/Console/Core/Booting/Scripts.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Container;
 use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
 use TYPO3\CMS\Core\Core\BootService;
 use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Page\PageRenderer;
 
 class Scripts
@@ -57,7 +58,9 @@ class Scripts
         $container->get('boot.state')->done = false;
         $assetsCache = $container->get('cache.assets');
         $coreCache = $container->get('cache.core');
-        PageRenderer::setCache($assetsCache);
+        if ((new Typo3Version())->getMajorVersion() < 12) {
+            PageRenderer::setCache($assetsCache);
+        }
         Bootstrap::loadTypo3LoadedExtAndExtLocalconf(true, $coreCache);
         Bootstrap::unsetReservedGlobalVariables();
         $container->get('boot.state')->done = true;


### PR DESCRIPTION
This change adds basic functionality for TYPO3 v12.

By using TYPO3 v12 the main issue is providing
compatibility with symfony 6.

This means, that all *Command->execute() methods
need the return type "int" added. Similar
logic applies to "isHidden(): bool".

In addition, various helper functions need
to have their return type added.

The "Helper::strlen()" was deprecated in Symfony 5.3 and removed in Symfony 6. The replacement is
"Helper::width()" which is solved by using
a helper class to support both Symfony 4+6.

Support for TYPO3 v12 was provided by using
"Typo3Version" with a few switches regarding
Doctrine DBAL 3.x support and Bootstrap
(PageRenderer::setCache is not needed anymore).

Manual tests executed with TYPO3 v12:
* install:setup
* backend:createadmin
* upgrade:prepare