### PR TITLE
[TASK] Add support for PHP 8.4

### DIFF
--- a/.github/workflows/Analyze.yml
+++ b/.github/workflows/Analyze.yml
@@ -46,7 +46,7 @@ jobs:
             -   name: Set up PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.3
+                    php-version: 8.4
 
             -   name: Test
                 run: |

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -38,7 +38,7 @@ jobs:
             -   name: Set up PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.3
+                    php-version: 8.4
                     coverage: none
 
             -   name: "Extract tag, branch, version from GITHUB_REF"

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -31,10 +31,10 @@ jobs:
                         ${{ runner.os }}-composer-^11.5.26-
                         ${{ runner.os }}-composer-
 
-            -   name: Set up PHP Version 8.3
+            -   name: Set up PHP Version 8.4
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.3
+                    php-version: 8.4
                     tools: composer:v2
                     coverage: none
 
@@ -69,14 +69,16 @@ jobs:
             matrix:
                 os: [ 'ubuntu-latest' ]
                 typo3: [ '^11.5.26', '^12.4', '^13.4' ]
-                php: [ 8.1, 8.2, 8.3 ]
+                php: [ 8.1, 8.2, 8.3, 8.4 ]
                 dependency-version: [ lowest, stable ]
                 exclude:
+                    - typo3: "^11.5.26"
+                      php: 8.4
                     - typo3: "^13.4"
                       php: 8.1
                 include:
                     -   os: 'windows-latest'
-                        php: 8.3
+                        php: 8.4
                         typo3: '^13.4'
                         dependency-version: stable
 

--- a/.github/workflows/Update.yml
+++ b/.github/workflows/Update.yml
@@ -42,10 +42,10 @@ jobs:
                         ${{ runner.os }}-composer-^11.5.26-
                         ${{ runner.os }}-composer-
 
-            -   name: Set up PHP Version 8.1
+            -   name: Set up PHP Version 8.4
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.3
+                    php-version: 8.4
                     tools: composer:v2
                     coverage: none
 

--- a/Tests/Console/Unit/Database/Schema/TableMatcherTest.php
+++ b/Tests/Console/Unit/Database/Schema/TableMatcherTest.php
@@ -17,14 +17,11 @@ namespace Helhum\Typo3Console\Tests\Unit\Database\Schema;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Helhum\Typo3Console\Database\Schema\TableMatcher;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Information\Typo3Version;
 
 class TableMatcherTest extends TestCase
 {
-    use ProphecyTrait;
-
     public function matchReturnsCorrectTableMatchesDataProvider(): array
     {
         return [
@@ -114,17 +111,17 @@ class TableMatcherTest extends TestCase
             'fe_sessions',
             'be_sessions',
         ];
-        $connectionProphecy = $this->prophesize(Connection::class);
-        $schemaManagerProphecy = $this->prophesize(AbstractSchemaManager::class);
-        $schemaManagerProphecy->listTableNames()->willReturn($tables)->shouldBeCalled();
+        $connectionMock = $this->createMock(Connection::class);
+        $schemaManagerMock = $this->createMock(AbstractSchemaManager::class);
+        $schemaManagerMock->expects($this->atLeastOnce())->method('listTableNames')->willReturn($tables);
         if ((new Typo3Version())->getMajorVersion() > 12) {
-            $connectionProphecy->createSchemaManager()->willReturn($schemaManagerProphecy->reveal())->shouldBeCalled();
+            $connectionMock->expects($this->atLeastOnce())->method('createSchemaManager')->willReturn($schemaManagerMock);
         } else {
-            $connectionProphecy->getSchemaManager()->willReturn($schemaManagerProphecy->reveal())->shouldBeCalled();
+            $connectionMock->expects($this->atLeastOnce())->method('getSchemaManager')->willReturn($schemaManagerMock);
         }
 
         $tableMatcher = new TableMatcher();
-        $matchedTables = $tableMatcher->match($connectionProphecy->reveal(), $expression);
+        $matchedTables = $tableMatcher->match($connectionMock, $expression);
 
         foreach ($expectedMatches as $expectedMatch) {
             $this->assertTrue(in_array($expectedMatch, $matchedTables, true), sprintf('Expected table %s is not found in match result', $expectedMatch));
@@ -155,17 +152,17 @@ class TableMatcherTest extends TestCase
             'cache_foo',
             'cache_foo_tags',
         ];
-        $connectionProphecy = $this->prophesize(Connection::class);
-        $schemaManagerProphecy = $this->prophesize(AbstractSchemaManager::class);
-        $schemaManagerProphecy->listTableNames()->willReturn($tables)->shouldBeCalled();
+        $connectionMock = $this->createMock(Connection::class);
+        $schemaManagerMock = $this->createMock(AbstractSchemaManager::class);
+        $schemaManagerMock->expects($this->atLeastOnce())->method('listTableNames')->willReturn($tables);
         if ((new Typo3Version())->getMajorVersion() > 12) {
-            $connectionProphecy->createSchemaManager()->willReturn($schemaManagerProphecy->reveal())->shouldBeCalled();
+            $connectionMock->expects($this->atLeastOnce())->method('createSchemaManager')->willReturn($schemaManagerMock);
         } else {
-            $connectionProphecy->getSchemaManager()->willReturn($schemaManagerProphecy->reveal())->shouldBeCalled();
+            $connectionMock->expects($this->atLeastOnce())->method('getSchemaManager')->willReturn($schemaManagerMock);
         }
 
         $tableMatcher = new TableMatcher();
-        $matchedTables = $tableMatcher->match($connectionProphecy->reveal(), 'cf_*', 'cache_*');
+        $matchedTables = $tableMatcher->match($connectionMock, 'cf_*', 'cache_*');
 
         foreach ($expectedMatches as $expectedMatch) {
             $this->assertTrue(in_array($expectedMatch, $matchedTables, true), sprintf('Expected table %s is not found in match result', $expectedMatch));

--- a/Tests/Console/Unit/Install/InstallStepExecutorTest.php
+++ b/Tests/Console/Unit/Install/InstallStepExecutorTest.php
@@ -17,24 +17,21 @@ namespace Helhum\Typo3Console\Tests\Unit\Install;
 use Helhum\Typo3Console\Install\InstallStepActionExecutor;
 use Helhum\Typo3Console\Install\Upgrade\SilentConfigurationUpgrade;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Install\Controller\InstallerController;
 
 class InstallStepExecutorTest extends TestCase
 {
-    use ProphecyTrait;
-
     /**
      * @test
      */
     public function actionIsNeverExecutedIfNotNeeded()
     {
         $silentConfigUpgradeMock = $this->getMockBuilder(SilentConfigurationUpgrade::class)->disableOriginalConstructor()->getMock();
-        $installerControllerProphecy = $this->prophesize(InstallerController::class);
-        $installerControllerProphecy->checkEnvironmentAndFoldersAction()->willReturn(new JsonResponse(['success' => true]));
-        $executor = new InstallStepActionExecutor($silentConfigUpgradeMock, $installerControllerProphecy->reveal());
+        $installerControllerMock = $this->createMock(InstallerController::class);
+        $installerControllerMock->method('checkEnvironmentAndFoldersAction')->willReturn(new JsonResponse(['success' => true]));
+        $executor = new InstallStepActionExecutor($silentConfigUpgradeMock, $installerControllerMock);
         $response = $executor->executeActionWithArguments('environmentAndFolders');
         $this->assertFalse($response->actionNeedsExecution());
     }
@@ -45,9 +42,9 @@ class InstallStepExecutorTest extends TestCase
     public function actionIsNeverExecutedIfDryRun()
     {
         $silentConfigUpgradeMock = $this->getMockBuilder(SilentConfigurationUpgrade::class)->disableOriginalConstructor()->getMock();
-        $installerControllerProphecy = $this->prophesize(InstallerController::class);
-        $installerControllerProphecy->checkEnvironmentAndFoldersAction()->willReturn(new JsonResponse(['success' => false]));
-        $executor = new InstallStepActionExecutor($silentConfigUpgradeMock, $installerControllerProphecy->reveal());
+        $installerControllerMock = $this->createMock(InstallerController::class);
+        $installerControllerMock->method('checkEnvironmentAndFoldersAction')->willReturn(new JsonResponse(['success' => false]));
+        $executor = new InstallStepActionExecutor($silentConfigUpgradeMock, $installerControllerMock);
         $response = $executor->executeActionWithArguments('environmentAndFolders', [], true);
         $this->assertTrue($response->actionNeedsExecution());
     }
@@ -68,10 +65,10 @@ class InstallStepExecutorTest extends TestCase
             return $request;
         };
         $silentConfigUpgradeMock = $this->getMockBuilder(SilentConfigurationUpgrade::class)->disableOriginalConstructor()->getMock();
-        $installerControllerProphecy = $this->prophesize(InstallerController::class);
-        $installerControllerProphecy->checkEnvironmentAndFoldersAction()->willReturn(new JsonResponse(['success' => false]));
-        $installerControllerProphecy->executeEnvironmentAndFoldersAction($request)->willReturn(new JsonResponse(['success' => true]));
-        $executor = new InstallStepActionExecutor($silentConfigUpgradeMock, $installerControllerProphecy->reveal(), $requestFactory);
+        $installerControllerMock = $this->createMock(InstallerController::class);
+        $installerControllerMock->method('checkEnvironmentAndFoldersAction')->willReturn(new JsonResponse(['success' => false]));
+        $installerControllerMock->method('executeEnvironmentAndFoldersAction')->with($request)->willReturn(new JsonResponse(['success' => true]));
+        $executor = new InstallStepActionExecutor($silentConfigUpgradeMock, $installerControllerMock, $requestFactory);
         $response = $executor->executeActionWithArguments('environmentAndFolders');
         $this->assertFalse($response->actionNeedsExecution());
     }

--- a/composer.json
+++ b/composer.json
@@ -60,8 +60,6 @@
         "phpunit/phpunit": "^9.5.25",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "typo3-console/sql-command": "^1.0",
-        "phpspec/prophecy": "^1.15",
-        "phpspec/prophecy-phpunit": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.57",
         "dg/bypass-finals": "^1.4"
     },


### PR DESCRIPTION
This PR adds support for PHP 8.4. The following changes were made:

- Replaced prophecy with native PHPUnit mocks since prophecy is not ready for PHP 8.4 yet and, in addition, the used prophecies could be easily migrated to PHPUnit mocks.
- Switched PHP version from 8.3 to 8.4 in all GitHub workflows.
- Added PHP 8.4 to test matrix for TYPO3 v12 and v13 (TYPO3 v11 does not officially support PHP 8.4 according to https://get.typo3.org/).