### PR TITLE
[TASK] Use new project directory layout

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ To achieve this, you need to acquire the TYPO3 Console source code:
 2. Download the [`composer.phar`](https://getcomposer.org/composer.phar) executable
 3. Run Composer to get the dependencies: `cd typo3_console && php ../composer.phar install`
 
-You can run the test suite by executing `.Build/bin/phpunit` when inside the
+You can run the test suite by executing `vendor/bin/phpunit` when inside the
 typo3_console directory. Please note, that some of these tests need a database connection
 with a database user that is allowed to create databases. By default user `root` with no password is used.
 

--- a/.github/workflows/Analyze.yml
+++ b/.github/workflows/Analyze.yml
@@ -53,7 +53,7 @@ jobs:
                     if [ -n "${{ secrets.SONAR_TOKEN }}" ]; then
                         export COMPOSER_ROOT_VERSION=7.1.6
                         composer update
-                        .Build/bin/phpunit --whitelist Classes --coverage-clover .Build/clover.xml --log-junit .Build/junit.xml
+                        vendor/bin/phpunit --whitelist Classes --coverage-clover var/clover.xml --log-junit var/junit.xml
                     fi
 
             -   name: Setup sonarqube

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -133,7 +133,7 @@ jobs:
                     composer update --with "typo3/cms-core:${{ matrix.typo3 }}" --prefer-${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             -   name: Lint
-                run: php .Build/bin/parallel-lint --exclude .Build .
+                run: php vendor/bin/parallel-lint  --exclude vendor --exclude var --exclude public .
 
             # This fails when command reference is not up to date
             -   name: Test Command Reference
@@ -152,14 +152,14 @@ jobs:
 
             -   name: Test
                 if: matrix.os == 'ubuntu-latest' && !matrix.experimental
-                run: .Build/bin/phpunit
+                run: vendor/bin/phpunit
 
             -   name: Test - allow failure
                 if: matrix.experimental
-                run: .Build/bin/phpunit || true
+                run: vendor/bin/phpunit || true
 
             -   name: Test - Windows
                 if: matrix.os == 'windows-latest'
                 env:
                     TYPO3_INSTALL_DB_DRIVER: pdo_sqlite
-                run: .Build/bin/phpunit
+                run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-/.Build/*
+/config
+/public
+/var
+/vendor
 /Classes/Console/Hook/*
 /Configuration/ComposerPackagesCommands.php
 /Documentation-GENERATED-temp

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -5,7 +5,9 @@ if (PHP_SAPI !== 'cli') {
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
-    ->exclude('.Build')
+    ->exclude('vendor')
+    ->exclude('public')
+    ->exclude('var')
     ->exclude('Documentation')
     ->exclude('Libraries')
     ->notName('ext_emconf.php')

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -66,7 +66,9 @@ finder:
   name:
     - "*.php"
   exclude:
-    - ".Build"
+    - "vendor"
+    - "public"
+    - "var"
     - "Documentation"
     - "Libraries"
   not-name:

--- a/Classes/Console/Composer/InstallerScript/PopulateCommandConfiguration.php
+++ b/Classes/Console/Composer/InstallerScript/PopulateCommandConfiguration.php
@@ -50,7 +50,7 @@ class PopulateCommandConfiguration implements InstallerScript
         foreach ($this->extractPackageMapFromComposer($composer) as [$package, $installPath]) {
             /** @var PackageInterface $package */
             $installPath = ($installPath ?: $basePath);
-            if (in_array($package->getType(), ['metapackage', 'typo3-cms-extension', 'typo3-cms-framework'], true)) {
+            if ($installPath !== $basePath && in_array($package->getType(), ['metapackage', 'typo3-cms-extension', 'typo3-cms-framework'], true)) {
                 // Commands in TYPO3 extensions are not scanned any more. They should rather use DI configuration to register commands.
                 // Since meta packages have no code, thus cannot include any commands, we ignore them as well.
                 continue;

--- a/Scripts/typo3-console.php
+++ b/Scripts/typo3-console.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 (static function () {
     if ($vendorAutoLoadFile = $GLOBALS['_composer_autoload_path'] ?? null) {
         $classLoader = require $vendorAutoLoadFile;
-    } elseif (file_exists($vendorAutoLoadFile = dirname(__DIR__) . '/.Build/vendor/autoload.php')) {
-        // Console is root package, thus vendor folder is .Build/vendor
+    } elseif (file_exists($vendorAutoLoadFile = dirname(__DIR__) . '/vendor/autoload.php')) {
+        // Console is root package, thus vendor folder is /vendor
         $classLoader = require $vendorAutoLoadFile;
     } elseif (file_exists($vendorAutoLoadFile = dirname(dirname(dirname(__DIR__))) . '/autoload.php')) {
         // Console is a dependency, thus located in vendor/helhum/typo3-console

--- a/Tests/Console/Functional/Command/AbstractCommandTest.php
+++ b/Tests/Console/Functional/Command/AbstractCommandTest.php
@@ -17,13 +17,14 @@ namespace Helhum\Typo3Console\Tests\Functional\Command;
 use Helhum\Typo3Console\Error\ExceptionRenderer;
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
 use Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-abstract class AbstractCommandTest extends \PHPUnit\Framework\TestCase
+abstract class AbstractCommandTest extends TestCase
 {
     /**
      * @var CommandDispatcher
@@ -33,7 +34,7 @@ abstract class AbstractCommandTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         if (!file_exists(getenv('TYPO3_PATH_ROOT') . '/index.php')
-            && strpos(getenv('TYPO3_PATH_ROOT'), '.Build/public') === false
+            && strpos(getenv('TYPO3_PATH_ROOT'), '/public') === false
         ) {
             throw new \RuntimeException('TYPO3_PATH_ROOT is not properly set!', 1493574402);
         }

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         }
     },
     "name": "helhum/typo3-console",
+    "type": "typo3-cms-extension",
     "description": "A reliable and powerful command line interface for TYPO3 CMS",
     "keywords": [
         "TYPO3",
@@ -47,6 +48,7 @@
         "helhum/php-error-reporting": "^1.0"
     },
     "require-dev": {
+        "typo3/cms-composer-installers": "^4.0@rc || ^5.0",
         "typo3/cms-filemetadata": "^11.5.3 || dev-main",
         "typo3/cms-recordlist": "^11.5.3 || dev-main",
         "typo3/cms-reports": "^11.5.3 || dev-main",
@@ -81,8 +83,6 @@
         "preferred-install": {
             "*": "dist"
         },
-        "vendor-dir": ".Build/vendor",
-        "bin-dir": ".Build/bin",
         "allow-plugins": {
             "typo3/class-alias-loader": true,
             "typo3/cms-composer-installers": true
@@ -130,12 +130,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "7.1.x-dev"
+            "dev-main": "8.0.x-dev"
         },
         "typo3/cms": {
-            "ignore-as-root": false,
-            "app-dir": ".Build",
-            "web-dir": ".Build/public"
+            "extension-key": "typo3_console",
+            "ignore-as-root": false
         }
     }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.projectKey=typo3-console
 sonar.projectName=TYPO3 Console
 sonar.projectVersion=7.1.6
 sonar.sources=.
-sonar.exclusions=.Build/**, .github/**, Tests/**, Resources/**, Documentation/**, Configuration/**
+sonar.exclusions=public/**, var/**, vendor/**, .github/**, Tests/**, Resources/**, Documentation/**, Configuration/**
 
 # Ignore issues on multiple criteria
 sonar.issue.ignore.multicriteria = e1,e2
@@ -22,5 +22,5 @@ sonar.dbcleaner.weeksBeforeKeepingOnlyOneSnapshotByWeek=12
 sonar.dbcleaner.weeksBeforeKeepingOnlyOneSnapshotByMonth=52
 
 # PHPUnit test and coverage results import
-sonar.php.tests.reportPath=.Build/junit.xml
-sonar.php.coverage.reportPaths=.Build/clover.xml
+sonar.php.tests.reportPath=var/junit.xml
+sonar.php.coverage.reportPaths=var/clover.xml


### PR DESCRIPTION
TYPO3 12 and 11 with composer installers 4
use a different directory layout, which needs to be respected
for the test setup