### PR TITLE
[BUGFIX] Log all errors the same way

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
 
         "symfony/console": "^5.0 || ^6.0",
         "symfony/process": "^5.0 || ^6.0",
-        "helhum/config-loader": ">=0.9 <0.13"
+        "helhum/config-loader": ">=0.9 <0.13",
+        "helhum/php-error-reporting": "^1.0"
     },
     "require-dev": {
         "typo3/cms-filemetadata": "^11.5.3 || dev-main",


### PR DESCRIPTION
Instead of only having nice error exceptions for warnings,
now all other errors are converted into an exception
with the help of a recently published package.