### PR TITLE
[BUGFIX] Do not ignore global mysql/mariadb config

### DIFF
--- a/Classes/Console/Database/Process/MysqlCommand.php
+++ b/Classes/Console/Database/Process/MysqlCommand.php
@@ -102,7 +102,7 @@ class MysqlCommand
     private function buildConnectionArguments(): array
     {
         if ($configFile = $this->createTemporaryMysqlConfigurationFile()) {
-            $arguments[] = '--defaults-file=' . $configFile;
+            $arguments[] = '--defaults-extra-file=' . $configFile;
         }
         if (!empty($this->dbConfig['host'])) {
             $arguments[] = '-h';


### PR DESCRIPTION
Use the `--defaults-extra-file` option to set username/password information. This option allows to still load any global configuration in the system beforehand.

Resolves #1207 