### PR TITLE
[TASK] Provide return types for Symfony Commands

### DIFF
--- a/Classes/Console/Command/Backend/LockBackendForEditorsCommand.php
+++ b/Classes/Console/Command/Backend/LockBackendForEditorsCommand.php
@@ -39,7 +39,7 @@ class LockBackendForEditorsCommand extends Command implements RelatableCommandIn
 Admins will still be able to log in and work with the backend.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configurationService = new ConfigurationService();
         if (!$configurationService->localIsActive('BE/adminOnly')) {

--- a/Classes/Console/Command/Backend/UnlockBackendForEditorsCommand.php
+++ b/Classes/Console/Command/Backend/UnlockBackendForEditorsCommand.php
@@ -37,7 +37,7 @@ class UnlockBackendForEditorsCommand extends Command implements RelatableCommand
         $this->setHelp('Allow backend access for editors again (e.g. after having been locked with backend:lockforeditors command).');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configurationService = new ConfigurationService();
         if (!$configurationService->localIsActive('BE/adminOnly')) {

--- a/Classes/Console/Command/Cache/CacheFlushTagsCommand.php
+++ b/Classes/Console/Command/Cache/CacheFlushTagsCommand.php
@@ -52,7 +52,7 @@ EOH
         ]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $tags = GeneralUtility::trimExplode(',', $input->getArgument('tags'), true);
         if ($input->getOption('groups') !== null) {

--- a/Classes/Console/Command/Cache/CacheListGroupsCommand.php
+++ b/Classes/Console/Command/Cache/CacheListGroupsCommand.php
@@ -27,7 +27,7 @@ class CacheListGroupsCommand extends Command
         $this->setHelp('Lists all registered cache groups.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $cacheService = new CacheService();
         $groups = $cacheService->getValidCacheGroups();

--- a/Classes/Console/Command/Configuration/ConfigurationRemoveCommand.php
+++ b/Classes/Console/Command/Configuration/ConfigurationRemoveCommand.php
@@ -55,7 +55,7 @@ EOH
         ]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $paths = explode(',', $input->getArgument('paths'));
         $force = $input->getOption('force');

--- a/Classes/Console/Command/Configuration/ConfigurationSetCommand.php
+++ b/Classes/Console/Command/Configuration/ConfigurationSetCommand.php
@@ -61,7 +61,7 @@ EOH
         ]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $path = $input->getArgument('path');
         $value = $input->getArgument('value');

--- a/Classes/Console/Command/Configuration/ConfigurationShowActiveCommand.php
+++ b/Classes/Console/Command/Configuration/ConfigurationShowActiveCommand.php
@@ -52,7 +52,7 @@ EOH
         ]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $path = $input->getArgument('path');
         $json = $input->getOption('json');

--- a/Classes/Console/Command/Configuration/ConfigurationShowCommand.php
+++ b/Classes/Console/Command/Configuration/ConfigurationShowCommand.php
@@ -46,7 +46,7 @@ EOH
         ]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $path = $input->getArgument('path');
         $configurationService = new ConfigurationService();

--- a/Classes/Console/Command/Configuration/ConfigurationShowLocalCommand.php
+++ b/Classes/Console/Command/Configuration/ConfigurationShowLocalCommand.php
@@ -61,7 +61,7 @@ EOH
         ]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $path = $input->getArgument('path');
         $json = $input->getOption('json');

--- a/Classes/Console/Command/Database/DatabaseExportCommand.php
+++ b/Classes/Console/Command/Database/DatabaseExportCommand.php
@@ -79,7 +79,7 @@ EOH
         ]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $additionalMysqlDumpArguments = $input->getArgument('additionalMysqlDumpArguments');
         $connection = $input->getOption('connection');

--- a/Classes/Console/Command/Database/DatabaseImportCommand.php
+++ b/Classes/Console/Command/Database/DatabaseImportCommand.php
@@ -63,7 +63,7 @@ EOH
         ]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $interactive = $input->getOption('interactive');
         $connection = (string)$input->getOption('connection');

--- a/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
+++ b/Classes/Console/Command/Database/DatabaseUpdateSchemaCommand.php
@@ -88,7 +88,7 @@ EOH
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $schemaService = new SchemaService(new SchemaUpdate());
         $schemaUpdateResultRenderer = new SchemaUpdateResultRenderer();

--- a/Classes/Console/Command/Frontend/FrontendRequestCommand.php
+++ b/Classes/Console/Command/Frontend/FrontendRequestCommand.php
@@ -40,7 +40,7 @@ EOH
         ]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $requestUrl = $input->getArgument('requestUrl');
 

--- a/Classes/Console/Command/Install/InstallActionNeedsExecutionCommand.php
+++ b/Classes/Console/Command/Install/InstallActionNeedsExecutionCommand.php
@@ -38,7 +38,7 @@ class InstallActionNeedsExecutionCommand extends Command
         return getenv('TYPO3_CONSOLE_RENDERING_REFERENCE') === false;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $actionName = $input->getArgument('actionName');
         $installStepActionExecutor = new InstallStepActionExecutor(

--- a/Classes/Console/Command/Install/InstallDatabaseConnectCommand.php
+++ b/Classes/Console/Command/Install/InstallDatabaseConnectCommand.php
@@ -77,7 +77,7 @@ class InstallDatabaseConnectCommand extends Command
         return getenv('TYPO3_CONSOLE_RENDERING_REFERENCE') === false;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $databaseUserName = $input->getOption('database-user-name');
         $databaseUserPassword = $input->getOption('database-user-password');

--- a/Classes/Console/Command/Install/InstallDatabaseDataCommand.php
+++ b/Classes/Console/Command/Install/InstallDatabaseDataCommand.php
@@ -54,7 +54,7 @@ class InstallDatabaseDataCommand extends Command
         return getenv('TYPO3_CONSOLE_RENDERING_REFERENCE') === false;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $adminUserName = $input->getOption('admin-user-name');
         $adminPassword = $input->getOption('admin-password');

--- a/Classes/Console/Command/Install/InstallDatabaseSelectCommand.php
+++ b/Classes/Console/Command/Install/InstallDatabaseSelectCommand.php
@@ -47,7 +47,7 @@ class InstallDatabaseSelectCommand extends Command
         return getenv('TYPO3_CONSOLE_RENDERING_REFERENCE') === false;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $databaseName = $input->getOption('database-name');
         $useExistingDatabase = $input->getOption('use-existing-database');

--- a/Classes/Console/Command/Install/InstallDefaultConfigurationCommand.php
+++ b/Classes/Console/Command/Install/InstallDefaultConfigurationCommand.php
@@ -60,7 +60,7 @@ EOH
         return getenv('TYPO3_CONSOLE_RENDERING_REFERENCE') === false;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $siteSetupType = $input->getOption('site-setup-type');
         $arguments['siteUrl'] = $input->getOption('site-base-url');

--- a/Classes/Console/Command/Install/InstallEnvironmentAndFoldersCommand.php
+++ b/Classes/Console/Command/Install/InstallEnvironmentAndFoldersCommand.php
@@ -38,7 +38,7 @@ EOH
         return getenv('TYPO3_CONSOLE_RENDERING_REFERENCE') === false;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $installStepActionExecutor = new InstallStepActionExecutor(
             new SilentConfigurationUpgrade()

--- a/Classes/Console/Command/Install/InstallExtensionSetupIfPossibleCommand.php
+++ b/Classes/Console/Command/Install/InstallExtensionSetupIfPossibleCommand.php
@@ -45,7 +45,7 @@ EOH
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $commandDispatcher = CommandDispatcher::createFromCommandRun();
         try {

--- a/Classes/Console/Command/Install/InstallFixFolderStructureCommand.php
+++ b/Classes/Console/Command/Install/InstallFixFolderStructureCommand.php
@@ -42,7 +42,7 @@ EOH
      * @throws \TYPO3\CMS\Install\FolderStructure\Exception\InvalidArgumentException
      * @throws \TYPO3\CMS\Install\FolderStructure\Exception\RootNodeException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $folderStructureFactory = GeneralUtility::makeInstance(DefaultFactory::class);
         $messages = $folderStructureFactory

--- a/Classes/Console/Command/Install/InstallGeneratePackageStatesCommand.php
+++ b/Classes/Console/Command/Install/InstallGeneratePackageStatesCommand.php
@@ -77,12 +77,12 @@ EOH
         ]);
     }
 
-    public function isHidden()
+    public function isHidden(): bool
     {
         return !getenv('TYPO3_CONSOLE_RENDERING_REFERENCE') && Environment::isComposerMode();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (Environment::isComposerMode()) {
             $output->writeln('<error>The command "install:generatepackagestates" is not available, because TYPO3 does not need this file any more in Composer mode.</error>');

--- a/Classes/Console/Command/Install/InstallSetupCommand.php
+++ b/Classes/Console/Command/Install/InstallSetupCommand.php
@@ -174,7 +174,7 @@ EOH
         ]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $force = $input->getOption('force');
         $skipIntegrityCheck = $input->getOption('skip-integrity-check');

--- a/Classes/Console/Command/InstallTool/LockInstallToolCommand.php
+++ b/Classes/Console/Command/InstallTool/LockInstallToolCommand.php
@@ -38,7 +38,7 @@ class LockInstallToolCommand extends Command implements RelatableCommandInterfac
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!EnableFileService::checkInstallToolEnableFile()) {
             $output->writeln('<info>Install Tool is already locked.</info>');

--- a/Classes/Console/Command/Upgrade/UpgradeCheckExtensionCompatibilityCommand.php
+++ b/Classes/Console/Command/Upgrade/UpgradeCheckExtensionCompatibilityCommand.php
@@ -49,7 +49,7 @@ EOH
         );
     }
 
-    public function isHidden()
+    public function isHidden(): bool
     {
         return true;
     }
@@ -59,7 +59,7 @@ EOH
         return getenv('TYPO3_CONSOLE_RENDERING_REFERENCE') === false;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $extensionKey = $input->getArgument('extensionKey');
         $configOnly = $input->getOption('config-only');

--- a/Classes/Console/Command/Upgrade/UpgradeCheckExtensionConstraintsCommand.php
+++ b/Classes/Console/Command/Upgrade/UpgradeCheckExtensionConstraintsCommand.php
@@ -52,12 +52,12 @@ EOH
         ]);
     }
 
-    public function isHidden()
+    public function isHidden(): bool
     {
         return !getenv('TYPO3_CONSOLE_RENDERING_REFERENCE') && Environment::isComposerMode();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (Environment::isComposerMode()) {
             $output->writeln('<error>The command "upgrade:checkextensionconstraints" is not available in Composer mode, because Composer already enforces such constraints.</error>');

--- a/Classes/Console/Command/Upgrade/UpgradeListCommand.php
+++ b/Classes/Console/Command/Upgrade/UpgradeListCommand.php
@@ -35,7 +35,7 @@ class UpgradeListCommand extends Command
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $upgradeHandling = new UpgradeHandling();
         if (!$upgradeHandling->isUpgradePrepared()) {

--- a/Classes/Console/Command/Upgrade/UpgradePrepareCommand.php
+++ b/Classes/Console/Command/Upgrade/UpgradePrepareCommand.php
@@ -26,7 +26,7 @@ class UpgradePrepareCommand extends Command
         $this->setDescription('Executes preparational upgrade steps and checks basic extension compatibility');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $upgradeHandling = new UpgradeHandling();
         if ($upgradeHandling->isUpgradePrepared()) {

--- a/Classes/Console/Command/Upgrade/UpgradeRunCommand.php
+++ b/Classes/Console/Command/Upgrade/UpgradeRunCommand.php
@@ -123,7 +123,7 @@ EOH
         }
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->upgradeHandling = $this->upgradeHandling ?? new UpgradeHandling();
         if (!$this->upgradeHandling->isUpgradePrepared()) {

--- a/Classes/Console/Install/Upgrade/UpgradeWizardFactory.php
+++ b/Classes/Console/Install/Upgrade/UpgradeWizardFactory.php
@@ -50,7 +50,7 @@ class UpgradeWizardFactory
                 return GeneralUtility::makeInstance($id);
             }
 
-            public function has(string $id)
+            public function has(string $id): bool
             {
                 return true;
             }

--- a/Classes/Console/Mvc/Cli/Symfony/Application.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Application.php
@@ -228,7 +228,7 @@ class Application extends BaseApplication
         }
     }
 
-    protected function getDefaultInputDefinition()
+    protected function getDefaultInputDefinition(): InputDefinition
     {
         return new InputDefinition([
             new InputArgument('command', InputArgument::REQUIRED, 'The command to execute'),

--- a/Classes/Console/Mvc/Cli/Symfony/Command/HelpCommand.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Command/HelpCommand.php
@@ -86,7 +86,7 @@ EOF
      * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
      * @throws \Symfony\Component\Console\Exception\CommandNotFoundException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($this->command === null) {
             $this->command = $this->getApplication()->find($input->getArgument('command_name'));

--- a/Classes/Console/Mvc/Cli/Symfony/Command/ListCommand.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Command/ListCommand.php
@@ -66,7 +66,7 @@ EOF
      * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
      * @return null|int null or 0 if everything went fine, or an error code
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $helper = new DescriptorHelper();
         $helper->register('txt', new TextDescriptor());

--- a/Classes/Console/Mvc/Cli/Symfony/Output/TrackableOutput.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Output/TrackableOutput.php
@@ -63,7 +63,7 @@ class TrackableOutput extends ConsoleOutput
         return $this->outputTracked;
     }
 
-    public function getErrorOutput()
+    public function getErrorOutput(): OutputInterface
     {
         if ($this->output instanceof ConsoleOutput) {
             return $this->output->getErrorOutput();
@@ -96,7 +96,7 @@ class TrackableOutput extends ConsoleOutput
         $this->output->setVerbosity($level);
     }
 
-    public function getVerbosity()
+    public function getVerbosity(): int
     {
         return $this->output->getVerbosity();
     }
@@ -116,7 +116,7 @@ class TrackableOutput extends ConsoleOutput
         $this->output->setFormatter($formatter);
     }
 
-    public function getFormatter()
+    public function getFormatter(): OutputFormatterInterface
     {
         return $this->output->getFormatter();
     }


### PR DESCRIPTION
This change adds return types,
which are required for the compatibility
with Symfony 6.

This is a pre-patch for supporting
Symfony 4-6, however a few further changes
are necessary as well to provide
Symfony 6 compat.

It should be noted that
TYPO3 v11 LTS requires Symfony 5.4, and
TYPO3 v12 requires Symfony 6.x.

See https://github.com/TYPO3/typo3/blob/11.5/composer.json