### PR TITLE
[TASK] Drop support for Symfony 4 + add Symfony 6 support

### DIFF
--- a/Classes/Console/Error/ExceptionRenderer.php
+++ b/Classes/Console/Error/ExceptionRenderer.php
@@ -16,9 +16,9 @@ namespace Helhum\Typo3Console\Error;
 
 use Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException;
 use Helhum\Typo3Console\Mvc\Cli\SubProcessException;
+use Helhum\Typo3Console\SymfonyCompatibilityBridge;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Formatter\OutputFormatter;
-use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Terminal;
@@ -103,13 +103,13 @@ class ExceptionRenderer
 
         $title = sprintf('[ %s ]', $exceptionClass);
 
-        $messageLength = Helper::strlen($title);
+        $messageLength = SymfonyCompatibilityBridge::helperLength($title);
 
         $lines = [];
         foreach (preg_split('/\r?\n/', trim($exceptionMessage)) as $line) {
             foreach ($this->splitStringByWidth($line, $this->renderingWidth - 4) as $splitLine) {
                 $lines[] = $splitLine;
-                $messageLength = max(Helper::strlen($splitLine), $messageLength);
+                $messageLength = max(SymfonyCompatibilityBridge::helperLength($splitLine), $messageLength);
             }
         }
 

--- a/Classes/Console/Mvc/Cli/Symfony/Descriptor/TextDescriptor.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Descriptor/TextDescriptor.php
@@ -23,11 +23,11 @@ namespace Helhum\Typo3Console\Mvc\Cli\Symfony\Descriptor;
  * file that was distributed with this source code.
  */
 
+use Helhum\Typo3Console\SymfonyCompatibilityBridge;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Descriptor\ApplicationDescription;
 use Symfony\Component\Console\Formatter\OutputFormatter;
-use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
@@ -46,7 +46,7 @@ class TextDescriptor extends \Symfony\Component\Console\Descriptor\TextDescripto
      */
     protected function describeInputArgument(InputArgument $argument, array $options = [])
     {
-        $totalWidth = isset($options['total_width']) ? $options['total_width'] : Helper::strlen($argument->getName());
+        $totalWidth = isset($options['total_width']) ? $options['total_width'] : SymfonyCompatibilityBridge::helperLength($argument->getName());
         $spacingWidth = $totalWidth - strlen($argument->getName());
 
         // + 4 = 2 spaces before <info>, 2 spaces after </info>
@@ -98,7 +98,7 @@ class TextDescriptor extends \Symfony\Component\Console\Descriptor\TextDescripto
             sprintf('--%s%s', $option->getName(), $value)
         );
 
-        $spacingWidth = $totalWidth - Helper::strlen($synopsis);
+        $spacingWidth = $totalWidth - SymfonyCompatibilityBridge::helperLength($synopsis);
         $maxWidth = isset($options['screen_width']) ? ($options['screen_width'] - $indent) : null;
         $this->writeText(sprintf(
             '  <info>%s</info>  %s%s%s%s',
@@ -222,7 +222,7 @@ class TextDescriptor extends \Symfony\Component\Console\Descriptor\TextDescripto
                 $maxWidth = isset($options['screen_width']) ? ($options['screen_width'] - $indent) : null;
                 foreach ($namespace['commands'] as $name) {
                     $this->writeText("\n");
-                    $spacingWidth = $width - Helper::strlen($name);
+                    $spacingWidth = $width - SymfonyCompatibilityBridge::helperLength($name);
                     $command = $commands[$name];
                     $this->writeText(sprintf('  <info>%s</info>%s%s', $name, str_repeat(' ', $spacingWidth), $this->wordWrap((string)$command->getDescription(), $indent, $maxWidth)), $options);
                 }
@@ -293,12 +293,12 @@ class TextDescriptor extends \Symfony\Component\Console\Descriptor\TextDescripto
 
         foreach ($commands as $command) {
             if ($command instanceof Command) {
-                $widths[] = Helper::strlen($command->getName());
+                $widths[] = SymfonyCompatibilityBridge::helperLength($command->getName());
                 foreach ($command->getAliases() as $alias) {
-                    $widths[] = Helper::strlen($alias);
+                    $widths[] = SymfonyCompatibilityBridge::helperLength($alias);
                 }
             } else {
-                $widths[] = Helper::strlen($command);
+                $widths[] = SymfonyCompatibilityBridge::helperLength($command);
             }
         }
 
@@ -315,10 +315,10 @@ class TextDescriptor extends \Symfony\Component\Console\Descriptor\TextDescripto
         $totalWidth = 0;
         foreach ($options as $option) {
             // "-" + shortcut + ", --" + name
-            $nameLength = 1 + max(Helper::strlen($option->getShortcut()), 1) + 4 + Helper::strlen($option->getName());
+            $nameLength = 1 + max(SymfonyCompatibilityBridge::helperLength($option->getShortcut()), 1) + 4 + SymfonyCompatibilityBridge::helperLength($option->getName());
 
             if ($option->acceptValue()) {
-                $valueLength = 1 + Helper::strlen($option->getName()); // = + value
+                $valueLength = 1 + SymfonyCompatibilityBridge::helperLength($option->getName()); // = + value
                 $valueLength += $option->isValueOptional() ? 2 : 0; // [ + ]
 
                 $nameLength += $valueLength;

--- a/Classes/Console/SymfonyCompatibilityBridge.php
+++ b/Classes/Console/SymfonyCompatibilityBridge.php
@@ -35,6 +35,7 @@ class SymfonyCompatibilityBridge
         if (method_exists(Helper::class, 'length')) {
             return Helper::length($string);
         }
+
         return Helper::strlen($string);
     }
 }

--- a/Classes/Console/SymfonyCompatibilityBridge.php
+++ b/Classes/Console/SymfonyCompatibilityBridge.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3Console;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Symfony\Component\Console\Helper\Helper;
+
+/**
+ * Compatibility code to support symfony 5.0 and 6.0
+ */
+class SymfonyCompatibilityBridge
+{
+    /**
+     * Method Helper::length() was added in Symfony 5.2,
+     * while Helper::strlen() is needed for Symfony 5.0-5.1.
+     *
+     * See https://github.com/symfony/console/commit/f0671efd0e144681fd74ac1208ca0b5da8591b8a
+     *
+     * @param string $string
+     * @return int
+     */
+    public static function helperLength(string $string)
+    {
+        if (method_exists(Helper::class, 'length')) {
+            return Helper::length($string);
+        }
+        return Helper::strlen($string);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,8 @@
         "typo3/cms-frontend": "^11.5.3 || dev-main",
         "typo3/cms-install": "^11.5.3 || dev-main",
 
-        "symfony/console": "^4.4 || ^5.0",
-        "symfony/process": "^4.4 || ^5.0",
+        "symfony/console": "^5.0 || ^6.0",
+        "symfony/process": "^5.0 || ^6.0",
         "helhum/config-loader": ">=0.9 <0.13"
     },
     "require-dev": {
@@ -50,8 +50,8 @@
         "typo3/cms-recordlist": "^11.5.3 || dev-main",
         "typo3/cms-reports": "^11.5.3 || dev-main",
         "typo3-console/create-reference-command": "@dev",
-        "symfony/expression-language": "^4.4 || ^5.0",
-        "symfony/filesystem": "^4.4 || ^5.0",
+        "symfony/expression-language": "^5.0 || ^6.0",
+        "symfony/filesystem": "^5.0 || ^6.0",
         "nimut/testing-framework": "^6.0.1",
         "phpunit/phpunit": "^8.5.18",
         "php-parallel-lint/php-parallel-lint": "^1.2",


### PR DESCRIPTION
TYPO3 v11 supports Symfony 5.0 - 5.4 while TYPO3 v12
requires Symfony 6.x.

For this reason, support for Symfony 4 within TYPO3 Console
is removed, which was impossible before anyways.

In addition, Symfony 6 support is added.

For `Symfony\Console\Helper\Helper::width()` a
compatibility layer is added to support both Symfony 5.0
and Symfony 6.x.