### PR TITLE
[BUGFIX] Add new tables first when updating DB schema

### DIFF
--- a/Classes/Console/Database/Schema/SchemaUpdateType.php
+++ b/Classes/Console/Database/Schema/SchemaUpdateType.php
@@ -23,6 +23,16 @@ use TYPO3\CMS\Core\Type\Exception\InvalidEnumerationValueException;
 class SchemaUpdateType extends Enumeration
 {
     /**
+     * Add a table
+     */
+    const TABLE_ADD = 'table.add';
+
+    /**
+     * Change a table
+     */
+    const TABLE_CHANGE = 'table.change';
+
+    /**
      * Add a field
      */
     const FIELD_ADD = 'field.add';
@@ -41,16 +51,6 @@ class SchemaUpdateType extends Enumeration
      * Drop a field
      */
     const FIELD_DROP = 'field.drop';
-
-    /**
-     * Add a table
-     */
-    const TABLE_ADD = 'table.add';
-
-    /**
-     * Change a table
-     */
-    const TABLE_CHANGE = 'table.change';
 
     /**
      * Prefix a table
@@ -87,10 +87,10 @@ class SchemaUpdateType extends Enumeration
         self::TABLE_PREFIX => ['change_table' => self::GROUP_DESTRUCTIVE],
         self::TABLE_DROP => ['drop_table' => self::GROUP_DESTRUCTIVE],
         self::GROUP_SAFE => [
-            self::FIELD_ADD,
-            self::FIELD_CHANGE,
             self::TABLE_ADD,
             self::TABLE_CHANGE,
+            self::FIELD_ADD,
+            self::FIELD_CHANGE,
         ],
         self::GROUP_DESTRUCTIVE => [
             self::FIELD_PREFIX,
@@ -99,12 +99,12 @@ class SchemaUpdateType extends Enumeration
             self::TABLE_DROP,
         ],
         '*' => [
+            self::TABLE_ADD,
+            self::TABLE_CHANGE,
             self::FIELD_ADD,
             self::FIELD_CHANGE,
             self::FIELD_PREFIX,
             self::FIELD_DROP,
-            self::TABLE_ADD,
-            self::TABLE_CHANGE,
             self::TABLE_PREFIX,
             self::TABLE_DROP,
         ],

--- a/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
@@ -25,7 +25,7 @@ class DatabaseCommandControllerTest extends AbstractCommandTest
     {
         $output = $this->executeConsoleCommand('database:updateschema');
         $this->assertStringContainsString('No schema updates were performed for update types:', $output);
-        $this->assertStringContainsString('"field.add", "field.change", "table.add", "table.change"', $output);
+        $this->assertStringContainsString('"table.add", "table.change", "field.add", "field.change"', $output);
     }
 
     /**
@@ -35,7 +35,7 @@ class DatabaseCommandControllerTest extends AbstractCommandTest
     {
         $output = $this->executeConsoleCommand('database:updateschema', ['field.add,table.add', '--verbose']);
         $this->assertStringContainsString('No schema updates were performed for update types:', $output);
-        $this->assertStringContainsString('"field.add", "table.add"', $output);
+        $this->assertStringContainsString('"table.add", "field.add"', $output);
     }
 
     /**
@@ -45,7 +45,7 @@ class DatabaseCommandControllerTest extends AbstractCommandTest
     {
         $output = $this->executeConsoleCommand('database:updateschema', ['*', '--verbose']);
         $this->assertStringContainsString('No schema updates were performed for update types:', $output);
-        $this->assertStringContainsString('"field.add", "field.change", "field.prefix", "field.drop", "table.add", "table.change", "table.prefix", "table.drop"', $output);
+        $this->assertStringContainsString('"table.add", "table.change", "field.add", "field.change", "field.prefix", "field.drop", "table.prefix", "table.drop"', $output);
     }
 
     /**

--- a/Tests/Console/Unit/Database/Schema/SchemaUpdateTypeTest.php
+++ b/Tests/Console/Unit/Database/Schema/SchemaUpdateTypeTest.php
@@ -29,12 +29,12 @@ class SchemaUpdateTypeTest extends TestCase
             'all' => [
                 ['*'],
                 [
+                    'table.add',
+                    'table.change',
                     'field.add',
                     'field.change',
                     'field.prefix',
                     'field.drop',
-                    'table.add',
-                    'table.change',
                     'table.prefix',
                     'table.drop',
                 ],
@@ -42,12 +42,12 @@ class SchemaUpdateTypeTest extends TestCase
             'all double' => [
                 ['*', '*'],
                 [
+                    'table.add',
+                    'table.change',
                     'field.add',
                     'field.change',
                     'field.prefix',
                     'field.drop',
-                    'table.add',
-                    'table.change',
                     'table.prefix',
                     'table.drop',
                 ],
@@ -73,15 +73,15 @@ class SchemaUpdateTypeTest extends TestCase
             'all add' => [
                 ['*.add'],
                 [
-                    'field.add',
                     'table.add',
+                    'field.add',
                 ],
             ],
             'all change' => [
                 ['*.change'],
                 [
-                    'field.change',
                     'table.change',
+                    'field.change',
                 ],
             ],
             'all prefix' => [
@@ -101,10 +101,10 @@ class SchemaUpdateTypeTest extends TestCase
             'all safe' => [
                 ['safe'],
                 [
-                    'field.add',
-                    'field.change',
                     'table.add',
                     'table.change',
+                    'field.add',
+                    'field.change',
                 ],
             ],
             'all destructive' => [


### PR DESCRIPTION
When cache tables should be created, e.g. when a new DB cache
backend is introduced, and at the same time other change
updates are to be applied, then the schema update fails,
because after performing each schema update type,
TYPO3 flushes caches, which then will fail, when cache
tables have not been created yet.