### PR TITLE
Use siteBaseUrl instead of siteUrl for install step argument definition

### DIFF
--- a/Configuration/Install/InstallSteps.yaml
+++ b/Configuration/Install/InstallSteps.yaml
@@ -115,7 +115,7 @@ defaultConfiguration:
                 site: 'Create root page'
             value: '%env(TYPO3_INSTALL_SITE_SETUP_TYPE)%'
             default: 'no'
-        siteUrl:
+        siteBaseUrl:
             condition: 'siteSetupType == "site"'
             description: 'Specify the site base url'
             option: '--site-base-url'

--- a/Tests/Console/Functional/Fixtures/Install/mysql-install.yaml
+++ b/Tests/Console/Functional/Fixtures/Install/mysql-install.yaml
@@ -36,7 +36,7 @@ defaultConfiguration:
     arguments:
         siteSetupType:
             value: 'site'
-        siteUrl:
+        siteBaseUrl:
             value: '/'
 
 writeWebserverConfiguration:

--- a/Tests/Console/Functional/Fixtures/Install/sqlite-install.yaml
+++ b/Tests/Console/Functional/Fixtures/Install/sqlite-install.yaml
@@ -36,7 +36,7 @@ defaultConfiguration:
     arguments:
         siteSetupType:
             value: 'site'
-        siteUrl:
+        siteBaseUrl:
             value: '/'
 
 writeWebserverConfiguration:


### PR DESCRIPTION
`\Helhum\Typo3Console\Install\Action\InteractiveActionArguments::populate` loops over the argument definitions of the install step by name. The input options from the `install:setup` command define `--site-base-url`, which is translated to the givenArguments key `siteBaseUrl`.

Passing a base URL other than `/` to `--site-base-url` did not work at all, because the code looked for a `siteUrl` option instead.