### PR TITLE
Drop typo3/cms-extensionmanager dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
         "typo3/cms-composer-installers": "^4.0@rc || >=5.0",
         "typo3/cms-core": "^11.5.26 || ^12.4.18 || ^13.1",
         "typo3/cms-extbase": "^11.5.26 || ^12.4.18 || ^13.1",
-        "typo3/cms-extensionmanager": "^11.5.26 || ^12.4.18 || ^13.1",
         "typo3/cms-fluid": "^11.5.26 || ^12.4.18 || ^13.1",
         "typo3/cms-frontend": "^11.5.26 || ^12.4.18 || ^13.1",
         "typo3/cms-install": "^11.5.26 || ^12.4.18 || ^13.1",


### PR DESCRIPTION
The last usage of this package was removed, when the custom extension:setupactive
command was dropped.

Fixes #1186