### PR TITLE
[TASK] Disable tests agains TYPO3 dev-main for now

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -68,11 +68,11 @@ jobs:
                 dependency-version: [ lowest, stable ]
                 experimental: [ false ]
                 include:
-                    -   os: 'ubuntu-latest'
-                        php: 8.1
-                        typo3: dev-main
-                        dependency-version: stable
-                        experimental: true
+#                    -   os: 'ubuntu-latest'
+#                        php: 8.2
+#                        typo3: dev-main
+#                        dependency-version: stable
+#                        experimental: true
                     -   os: 'windows-latest'
                         php: 8.1
                         typo3: '^11.5.26'


### PR DESCRIPTION
Testing against this TYPO3 branch at this point in time
is pointless, as too many things are broken. These
tests will be enabled, once working on compatibility with TYPO3 13