### PR TITLE
[FEATURE] Basic MySQL SSL support for database import and export command

### DIFF
--- a/Classes/Console/Database/Process/MysqlCommand.php
+++ b/Classes/Console/Database/Process/MysqlCommand.php
@@ -116,6 +116,9 @@ class MysqlCommand
             $arguments[] = '-S';
             $arguments[] = $this->dbConfig['unix_socket'];
         }
+        if (isset($this->dbConfig['driverOptions']['flags']) && (int)$this->dbConfig['driverOptions']['flags'] === MYSQLI_CLIENT_SSL) {
+            $arguments[] = '--ssl';
+        }
         $arguments[] = $this->dbConfig['dbname'];
 
         return $arguments;


### PR DESCRIPTION
Simple check to add ssl flag into connection arguments.

relates to #1141