### PR TITLE
[BUGFIX] Avoid implicitly nullable parameter declarations

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -79,6 +79,7 @@ return (new PhpCsFixer\Config)
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,
         'normalize_index_brace' => true,
+        'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'ordered_imports' => true,
         'phpdoc_add_missing_param_annotation' => true,

--- a/Classes/Console/Database/Configuration/ConnectionConfiguration.php
+++ b/Classes/Console/Database/Configuration/ConnectionConfiguration.php
@@ -22,7 +22,7 @@ class ConnectionConfiguration
      * @param string|null $name
      * @return array
      */
-    public function build(string $name = null): array
+    public function build(?string $name = null): array
     {
         if ($name === null) {
             return $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'];

--- a/Classes/Console/Database/Process/MysqlCommand.php
+++ b/Classes/Console/Database/Process/MysqlCommand.php
@@ -35,7 +35,7 @@ class MysqlCommand
      */
     private $output;
 
-    public function __construct(array $dbConfig, ConsoleOutput $output = null)
+    public function __construct(array $dbConfig, ?ConsoleOutput $output = null)
     {
         $this->dbConfig = $dbConfig;
         $this->output = $output ?: new ConsoleOutput(); // output being optional is @deprecated. Will become required in 6.0

--- a/Classes/Console/Database/Schema/SchemaUpdate.php
+++ b/Classes/Console/Database/Schema/SchemaUpdate.php
@@ -40,7 +40,7 @@ class SchemaUpdate implements SchemaUpdateInterface, SingletonInterface
      * @param SqlReader $sqlReader
      * @param SchemaMigrator $schemaMigrator
      */
-    public function __construct(SqlReader $sqlReader = null, SchemaMigrator $schemaMigrator = null)
+    public function __construct(?SqlReader $sqlReader = null, ?SchemaMigrator $schemaMigrator = null)
     {
         $this->sqlReader = $sqlReader ?: GeneralUtility::makeInstance(SqlReader::class);
         $this->schemaMigrator = $schemaMigrator ?: GeneralUtility::makeInstance(SchemaMigrator::class);

--- a/Classes/Console/Error/ExceptionRenderer.php
+++ b/Classes/Console/Error/ExceptionRenderer.php
@@ -32,7 +32,7 @@ class ExceptionRenderer
      */
     private $renderingWidth;
 
-    public function __construct(int $renderingWidth = null)
+    public function __construct(?int $renderingWidth = null)
     {
         if ($renderingWidth === null) {
             $terminal = new Terminal();
@@ -48,7 +48,7 @@ class ExceptionRenderer
      * @param OutputInterface $output
      * @param Application|null $application
      */
-    public function render(\Throwable $exception, OutputInterface $output, Application $application = null)
+    public function render(\Throwable $exception, OutputInterface $output, ?Application $application = null)
     {
         if ($output instanceof ConsoleOutput) {
             $output = $output->getErrorOutput();
@@ -187,7 +187,7 @@ class ExceptionRenderer
         }
     }
 
-    private function outputSynopsis(OutputInterface $output, Application $application = null)
+    private function outputSynopsis(OutputInterface $output, ?Application $application = null)
     {
         if (!$application || getenv('TYPO3_CONSOLE_SUB_PROCESS')) {
             return;
@@ -271,7 +271,7 @@ class ExceptionRenderer
      * @param \Throwable $exception
      * @return array|null
      */
-    private function serializeException(\Throwable $exception = null)
+    private function serializeException(?\Throwable $exception = null)
     {
         $serializedException = null;
         if ($exception) {

--- a/Classes/Console/Install/Action/InstallActionDispatcher.php
+++ b/Classes/Console/Install/Action/InstallActionDispatcher.php
@@ -42,10 +42,10 @@ class InstallActionDispatcher
     private $installActionFactory;
 
     public function __construct(
-        ConsoleOutput $output = null,
-        CommandDispatcher $commandDispatcher = null,
-        StepsConfig $stepsConfig = null,
-        InstallActionFactory $installActionFactory = null
+        ?ConsoleOutput $output = null,
+        ?CommandDispatcher $commandDispatcher = null,
+        ?StepsConfig $stepsConfig = null,
+        ?InstallActionFactory $installActionFactory = null
     ) {
         $this->output = $output ?: new ConsoleOutput();
         $commandDispatcher = $commandDispatcher ?: CommandDispatcher::createFromCommandRun();
@@ -53,7 +53,7 @@ class InstallActionDispatcher
         $this->installActionFactory = $installActionFactory ?: new InstallActionFactory($this->output, $commandDispatcher);
     }
 
-    public function dispatch(array $givenArguments, array $options = [], string $stepsConfigFile = null): bool
+    public function dispatch(array $givenArguments, array $options = [], ?string $stepsConfigFile = null): bool
     {
         try {
             $installSteps = $this->stepsConfig->getInstallSteps($stepsConfigFile);

--- a/Classes/Console/Install/InstallStepActionExecutor.php
+++ b/Classes/Console/Install/InstallStepActionExecutor.php
@@ -48,7 +48,7 @@ class InstallStepActionExecutor
     /**
      * @param SilentConfigurationUpgrade $silentConfigurationUpgrade
      */
-    public function __construct(SilentConfigurationUpgrade $silentConfigurationUpgrade, InstallerController $installerController = null, callable $requestFactory = null)
+    public function __construct(SilentConfigurationUpgrade $silentConfigurationUpgrade, ?InstallerController $installerController = null, ?callable $requestFactory = null)
     {
         $this->silentConfigurationUpgrade = $silentConfigurationUpgrade;
         $this->installerController = $installerController ?? GeneralUtility::makeInstance(InstallerController::class);

--- a/Classes/Console/Install/StepsConfig.php
+++ b/Classes/Console/Install/StepsConfig.php
@@ -24,12 +24,12 @@ class StepsConfig
      */
     private $baseConfigFile;
 
-    public function __construct(string $baseConfigFile = null)
+    public function __construct(?string $baseConfigFile = null)
     {
         $this->baseConfigFile = $baseConfigFile ?: __DIR__ . '/../../../Configuration/Install/InstallSteps.yaml';
     }
 
-    public function getInstallSteps(string $stepsConfigFile = null): array
+    public function getInstallSteps(?string $stepsConfigFile = null): array
     {
         $stepsConfigFile = $stepsConfigFile ?: (string)getenv('TYPO3_INSTALL_SETUP_STEPS') ?: $this->baseConfigFile;
         $stepsConfigFile = (string)realpath($stepsConfigFile);

--- a/Classes/Console/Install/Upgrade/SilentConfigurationUpgrade.php
+++ b/Classes/Console/Install/Upgrade/SilentConfigurationUpgrade.php
@@ -33,7 +33,7 @@ class SilentConfigurationUpgrade
      */
     private $configurationManager;
 
-    public function __construct(ConfigurationManager $configurationManager = null)
+    public function __construct(?ConfigurationManager $configurationManager = null)
     {
         $this->configurationManager = $configurationManager ?: GeneralUtility::makeInstance(ConfigurationManager::class);
     }

--- a/Classes/Console/Install/Upgrade/UpgradeHandling.php
+++ b/Classes/Console/Install/Upgrade/UpgradeHandling.php
@@ -62,12 +62,12 @@ class UpgradeHandling
     private Typo3Version $typo3Version;
 
     public function __construct(
-        UpgradeWizardFactory $factory = null,
-        UpgradeWizardExecutor $executor = null,
-        UpgradeWizardList $upgradeWizardList = null,
-        SilentConfigurationUpgrade $silentConfigurationUpgrade = null,
-        CommandDispatcher $commandDispatcher = null,
-        ConfigurationService $configurationService = null,
+        ?UpgradeWizardFactory $factory = null,
+        ?UpgradeWizardExecutor $executor = null,
+        ?UpgradeWizardList $upgradeWizardList = null,
+        ?SilentConfigurationUpgrade $silentConfigurationUpgrade = null,
+        ?CommandDispatcher $commandDispatcher = null,
+        ?ConfigurationService $configurationService = null,
     ) {
         $this->factory = $factory ?: new UpgradeWizardFactory();
         $this->executor = $executor ?: new UpgradeWizardExecutor($this->factory);

--- a/Classes/Console/Install/Upgrade/UpgradeWizardExecutor.php
+++ b/Classes/Console/Install/Upgrade/UpgradeWizardExecutor.php
@@ -37,7 +37,7 @@ class UpgradeWizardExecutor
      */
     private $upgradeWizardsService;
 
-    public function __construct(UpgradeWizardFactory $factory = null, UpgradeWizardsService $upgradeWizardsService = null)
+    public function __construct(?UpgradeWizardFactory $factory = null, ?UpgradeWizardsService $upgradeWizardsService = null)
     {
         $this->factory = $factory ?? new UpgradeWizardFactory();
         $this->upgradeWizardsService = $upgradeWizardsService ?? GeneralUtility::makeInstance(UpgradeWizardsService::class);

--- a/Classes/Console/Install/Upgrade/UpgradeWizardFactory.php
+++ b/Classes/Console/Install/Upgrade/UpgradeWizardFactory.php
@@ -41,8 +41,8 @@ class UpgradeWizardFactory
      * @param array $wizardRegistry
      */
     public function __construct(
-        ContainerInterface $container = null,
-        array $wizardRegistry = null
+        ?ContainerInterface $container = null,
+        ?array $wizardRegistry = null
     ) {
         $this->container = $container ?: new class() implements ContainerInterface {
             public function get(string $id)

--- a/Classes/Console/Install/Upgrade/UpgradeWizardList.php
+++ b/Classes/Console/Install/Upgrade/UpgradeWizardList.php
@@ -51,10 +51,10 @@ class UpgradeWizardList
     private $upgradeWizardsService;
 
     public function __construct(
-        UpgradeWizardFactory $factory = null,
-        Registry $registry = null,
+        ?UpgradeWizardFactory $factory = null,
+        ?Registry $registry = null,
         array $wizardRegistry = [],
-        UpgradeWizardsService $upgradeWizardsService = null
+        ?UpgradeWizardsService $upgradeWizardsService = null
     ) {
         $this->factory = $factory ?: new UpgradeWizardFactory();
         $this->registry = $registry ?: GeneralUtility::makeInstance(Registry::class);

--- a/Classes/Console/Mvc/Cli/CommandDispatcher.php
+++ b/Classes/Console/Mvc/Cli/CommandDispatcher.php
@@ -54,7 +54,7 @@ class CommandDispatcher
     /**
      * Create the dispatcher from within a composer plugin context
      */
-    public static function createFromComposerRun(ScriptEvent|string $scriptEventOrCommandPath, array $commandLine = [], array $environmentVars = [], PhpExecutableFinder $phpFinder = null): self
+    public static function createFromComposerRun(ScriptEvent|string $scriptEventOrCommandPath, array $commandLine = [], array $environmentVars = [], ?PhpExecutableFinder $phpFinder = null): self
     {
         $typo3CommandPath = $scriptEventOrCommandPath;
         if ($scriptEventOrCommandPath instanceof ScriptEvent) {
@@ -76,7 +76,7 @@ class CommandDispatcher
      * @throws RuntimeException
      * @return CommandDispatcher
      */
-    public static function createFromCommandRun(array $commandLine = [], array $environmentVars = [], PhpExecutableFinder $phpFinder = null): self
+    public static function createFromCommandRun(array $commandLine = [], array $environmentVars = [], ?PhpExecutableFinder $phpFinder = null): self
     {
         if (!isset($_SERVER['argv'][0]) || strpos($_SERVER['argv'][0], Application::COMMAND_NAME) === false) {
             throw new RuntimeException('Tried to create typo3 command runner from wrong context', 1484945065);
@@ -115,7 +115,7 @@ class CommandDispatcher
      * @throws RuntimeException
      * @return CommandDispatcher
      */
-    public static function create($typo3CommandPath, array $commandLine = [], array $environmentVars = [], PhpExecutableFinder $phpFinder = null): self
+    public static function create($typo3CommandPath, array $commandLine = [], array $environmentVars = [], ?PhpExecutableFinder $phpFinder = null): self
     {
         $environmentVars['TYPO3_CONSOLE_SUB_PROCESS'] = $environmentVars['TYPO3_CONSOLE_SUB_PROCESS'] ?? '1';
         $phpFinder = $phpFinder ?: new PhpExecutableFinder();

--- a/Classes/Console/Mvc/Cli/ConsoleOutput.php
+++ b/Classes/Console/Mvc/Cli/ConsoleOutput.php
@@ -73,7 +73,7 @@ class ConsoleOutput
      * @param Output|null $output
      * @param Input|null $input
      */
-    public function __construct(Output $output = null, Input $input = null)
+    public function __construct(?Output $output = null, ?Input $input = null)
     {
         $this->output = new TrackableOutput($output ?: new SymfonyConsoleOutput());
         $this->output->getFormatter()->setStyle('b', new OutputFormatterStyle(null, null, ['bold']));
@@ -216,7 +216,7 @@ class ConsoleOutput
      * @throws \Symfony\Component\Console\Exception\RuntimeException
      * @return string The user answer
      */
-    public function ask($question, $default = null, array $autocomplete = null)
+    public function ask($question, $default = null, ?array $autocomplete = null)
     {
         $question = (new Question($question, $default))
             ->setAutocompleterValues($autocomplete);
@@ -275,7 +275,7 @@ class ConsoleOutput
      * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
      * @return mixed
      */
-    public function askAndValidate($question, $validator, $attempts = false, $default = null, array $autocomplete = null)
+    public function askAndValidate($question, $validator, $attempts = false, $default = null, ?array $autocomplete = null)
     {
         $question = (new Question($question, $default))
             ->setValidator($validator)

--- a/Classes/Console/Mvc/Cli/Symfony/Input/ArgvInput.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Input/ArgvInput.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class ArgvInput extends \Symfony\Component\Console\Input\ArgvInput
 {
-    public function __construct(InputInterface $input = null)
+    public function __construct(?InputInterface $input = null)
     {
         if ($input instanceof \Symfony\Component\Console\Input\ArgvInput) {
             $this->options = $input->options;

--- a/Classes/Console/Mvc/Cli/Symfony/Output/TrackableOutput.php
+++ b/Classes/Console/Mvc/Cli/Symfony/Output/TrackableOutput.php
@@ -35,7 +35,7 @@ class TrackableOutput extends ConsoleOutput
      */
     private $parentOutput;
 
-    public function __construct(OutputInterface $output, self $parentOutput = null)
+    public function __construct(OutputInterface $output, ?self $parentOutput = null)
     {
         $this->output = $output;
         $this->parentOutput = $parentOutput;

--- a/Classes/Console/Service/CacheService.php
+++ b/Classes/Console/Service/CacheService.php
@@ -33,7 +33,7 @@ class CacheService implements SingletonInterface
      */
     protected $cacheConfiguration;
 
-    public function __construct(array $cacheConfiguration = null)
+    public function __construct(?array $cacheConfiguration = null)
     {
         // We need a new instance here to get the real caches instead of the disabled ones
         $this->cacheManager = new CacheManager();
@@ -88,7 +88,7 @@ class CacheService implements SingletonInterface
      * @param array $groups
      * @throws NoSuchCacheGroupException
      */
-    public function flushByTagsAndGroups(array $tags, array $groups = null): void
+    public function flushByTagsAndGroups(array $tags, ?array $groups = null): void
     {
         if ($groups === null) {
             $this->flushByTags($tags);

--- a/Classes/Console/Service/Configuration/ConfigurationService.php
+++ b/Classes/Console/Service/Configuration/ConfigurationService.php
@@ -39,7 +39,7 @@ class ConfigurationService implements SingletonInterface
      * @param ConfigurationManager $configurationManager
      * @param array $activeConfiguration
      */
-    public function __construct(ConfigurationManager $configurationManager = null, array $activeConfiguration = [])
+    public function __construct(?ConfigurationManager $configurationManager = null, array $activeConfiguration = [])
     {
         $this->configurationManager = $configurationManager ?: GeneralUtility::makeInstance(ConfigurationManager::class);
         $this->activeConfiguration = $activeConfiguration ?: $GLOBALS['TYPO3_CONF_VARS'];

--- a/Tests/Console/Functional/Command/AbstractCommandTest.php
+++ b/Tests/Console/Functional/Command/AbstractCommandTest.php
@@ -193,7 +193,7 @@ abstract class AbstractCommandTest extends TestCase
         $fileSystem->remove($targetPath);
     }
 
-    protected function executeConsoleCommand($command, array $arguments = [], array $environment = [], string $stdIn = null)
+    protected function executeConsoleCommand($command, array $arguments = [], array $environment = [], ?string $stdIn = null)
     {
         try {
             return $this->commandDispatcher->executeCommand($command, $arguments, $environment, $stdIn);

--- a/Tests/Console/Functional/Fixtures/Extensions/ext_command/src/ExtAlias.php
+++ b/Tests/Console/Functional/Fixtures/Extensions/ext_command/src/ExtAlias.php
@@ -11,7 +11,7 @@ class ExtAlias extends ExtCommand
      */
     private static $instanceCount = 0;
 
-    public function __construct(string $name = null, CommandRegistry $registry = null)
+    public function __construct(?string $name = null, ?CommandRegistry $registry = null)
     {
         if (getenv('THROWS_CONSTRUCT_EXCEPTION')) {
             throw new \Exception('Error occurred during object creation', 1589036051);

--- a/Tests/Console/Functional/Fixtures/Extensions/ext_command/src/ExtCommand.php
+++ b/Tests/Console/Functional/Fixtures/Extensions/ext_command/src/ExtCommand.php
@@ -14,7 +14,7 @@ class ExtCommand extends Command
      */
     private $registry;
 
-    public function __construct(string $name = null, CommandRegistry $registry = null)
+    public function __construct(?string $name = null, ?CommandRegistry $registry = null)
     {
         $this->registry = $registry;
         parent::__construct($name);

--- a/Tests/Console/Unit/Command/Frontend/RequestCommandTest.php
+++ b/Tests/Console/Unit/Command/Frontend/RequestCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace  Helhum\Typo3Console\Tests\Unit\Command\Frontend;
+namespace Helhum\Typo3Console\Tests\Unit\Command\Frontend;
 
 use Helhum\Typo3Console\Command\Frontend\FrontendRequestCommand;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
Since PHP 8.4 [implicitly nullable parameter declarations are deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated). Therefore, this PR enables the new `nullable_type_declaration_for_default_null_value` configuration option and converts all implicitly nullable parameter declarations to explicit type declarations.