### PR TITLE
!!![BUGFIX] Require current versions of composer installers

### DIFF
--- a/Resources/Private/ExtensionArtifacts/composer.json
+++ b/Resources/Private/ExtensionArtifacts/composer.json
@@ -56,6 +56,7 @@
     },
     "replace": {
         "typo3/cms-backend": "*",
+        "typo3/cms-composer-installers": "*",
         "typo3/cms-core": "*",
         "typo3/cms-extbase": "*",
         "typo3/cms-extensionmanager": "*",

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "composer-runtime-api": "^2.1",
 
         "typo3/cms-backend": "^11.5.3 || dev-main",
+        "typo3/cms-composer-installers": "^4.0@rc || >=5.0",
         "typo3/cms-core": "^11.5.3 || dev-main",
         "typo3/cms-extbase": "^11.5.3 || dev-main",
         "typo3/cms-extensionmanager": "^11.5.3 || dev-main",
@@ -48,7 +49,6 @@
         "helhum/php-error-reporting": "^1.0"
     },
     "require-dev": {
-        "typo3/cms-composer-installers": "^4.0@rc || ^5.0",
         "typo3/cms-filemetadata": "^11.5.3 || dev-main",
         "typo3/cms-recordlist": "^11.5.3 || dev-main",
         "typo3/cms-reports": "^11.5.3 || dev-main",


### PR DESCRIPTION
TYPO3 Console should never be installed in a
typo3conf/ext folder, thus new versions composer installers are required