### PR TITLE
[BUGFIX] Access class property closure correctly

### DIFF
--- a/Classes/Compatibility/CompatibilityClassLoader.php
+++ b/Classes/Compatibility/CompatibilityClassLoader.php
@@ -63,7 +63,7 @@ class CompatibilityClassLoader
         }
         $compatibilityClassName = str_replace('Helhum\\Typo3Console\\', $this->compatibilityNamespace, $class);
         if ($file = $this->originalClassLoader->findFile($compatibilityClassName)) {
-            $this->includeFile($file);
+            ($this->includeFile)($file);
             class_alias($compatibilityClassName, $class);
 
             return true;


### PR DESCRIPTION
Accessing the property closure directly throws an exception:

```
> typo3cms install:generatepackagestates
                                                                               
  [ Error ]                                                                    
  Call to undefined method Helhum\Typo3Console\CompatibilityClassLoader::includeFile()                                                                    
                                                                               
Exception trace:
#0 ()
   app/vendor/helhum/typo3-console/Classes/Compatibility/CompatibilityClassLoader.php:66
#1 Helhum\Typo3Console\CompatibilityClassLoader->loadClass()
#2 spl_autoload_call()
   app/vendor/helhum/typo3-console/Classes/Console/Core/Kernel.php:94
#3 Helhum\Typo3Console\Core\Kernel->handle()
   app/vendor/helhum/typo3-console/Scripts/typo3-console.php:31
#4 {closure}()
   app/vendor/helhum/typo3-console/Scripts/typo3-console.php:33
#5 require()
   app/vendor/helhum/typo3-console/typo3cms:2
#6 include()
   app/vendor/bin/typo3cms:115
```

Related: #1082
Resolves: #1081